### PR TITLE
docs(skills): add cursor rules loading instruction to skill definitions

### DIFF
--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -2,7 +2,7 @@
 name: class-refactoring
 description: PHP/Laravel code simplification and refactoring specialist. Use when the user wants to refactor, simplify, or improve PHP/Laravel code clarity, maintainability, or consistency.
 ---
-
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 # Class Refactoring
 
 **Role:** PHP/Laravel code simplification specialist. Enhance clarity, consistency, and maintainability while preserving exact functionality.

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -1,11 +1,7 @@
-I want you to create @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for the issue (find it by code or URL) on GitHub.
-
-Find the Git branch and switch to it.
-
-If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR.
-
-List only critical or moderately difficult problems for me.
-
-If there are any, I want you to add comments to the PR about where you found these errors. If that is not possible, I want you to create a new comment on the PR with a list of errors from the CR. If you do not find any errors, write that you have done the CR but did not find any serious errors. Every text in English.
-
-I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. I do not want to list "What was checked," but only the errors.
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
+- I want you to create @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for the issue (find it by code or URL) on GitHub.
+- Find the Git branch and switch to it.
+- If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR.
+- List only critical or moderately difficult problems for me.
+- If there are any, I want you to add comments to the PR about where you found these errors. If that is not possible, I want you to create a new comment on the PR with a list of errors from the CR. If you do not find any errors, write that you have done the CR but did not find any serious errors. Every text in English.
+- I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. I do not want to list "What was checked," but only the errors.

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -2,7 +2,7 @@
 name: create-test
 description: PHP Laravel test creation specialist. Use when the user wants to create, write, or generate tests for PHP/Laravel code. Follows project conventions and ensures 100% coverage.
 ---
-
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 # Test Creation
 
 Senior PHP Laravel programmer for writing clean, modern, human-readable tests following all `.cursor/rules/**/*.mdc` rules. Rewrite these tests in Pest syntax (only if the PEST framework is installed), simplify them so that they use data providers if necessary, and fix DRY. Also ensure 100% coverage and add any missing tests. Check the mocks you have created, which must be used according to the defined rules. Never change logic outside of tests! After generating the tests, remove all auxiliary and debug files that are not needed in the codebase and run automatic fixers if available in the project (composer scripts, phing, etc.).

--- a/skills/package-review/SKILL.md
+++ b/skills/package-review/SKILL.md
@@ -2,7 +2,7 @@
 name: package-review
 description: Public package tester for GitHub repositories. Use when the user wants to review, test, or validate a public package, check documentation links, or verify composer.json quality.
 ---
-
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 # Package Review
 
 **Role:** Tester of public packages published on GitHub or similar hubs. Validate documentation links and `composer.json` quality.

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -1,15 +1,8 @@
-First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
-
-I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them.
-
-Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
-
-Ensure 100% code coverage for the current changes.
-
-If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction. If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-
-If everything is OK create a pull request, create it according to the pr.mdc rules.
-
-I want you to post a comment on the issue on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
-
-If you are not on the main git branch in the project, switch to it.
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
+- I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them.
+- Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
+- Ensure 100% code coverage for the current changes.
+- If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction. If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
+- If everything is OK create a pull request, create it according to the pr.mdc rules.
+- I want you to post a comment on the issue on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
+- If you are not on the main git branch in the project, switch to it.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -1,17 +1,9 @@
-First, load all rules for the cursor editor (.cursor/rules/.*mdc).
-
-I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them.
-
-Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
-
-Ensure 100% code coverage for the current changes.
-
-If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction. If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-
-If everything is OK, create a pull request according to the pr.mdc rules.
-
-I want you to post a comment on the core revision on GitHub, but I want you to post only critical or medium-severity issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue as ready for review.
-
-After completing all tasks for GitHub, link the created PR in the JIRA issue, post it as a comment in the JIRA issue, and change the status of the JIRA issue to ready for review.
-
-If you are not on the main git branch in the project, switch to it.
+- First, load all rules for the cursor editor (.cursor/rules/.*mdc).
+- I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them.
+- Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
+- Ensure 100% code coverage for the current changes. 
+- If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction. If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
+- If everything is OK, create a pull request according to the pr.mdc rules.
+- I want you to post a comment on the core revision on GitHub, but I want you to post only critical or medium-severity issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue as ready for review.
+- After completing all tasks for GitHub, link the created PR in the JIRA issue, post it as a comment in the JIRA issue, and change the status of the JIRA issue to ready for review.
+- If you are not on the main git branch in the project, switch to it.

--- a/skills/rewrite-tests-pest/SKILL.md
+++ b/skills/rewrite-tests-pest/SKILL.md
@@ -4,7 +4,7 @@ description: Rewrites existing PHPUnit-style tests to PEST syntax following proj
 ---
 
 # Rewrite Tests to PEST Syntax
-
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 Specialist for converting PHPUnit test classes to PEST syntax. Apply testing rules from `.cursor/rules/php/standards.mdc` (Testing section) and `.cursor/rules/php-testing.mdc`. Never modify production code. After rewrite, coverage must be 100% for changed code; add missing tests if needed.
 
 **Role:** Rewrite tests only. Apply all project test rules.

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -4,7 +4,7 @@ description: Web application security reviewer. Use when the user wants to check
 ---
 
 # Security Review
-
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 **Role:** Senior web application security reviewer. Audit code for vulnerabilities using `.cursor/rules/security/*.md` and `.cursor/rules/**/*.mdc` rules. Apply OWASP Top 10 and SecureCodeWarrior best practices.
 
 **Constraint:** Review only. Never modify code.


### PR DESCRIPTION
## Změny
- Do skillů (class-refactoring, create-test, package-review, rewrite-tests-pest, security-review) přidána instrukce načíst pravidla z `.cursor/rules/.*mdc`.
- Upraveny a sjednoceny instrukce v code-review-github, resolve-bugsnag-issue a resolve-jira-issue.

Made with [Cursor](https://cursor.com)