### PR TITLE
feat(skill): add process-code-review skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,5 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 🐛 **Fixed**: Symfony console v8 compatibility
 - ♻️ **Refactored**: optimize commands and prompts
 - ✨ **Added**: new Agent skills (resolve-github-issue, merge-github-pr, code-review, seo-fix, package-review, and others)
+- ✨ **Added**: new Agent skill `process-code-review` for handling pull request review feedback loops
 - 📝 **Changed**: Update SKILL.md files and rule files (php standards, sql, git, laravel)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | Skill                    | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
 | `code-review`            | Senior PHP code reviewer. Use when reviewing pull requests, examining code changes vs master branch, or when the user asks for a code review. Read-only review — never modifies code. |
+| `process-code-review`    | Processes feedback from existing pull request reviews: finds latest PR for task, resolves review comments, updates review status comments, and triggers the next review cycle. |
 | `code-review-github`     | Performs comprehensive code review for GitHub pull requests. Analyzes code changes, identifies critical and moderate issues, runs tests, and posts review comments. Reviews code quality, security, and adherence to project standards. |
 | `code-review-jira`       | Performs code review for JIRA issues. Analyzes pull requests, identifies critical and moderate issues, runs tests, and posts review comments to GitHub PRs. Reviews code quality, security, and adherence to project standards. |
 | `security-review`        | Performs comprehensive security review following OWASP Top 10 and security best practices. Checks for injection vulnerabilities, authentication flaws, sensitive data exposure, misconfigurations, and provides structured security reports with severity levels. |

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: process-code-review
+description: "Use when processing pull request code review feedback. Finds the latest PR for a task, resolves review comments, updates review status, and triggers the next review cycle."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+**Constraint:**
+- Read project.mdc file
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
+- I want the texts to be in the language in which the assignment was written.
+- Never push direct changes to the main branch.
+- If the pull request has merge conflicts with the base branch, stop and report that the code review processing is blocked.
+
+**Steps:**
+- Identify the task from the provided issue code or URL.
+- Find the latest pull request for that task using available CLI tools or MCP servers.
+- In the pull request, locate code review output and all review comments (including review threads and general comments).
+- If there is only a generic `CR` comment, treat it as `code review` feedback.
+- Build a checklist from all review findings and map each item to a concrete code or test change.
+- Apply the requested changes and keep scope limited to review feedback.
+- Re-check current changes with @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md.  
+- If review feedback requires additional tests, use @.cursor/skills/create-missing-tests-in-pr/SKILL.md and ensure current changes are fully covered.
+- Run only checks/tests needed for the changed files and fix all errors before continuing.
+- Update the review result comment in the pull request:
+- mark resolved points as checked items when possible, or
+- format resolved points as underlined text when checkbox updates are not possible.
+- If you cannot update the original comment, add a new PR comment with the same resolved-point status.
+- After all points are addressed, trigger the next review interaction by issue tracker:
+- GitHub: run @.cursor/skills/code-review-github/SKILL.md
+- JIRA: run @.cursor/skills/code-review-jira/SKILL.md
+- Share a concise completion report with PR link, resolved items, and any remaining blockers.
+
+**After completing the tasks**
+- Confirm all review points are resolved or explicitly marked as blocked with reasons.
+- Ensure the PR contains clear evidence that each review remark was handled.
+- Summarize what changed, what was tested, and what requires follow-up.


### PR DESCRIPTION
## Shrnutí
- Přidán nový skill `process-code-review` pro zpracování připomínek z code review v PR.
- Skill pokrývá dohledání posledního PR k tasku, zpracování review komentářů, označení vyřešených bodů a spuštění navazujícího review skillu podle issue trackeru.
- Aktualizována dokumentace v `README.md` a `CHANGELOG.md`.

## Test plan
- [x] Spuštěn `composer build`
- [x] Ověřena validace skillů (`skill-check` v rámci build)
- [x] Ověřeny testy (`pest` v rámci build)
- [x] Ověřeno, že nové změny nehlásí lint chyby
- [ ] Byly doplněny nové testy pro tuto změnu: **no**

## Zdroje analýzy
- [Issue #72](https://github.com/pekral/cursor-rules/issues/72)
- [resolve-github-issue skill](https://github.com/pekral/cursor-rules/blob/master/skills/resolve-github-issue/SKILL.md)
- [code-review-github skill](https://github.com/pekral/cursor-rules/blob/master/skills/code-review-github/SKILL.md)

## Vazba na issue
Closes #72

Made with [Cursor](https://cursor.com)