### PR TITLE
docs(php): add PHPDoc rules for business logic focus

### DIFF
--- a/rules/php/standards.mdc
+++ b/rules/php/standards.mdc
@@ -88,6 +88,12 @@ Simplify the tests by dividing them into multiple test cases.
 - Don't comment on what the code does - make the code self-documenting
 - Document APIs, complex algorithms, and non-obvious side effects
 
+## PHPDoc
+- Prefer general description and business logic over implementation details
+- Class-level PHPDoc: describe the class role in the domain, not a list of methods or internal behavior
+- Method-level PHPDoc: describe intent and business meaning; avoid restating the method name or parameter names
+- Do not use PHPDoc to enumerate method calls or step-by-step solution; keep it high-level and readable for maintainers
+
 ## Single Responsibility
 - Each function should do exactly one thing
 - Functions should be small and focused

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 - Clean, modern, optimized code.
 - Stateless PHP classes.
 - Collections over `foreach` where appropriate.
-- PHPDoc for PHPStan analysis.
+- PHPDoc for PHPStan analysis. PHPDoc content: describe business logic and general purpose; avoid listing method calls or implementation steps.
 - Complex logic commented
 - No magic numbers
 - No deep nesting


### PR DESCRIPTION
## Popis

Implementace pravidel pro PHPDoc dle [issue #51](https://github.com/pekral/cursor-rules/issues/51): PHPDoc má popisovat spíše obecné informace a business logiku než konkrétní volání metod nebo implementační detaily.

## Změny

- **`rules/php/standards.mdc`** – přidána sekce **PHPDoc**:
  - Preferovat obecný popis a business logiku před detaily implementace
  - Na úrovni třídy: popisovat roli třídy v doméně, ne výčet metod
  - Na úrovni metod: popisovat záměr a business význam, ne přeříkávat název metody/parametrů
  - Nepoužívat PHPDoc k výčtu volání metod ani k popisu krokového řešení; držet ho na vysoké úrovni

- **`skills/class-refactoring/SKILL.md`** – doplněno pravidlo: obsah PHPDoc má popisovat business logiku a obecný účel; vyvarovat se výčtu volání metod a kroků implementace.

Closes #51

## Zdroje

- [Issue #51 – PHPDoc - rules](https://github.com/pekral/cursor-rules/issues/51)

## Doporučení k testování

Úpravy se týkají pouze pravidel a skillu (MDC/MD). Ověření:
- Při generování/refaktoringu PHP tříd zkontrolovat, že AI/agent vytváří PHPDoc s obecným popisem a business logikou místo výčtu metod nebo implementačních kroků.
- Žádné automatické testy v repozitáři tyto soubory pravidel nekontrolují; změny ověřit manuálně při použití skillu class-refactoring nebo při práci s PHP kódem podle těchto pravidel.
