### PR TITLE
fix(skills): add Cancel CR if PR has conflicts step to code-review skills

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -16,6 +16,7 @@ metadata:
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 
 **Steps:**
+- **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.
 - Switch locally to the branch in PR and perform code review over changes locally on the filesystem.
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -15,6 +15,7 @@ metadata:
 - All messages formatted as markdown for output.
 
 **Steps:**
+- **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.
 - Find only opened PRs!
 - Switch locally to the branch in PR and perform code review over changes locally on the filesystem.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -16,6 +16,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Check for any points where the current changes could break the logic. If it is shared functionality, make sure to check these parts of the application as well!
 
 **Steps:**
+- **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.
 - All changes must comply with `.cursor/rules/**/*.mdc`.
 - Read project.md file
 - Understand what has changed and pay attention to the structural quality of the code defined in the rules.


### PR DESCRIPTION
Closes #56

## Summary
Adds the step **Cancel CR if PR has conflicts!** to all code-review skills so that the agent skips the code review and reports when the PR has merge conflicts with the base branch.

## Changes
- `skills/code-review/SKILL.md` — new first step in Steps
- `skills/code-review-github/SKILL.md` — new first step in Steps  
- `skills/code-review-jira/SKILL.md` — new first step in Steps

## Testing
- **Manual:** Run any of the code-review skills (code-review, code-review-github, code-review-jira) on a PR that has merge conflicts with the base branch — the agent should cancel the CR and report that it was skipped due to conflicts.
- **Manual:** Run the same skills on a PR without conflicts — the CR should run as before.
- No automated tests; skills are documentation only.

Made with [Cursor](https://cursor.com)