### PR TITLE
feat(skills): add test-like-human and load-issue fallback to code/test skills

### DIFF
--- a/skills/analyze-problem/SKILL.md
+++ b/skills/analyze-problem/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 - All messages formatted as markdown for output.
 
 **Steps:**
-- Analyze the assignment and go through all the attached resources (download their contents via CLI or MCP). There are specific console CLI tools available for issue trackers, so use them. Never use a web browser!
+- Analyze the assignment and go through all the attached resources (download their contents via CLI or MCP). There are specific console CLI tools available for issue trackers, so use them. Never use a web browser! If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - I want to analyze the error as accurately as possible and write an analysis of how to fix this error and where the problem lies. The output will be prepared for quick and readable orientation for humans.

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -45,3 +45,6 @@ metadata:
 
   **Do not:** 
 - Modify existing tests (unless refactoring requires it for consistency).
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -22,9 +22,12 @@ metadata:
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want you to create @.cursor/skills/code-review/SKILL.md, @.cursor/skills/security-review/SKILL.md and, when the changes involve SQL queries, repositories, migrations, or query builder code, @.cursor/skills/mysql-problem-solver/SKILL.md for the issue (find it by code or URL) on GitHub.
 - Find the Git branch and switch to it.
-- If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR. Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
+- If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR. Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - List only critical or moderately difficult problems for me.
 - If there are any, I want you to add comments to the PR about where you found these errors. If that is not possible, I want you to create a new comment on the PR with a list of errors from the CR. If you do not find any errors, write that you have done the CR but did not find any serious errors. Every text in English.
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. I do not want to list "What was checked," but only the errors.
 - Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
 - If is needed use interactive-browser-testing skill for testing
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -22,10 +22,13 @@ metadata:
 - I want you to create @.cursor/skills/code-review/SKILL.md, @.cursor/skills/security-review/SKILL.md and, when the changes involve SQL queries, repositories, migrations, or query builder code, @.cursor/skills/mysql-problem-solver/SKILL.md for the issue (find it by code or URL) on JIRA (use acli console tool).
 - Find the Git branch and switch to it (if needed pull the latest changes).
 - I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them.
-- If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR. Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
+- If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR. Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - List only critical or moderately difficult problems for me.
 - If there are any, I want you to add comments to the PR about where you found these errors. If that is not possible, I want you to create a new comment on the PR with a list of errors from the CR. If you do not find any errors, write that you have done the CR but did not find any serious errors. Every text in English.
 - I don't want to enter technical data into the JIRA issue tracker after code review, but I want to edit the text so that project managers and testers can understand it. 
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. I do not want to list "What was checked," but only the errors.
 - Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
 - If is needed use interactive-browser-testing skill for testing
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -87,3 +87,6 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Give concrete fixes or code snippets where relevant; not only “something is wrong”.
 - Evaluate code in project context and against `.cursor/rules/**/*.mdc`.
 - Findings are recommendations; final decisions remain with the human reviewer.
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -55,8 +55,8 @@ name: fill-missing-pr-tests
     with 100% coverage.
 -   If fixers or test-related wrappers exist in the project, use them.
 -   Do not run the whole test suite unless it is required for the
-    changed files workflow.[
--   If the review recommendation is already sa]()tisfied by existing tests,
+    changed files workflow.
+-   If the review recommendation is already satisfied by existing tests,
     do not duplicate test coverage.
 
 **Deliver:**
@@ -78,3 +78,4 @@ Provide a brief markdown summary including:
 -   If something is still missing, clearly describe the blocker or
     uncovered scenario.
 - Ask for create new commit with missing tests
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -27,3 +27,6 @@ metadata:
 - Make sure of 100% coverage required for changes. Add tests so that 100% coverage is achieved. Prioritize modifying existing test cases; if tests do not exist, add them according to the valid rules for writing tests.
 - After creating or modifying tests, check that they are not flaky.
 - Remove generated coverage after work is done.
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/interactive-testing/SKILL.md
+++ b/skills/interactive-testing/SKILL.md
@@ -33,7 +33,7 @@ name: interactive-browser-testing
 
 **Steps:**
 
-1.  Load the issue using installed CLI tools or available MCP servers.
+1.  Load the issue using installed CLI tools or available MCP servers. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 2.  Read the full issue including:
     -   title
     -   description
@@ -210,3 +210,4 @@ Produce a markdown report including:
 -   Highlight the most important mismatch first.
 -   If all relevant scenarios passed, state that the issue appears
     validated in the browser flow.
+-   If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/mysql-problem-solver/SKILL.md
+++ b/skills/mysql-problem-solver/SKILL.md
@@ -363,3 +363,6 @@ A good result from this skill should:
 - provide actionable optimization steps
 - avoid fake certainty
 - stay consistent with a senior-engineer review style
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 **Steps:**
 - Analyze all comments in the issue tracker and check what needs to be done accordingly. Stick strictly to the assignment and comments!
-- I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them.
+- I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
@@ -28,3 +28,6 @@ metadata:
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After creating the PR, perform a code review @./cursor/skills/code-review/SKILL.md for the current task.
 - If you are not on the main git branch in the project, switch to it.
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 **Steps:**
 - Read project.md file
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
-- I want you to fix the bug from Github (you either got an ID or a link to Github). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them.
+- I want you to fix the bug from Github (you either got an ID or a link to Github). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
@@ -30,3 +30,4 @@ metadata:
 
 **After completing the tasks**
 - Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @.cursor/skills/code-review-github.md
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 **Steps:**
 - Read project.md file
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
-- I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them.
+- I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - Resolve this issue (the generated code must be according to @.cursor/skills/class-refacforing/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
@@ -31,5 +31,6 @@ metadata:
 
 - **After completing the tasks**
 - Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @./cursor/skills/code-review-jira/SKILL.md
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
 
 

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -15,5 +15,5 @@ metadata:
 
 **Steps:**
 - Log into JIRA, load all issues, and list only those that are to be resolved by AI (they are tagged).
-  Look for tasks labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only not resolved issues should be listed!
+  Look for tasks labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only not resolved issues should be listed! If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - Randomly select one and try to resolve it. Use the skill @.cursor/skills/resolve-jira-issue/SKILL.md.

--- a/skills/rewrite-tests-pest/SKILL.md
+++ b/skills/rewrite-tests-pest/SKILL.md
@@ -24,3 +24,6 @@ metadata:
 - Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them. 
 - Tests must have 100% coverage.
 - After writing the tests, verify that they are functional and follow the rules.
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -118,3 +118,6 @@ Refactored Example:
 $post = Post::where('user_id', auth()->id())
     ->findOrFail($id);
 ```
+
+**After completing the tasks**
+- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!


### PR DESCRIPTION
## Summary

Implements [issue #55](https://github.com/pekral/cursor-rules/issues/55): add two instructions to all skills that modify/control code or test the application:

1. **After completing the skill:** If according to `@.cursor/skills/test-like-human/SKILL.md` the changes can be tested, do it!
2. **When loading issues:** If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.

All texts are in English as requested.

## Skills updated

### Test-like-human (in "After completing the tasks")
- resolve-github-issue, resolve-jira-issue, resolve-bugsnag-issue
- code-review, code-review-github, code-review-jira
- class-refactoring, create-test, create-missing-tests-in-pr, rewrite-tests-pest
- security-review, mysql-problem-solver, interactive-testing

### Load-issue fallback (in Steps / assignment loading)
- resolve-github-issue, resolve-jira-issue, resolve-bugsnag-issue
- code-review-github, code-review-jira
- analyze-problem, interactive-testing, resolve-random-jira-issue

## Additional fix
- **create-missing-tests-in-pr:** Fixed typo (`workflow.[` and `sa]()tisfied` → `workflow.` and `satisfied`).

## Sources
- [Issue #55](https://github.com/pekral/cursor-rules/issues/55)
- [test-like-human skill](.cursor/skills/test-like-human/SKILL.md)

## Testing recommendations
- Ověř v Cursoru, že se skilly načítají a že nové řádky v SKILL.md nedělají problémy (žádné automatické testy pro skilly v repozitáři nejsou).
- Při příštím použití resolve-github-issue / resolve-jira-issue ověř, že agent po dokončení zváží test-like-human a že při nenačtení issue vyhledá vhodný nástroj.
