### PR TITLE
fix(installer): always use package rules in consuming projects

### DIFF
--- a/src/InstallerPath.php
+++ b/src/InstallerPath.php
@@ -14,33 +14,45 @@ final class InstallerPath
 
     public static function resolveRulesSource(string $root): string
     {
-        $packageDir = self::getPackageDirectory();
-        $packageSource = $packageDir . '/rules';
-
-        if (self::isPackageRoot($root)) {
-            $developmentSource = $root . '/rules';
-
-            if (is_dir($developmentSource)) {
-                return $developmentSource;
-            }
-        }
-
-        if (is_dir($packageSource)) {
-            return $packageSource;
-        }
+        $source = self::resolveSource($root, 'rules');
 
         // @codeCoverageIgnoreStart
-        throw InstallerFailure::missingSource($root . '/rules', $packageSource);
+        if ($source === null) {
+            $packageDir = self::getPackageDirectory();
+
+            throw InstallerFailure::missingSource($root . '/rules', $packageDir . '/rules');
+        }
+
         // @codeCoverageIgnoreEnd
+
+        return $source;
     }
 
     public static function resolveSkillsSource(string $root): ?string
     {
+        return self::resolveSource($root, 'skills');
+    }
+
+    public static function resolveTargetDirectory(string $root): string
+    {
+        return $root . '/.cursor/rules';
+    }
+
+    public static function resolveSkillsTargetDirectory(string $root): string
+    {
+        return $root . '/.cursor/skills';
+    }
+
+    /**
+     * @return string|null path to source directory, or null if not found (skills only)
+     */
+    private static function resolveSource(string $root, string $subdir): ?string
+    {
         $packageDir = self::getPackageDirectory();
-        $packageSource = $packageDir . '/skills';
+        $packageSource = $packageDir . '/' . $subdir;
 
         if (self::isPackageRoot($root)) {
-            $developmentSource = $root . '/skills';
+            $developmentSource = $root . '/' . $subdir;
 
             if (is_dir($developmentSource)) {
                 return $developmentSource;
@@ -54,16 +66,6 @@ final class InstallerPath
         // @codeCoverageIgnoreStart
         return null;
         // @codeCoverageIgnoreEnd
-    }
-
-    public static function resolveTargetDirectory(string $root): string
-    {
-        return $root . '/.cursor/rules';
-    }
-
-    public static function resolveSkillsTargetDirectory(string $root): string
-    {
-        return $root . '/.cursor/skills';
     }
 
     private static function getPackageDirectory(): string

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -588,14 +588,17 @@ test('install fails when copy fails due to unwritable destination', function ():
     }
 
     $root = installerCreateProjectRoot();
-    installerWriteFile($root . '/rules/test.mdc', 'content');
+    $packageRulesDir = __DIR__ . '/../rules';
     $targetDir = $root . '/.cursor/rules';
+    $blockedDir = $targetDir;
     installerEnsureDirectory($targetDir);
-    chmod($targetDir, 0444);
     $cwd = getcwd();
     $originalCwd = $cwd !== false ? $cwd : '';
 
     try {
+        $blockedDir = installerMirrorDirectories($packageRulesDir, $targetDir) ?? $blockedDir;
+
+        chmod($blockedDir, 0555);
         chdir($root);
         ob_start();
         set_error_handler(static fn (): bool => true);
@@ -605,7 +608,7 @@ test('install fails when copy fails due to unwritable destination', function ():
 
         expect($exitCode)->toBe(1);
     } finally {
-        chmod($targetDir, 0755);
+        chmod($blockedDir, 0755);
 
         if ($originalCwd !== '') {
             chdir($originalCwd);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -87,3 +87,27 @@ function installerCountFiles(string $dir): int
 
     return $count;
 }
+
+function installerMirrorDirectories(string $sourceDir, string $targetDir): ?string
+{
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($sourceDir, RecursiveDirectoryIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST,
+    );
+    $blockedDir = null;
+
+    foreach ($iterator as $fileInfo) {
+        if (!$fileInfo instanceof SplFileInfo || !$fileInfo->isDir()) {
+            continue;
+        }
+
+        $relativePath = ltrim(str_replace($sourceDir, '', $fileInfo->getPathname()), '/');
+        installerEnsureDirectory($targetDir . '/' . $relativePath);
+
+        if ($blockedDir === null && $relativePath !== '') {
+            $blockedDir = $targetDir . '/' . $relativePath;
+        }
+    }
+
+    return $blockedDir;
+}


### PR DESCRIPTION
Resolve rules/skills source from project root only when the project root is the package root (development mode). When run from a project that has the package via Composer, always use vendor/pekral/cursor-rules rules and skills so the correct Cursor editor rules are installed.

Fixes #24