### PR TITLE
feat: add postman collections skill for API endpoint changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - unified PHP coding guidelines for PHP 8.4 projects
 - Pest-based testing with mandatory code analysis and 100% coverage
 - strong focus on clean code: typed properties, SRP, no redundant comments
-- **15 comprehensive Agent skills** for automated workflows (v0.5)
+- **24 comprehensive Agent skills** for automated workflows (v0.5)
 - fast onboarding inside development repositories
 
 ## Installation
@@ -108,6 +108,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 
 | Skill                    | Description                                                                 |
 |--------------------------|-----------------------------------------------------------------------------|
+| `postman-collections`    | Generates or updates Postman collections when API endpoints are created or changed, keeps examples and auth variables in sync, and validates collection importability. |
 | `create-test`            | Creates tests following project conventions and patterns. Ensures deterministic tests, 100% code coverage for changes, uses data providers where appropriate, and mocks only external services or exception scenarios. |
 | `rewrite-tests-pest`     | Rewrites existing tests to PEST syntax following project conventions. Ensures DRY principles, uses data providers, maintains 100% coverage, and verifies test functionality. |
 | `package-review`         | Reviews composer.json packages by validating structure, checking required fields, verifying links, and ensuring proper configuration of autoloading, dependencies, and metadata. |

--- a/skills/postman-collections/SKILL.md
+++ b/skills/postman-collections/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: postman-collections
+description: "Use when AI creates or modifies API endpoints and you need to generate or update Postman collections, keep request examples aligned with routes, and verify the collection is importable and runnable."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+**Constraint:**
+- Read `project.mdc` file.
+- First, load all the rules for the cursor editor (`.cursor/rules/.*mdc`).
+- I want the texts to be in the language in which the assignment was written.
+- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
+- Never generate fake endpoints; only use endpoints that exist in code, route config, or API schema.
+- Keep secrets out of collections (tokens, passwords, API keys must be variables, never hard-coded values).
+
+**When to use:**
+- The AI adds a new API endpoint.
+- The AI modifies existing API endpoint path, method, headers, query params, body schema, or response examples.
+- The user asks to prepare or update Postman collections for current API changes.
+
+**Steps:**
+- Detect changed endpoints from current branch diff and route/schema sources (Laravel routes, OpenAPI, API docs, controller + request classes).
+- Build a change list grouped by resource (for example Users, Orders, Auth).
+- Locate existing Postman assets in the repository (`postman/`, `docs/postman/`, `*.postman_collection.json`, `*.postman_environment.json`).
+- If a collection exists, update it in place; if it does not exist, create a new collection in the project convention.
+- For each changed endpoint, ensure:
+  - method and path are correct,
+  - path/query variables are explicit,
+  - auth type is configured (Bearer/API key/etc.) via variables,
+  - required headers are included,
+  - request body example matches current validation/schema,
+  - at least one realistic response example is present.
+- Keep endpoint naming stable and human-readable (`[Resource] Action` style), avoid duplicates.
+- Organize folders by domain/module, not by HTTP method.
+- Add collection-level variables and environment placeholders:
+  - `baseUrl`
+  - `token` (or equivalent auth variable)
+  - any required tenant/workspace/account identifiers
+- If tests already exist inside collection requests, update assertions only where endpoint behavior changed.
+- Validate generated JSON format (no trailing commas, valid Postman v2.1 schema shape).
+- Verify collection importability and runnability using available tooling (CLI or local import check).
+- Summarize what was added/changed/removed in the collection and list any TODOs for missing backend behavior.
+
+**Quality checklist:**
+- No stale endpoints remain for removed routes.
+- No duplicated requests for the same method + path unless intentionally versioned.
+- All protected routes use variables for credentials.
+- Request examples reflect actual DTO/FormRequest validation rules.
+- Collection works with a clean environment file containing placeholders only.
+
+**Output expectations:**
+- Updated or newly created Postman collection file(s).
+- Updated environment file(s) if needed.
+- Short changelog of endpoints synchronized with code changes.


### PR DESCRIPTION
## Summary
- Add new `postman-collections` skill for generating/updating Postman collections when API endpoints are created or changed.
- Include a practical workflow for endpoint diffing, request/auth/example sync, and collection validation.
- Update README skills overview and count to include the new skill.

## Sources used for analysis
- https://github.com/pekral/cursor-rules/issues/75

## Testing recommendations
- [x] Run `composer build` and confirm all quality checks pass.
- [ ] Validate in a real target project that changing API routes triggers expected `postman-collections` guidance output.

## Tests covering recommendations
- no.

## Linked issue
- Closes #75

Made with [Cursor](https://cursor.com)