### PR TITLE
feat(ci): add skill-check GitHub Action

### DIFF
--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -1,0 +1,21 @@
+name: Skills Check
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  skill-check:
+    name: "📋 skill-check"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run skill-check
+        uses: thedaviddias/skill-check@v1
+        with:
+          path: .
+          format: github


### PR DESCRIPTION
## Summary

Adds [skill-check](https://github.com/thedaviddias/skill-check) as a new GitHub Action to validate agent `SKILL.md` files on every pull request and push to `master`.

Closes #45

## Changes

- New workflow `.github/workflows/skill-check.yml`:
  - Triggers on `pull_request` and `push` to `master`
  - Uses `thedaviddias/skill-check@v1` with `path: .` and `format: github` for inline annotations on PRs
  - Security scan left disabled (default) for faster CI

## Sources

- [skill-check repository](https://github.com/thedaviddias/skill-check)
- [skill-check README – GitHub Action](https://github.com/thedaviddias/skill-check#github-action)
- [Issue #45](https://github.com/pekral/cursor-rules/issues/45)

## How to test

1. Open a PR or push to `master` and confirm the **Skills Check** workflow runs.
2. Run locally: `npx skill-check . --no-security-scan`
3. Note: the repo currently has 4 skill-check **errors** (e.g. `name` vs directory in `merge-github-pr`, `seo-fix`). Fixing them is out of scope here; consider addressing in a follow-up PR so the new check turns green.

Made with [Cursor](https://cursor.com)