### PR TITLE
docs(skills): update Bugsnag and JIRA skill wording

### DIFF
--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -1,6 +1,6 @@
 First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 
-I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. Prefer CLI tools over Web browser.
+I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them.
 
 Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -1,6 +1,6 @@
 First, load all rules for the cursor editor (.cursor/rules/.*mdc).
 
-I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. Prefer CLI tools over Web browser.
+I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them.
 
 Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 


### PR DESCRIPTION
## Změny

- **resolve-bugsnag-issue/SKILL.md**: Odebrána redundantní věta „Prefer CLI tools over Web browser.“
- **resolve-jira-issue/SKILL.md**: Upřesněno na „acli tool nebo MCP server“, odstraněna duplicitní věta o CLI/MCP nástrojích.

Made with [Cursor](https://cursor.com)