### PR TITLE
feat(skills): add composer-update skill

### DIFF
--- a/skills/composer-update/SKILL.md
+++ b/skills/composer-update/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: composer-update
+description: "Use when the user ran composer update and wants to check for package conflicts and get a summary of changelogs from updated packages."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+**Constraint:**
+- Read project.md file.
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
+- Output in the same language as the user's request.
+- All messages formatted as markdown.
+
+**Trigger:**
+- User says they ran `composer update` and asks to check for conflicts and/or summarize changelogs of updated packages.
+
+**Steps:**
+
+## 1. Detect updated packages
+
+- If the user did not paste the `composer update` output, run `composer update --dry-run` (or inspect `composer.lock` vs last committed version) to see which packages would be or were updated.
+- From the update output or lock diff, list every package that was added or changed (name and old → new version).
+
+## 2. Check for conflicts
+
+- **From update output**: Look for Composer messages containing "conflict", "Conflict", "requires", "your requirement" or "cannot be installed".
+- **Explicit check**: For each updated or important dependency, optionally run `composer why-not vendor/package version` to see if the requested version is blocked.
+- **Lock vs require**: Compare `composer.json` constraints with resolved versions in `composer.lock`; note any package that was downgraded or could not be satisfied at the requested version.
+- Summarize: either "No conflicts detected" or list each conflict with the involved packages and the reason (e.g. "X requires Y ^2.0 but Z requires Y ^1.0").
+
+## 3. Changelog summary for updated packages
+
+For each updated package (from step 1):
+
+- **CHANGELOG in project**: Check `vendor/<vendor>/<package>/CHANGELOG.md` or `CHANGELOG`, `CHANGES.md`, `HISTORY.md` (or similar) and extract entries for the **new** version (and optionally the range from previous to new).
+- **GitHub/GitLab releases**: If the package is from GitHub/GitLab and no CHANGELOG is in vendor, use the repository URL from `composer show vendor/package` and fetch release notes for the new version (e.g. GitHub Releases API or project’s releases page).
+- **Packagist / package homepage**: If available, use the "source" or "homepage" link from Packagist or `composer show` to find release notes.
+
+**Summary format (per package):**
+
+- **vendor/package** (old → new): brief bullet list of notable changes (breaking changes, new features, bug fixes) from the changelog or release notes. If no changelog is found, state "No changelog found in vendor or linked repository."
+
+## 4. Final output
+
+- **Conflicts**: Short section with the result of step 2.
+- **Changelogs**: One subsection per updated package with the summary from step 3.
+- Optionally: suggest follow-up (e.g. run tests, run `composer validate`, check for security advisories with `composer audit`).


### PR DESCRIPTION
## Summary

Adds new skill `composer-update` for the workflow: user runs `composer update` and asks the agent to check for package conflicts and provide a summary of changelogs from updated packages.

Closes #64

## Changes

- **skills/composer-update/SKILL.md**: New skill that instructs the agent to:
  1. Detect updated packages (from update output or `composer update --dry-run` / lock diff)
  2. Check for conflicts (Composer messages, `composer why-not`, lock vs require)
  3. Summarize changelogs per package (vendor CHANGELOG, GitHub/GitLab releases, Packagist)
  4. Output a structured report: Conflicts section + Changelogs per package + optional follow-up (tests, `composer validate`, `composer audit`)

## Sources

- [GitHub Issue #64](https://github.com/pekral/cursor-rules/issues/64) — Skill - composer update
- [create-skill SKILL.md](https://github.com/pekral/cursor-rules/blob/master/.cursor/skills-cursor/create-skill/SKILL.md) — skill structure and description best practices (project uses `skills/` in repo root)
- [package-review SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/package-review/SKILL.md) — frontmatter and steps pattern

## Testing recommendations

- **Manual**: In a project with `composer.json`, run `composer update` (or `--dry-run`), then ask the agent (with this skill available): "I ran composer update, check for conflicts and give me a changelog summary." Verify the agent lists updated packages, reports conflicts (or none), and summarizes changelogs from vendor CHANGELOG or release notes.
- **Automated**: `composer run-script skill-check` and `vendor/bin/pest tests/InstallerTest.php` were run; both pass. No new PHP tests added (skill is markdown only; installer tests already cover copying all files from `skills/`).


Made with [Cursor](https://cursor.com)