### PR TITLE
fix(installer): do not overwrite existing project.mdc in .cursor/rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default the installer targets **Cursor** only (`.cursor/rules`, `.cursor/skil
 
 When the package is required via Composer, sources are read from `vendor/pekral/cursor-rules/rules` and `vendor/pekral/cursor-rules/skills`; in development it falls back to the local `rules/` and `skills/` directories.
 
-**Important:** By default, the installer only copies missing files and keeps existing content untouched. Use the `--force` flag to overwrite existing files: `vendor/bin/cursor-rules install --force`. This is particularly useful when you want to update rules to their latest versions or when you've made local changes that should be replaced.
+**Important:** By default, the installer only copies missing files and keeps existing content untouched. Use the `--force` flag to overwrite existing files: `vendor/bin/cursor-rules install --force`. This is particularly useful when you want to update rules to their latest versions or when you've made local changes that should be replaced. The file `.cursor/rules/project.mdc` is never overwritten once it exists in the target project, so you can safely customize it for your project.
 
 ### Installing rules from GitHub (Cursor only)
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -137,6 +137,10 @@ final class Installer
 
         self::ensureDirectoryExists($dirName);
 
+        if (file_exists($dst) && self::isProjectRule($relativePath)) {
+            return false;
+        }
+
         $effectiveForce = $force || self::isSecurityRule($relativePath);
 
         if (file_exists($dst) && !$effectiveForce) {
@@ -144,6 +148,13 @@ final class Installer
         }
 
         return self::installFile($src, $dst, $symlink);
+    }
+
+    private static function isProjectRule(string $relativePath): bool
+    {
+        $normalized = str_replace('\\', '/', $relativePath);
+
+        return $normalized === 'project.mdc';
     }
 
     private static function isSecurityRule(string $relativePath): bool

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -183,6 +183,35 @@ test('install respects force flag', function (): void {
     }
 });
 
+test('install never overwrites existing project.mdc in target', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/rules/project.mdc', 'package default content');
+    $installedFile = $root . '/.cursor/rules/project.mdc';
+    installerWriteFile($installedFile, 'my project-specific content');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+
+        ob_start();
+        Installer::run(['cursor-rules', 'install']);
+        ob_end_clean();
+        expect(file_get_contents($installedFile))->toBe('my project-specific content');
+
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--force']);
+        ob_end_clean();
+        expect(file_get_contents($installedFile))->toBe('my project-specific content');
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
 test('install creates symlinks when requested', function (): void {
     if (installerSymlinkUnsupported()) {
         expect(true)->toBeTrue();


### PR DESCRIPTION
## Summary

Fixes #48

The installer no longer overwrites an existing `.cursor/rules/project.mdc` file in the target project. This file is intended as the base rules for the actual project and is often customized per project, so it must be preserved once present.

## Changes

- **Installer**: Added `isProjectRule()` and in `shouldProcessFile()` skip copying when the destination file exists and the relative path is `project.mdc` (even with `--force`).
- **Tests**: New test `install never overwrites existing project.mdc in target` verifies that both `install` and `install --force` leave an existing `project.mdc` untouched.
- **README**: Documented that `.cursor/rules/project.mdc` is never overwritten.

## How to test

1. In a project using this package, ensure `.cursor/rules/project.mdc` exists with custom content.
2. Run `vendor/bin/cursor-rules install` — content should be unchanged.
3. Run `vendor/bin/cursor-rules install --force` — content should still be unchanged.
4. Run `vendor/bin/pest tests/InstallerTest.php` — all tests pass.

Made with [Cursor](https://cursor.com)