### PR TITLE
fix: standardize JIRA comment formatting output

### DIFF
--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -14,6 +14,17 @@ metadata:
 - All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - NEVER CHANGE THE CODE! Generate the output only.
 - All messages formatted as markdown for output.
+- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.
+
+**Universal JIRA Comment Formatting**
+- Use this output shape for every JIRA update from this skill:
+- `h3. <short status title>`
+- One short business-readable paragraph (non-technical wording)
+- `h4. Findings summary` and bullet list using `*`
+- If needed, `h4. Testing recommendations` and bullet list using `*`
+- Inline references with `{{...}}` (ticket id, endpoint, env, status code)
+- Use `{code}` / `{code:json}` only for short examples; never include markdown fences in JIRA comments
+- Keep comments understandable for project managers and testers, not only developers
 
 **Steps:**
 - **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - Never push direct changes to the main branch.
 - If the pull request has merge conflicts with the base branch, stop and report that the code review processing is blocked.
+- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown) and follow the universal structure from JIRA-focused skills.
 
 **Steps:**
 - Identify the task from the provided issue code or URL.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -13,6 +13,44 @@ metadata:
 - All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
+- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.
+
+**Universal JIRA Comment Formatting**
+- Use this structure for every JIRA comment type (status update, testing recommendation, CR summary, implementation summary):
+- Title: `h3. <short title>`
+- Short context paragraph (1-3 lines, plain text)
+- Optional sections with `h4. <section title>`
+- Bullets with `* item`
+- Inline code/paths/endpoints in monospace using `{{...}}`
+- Code examples only via `{code[:language]}` blocks
+- Tables only with JIRA table syntax (`||` header row, `|` data row)
+- Keep one empty line between blocks for readability
+
+Example of the final JIRA comment body:
+```text
+h3. Implementation summary
+
+Feature is ready for review. Main behavior was validated locally.
+
+h4. What changed
+* Added validation for {{subscriber_data}} payload.
+* Added guard for {{allow_resubscribe}} transition from {{2 -> 1}}.
+
+h4. API example
+{code:json}
+{
+  "allow_resubscribe": true,
+  "subscriber_data": [
+    {"email": "user@example.com", "status": 1}
+  ]
+}
+{code}
+
+h4. Testing recommendations
+* Verify update for an existing contact.
+* Verify skipped unknown contact appears in response {{errors}}.
+* Verify rate-limit handling (HTTP {{429}} with {{Retry-After}}).
+```
 
 **Steps:**
 - Read project.mdc file

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -12,6 +12,7 @@ metadata:
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want the texts to be in the language in which the assignment was written.
 - If you are not on the main git branch in the project, switch to it.
+- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown) and follow the universal structure from JIRA-focused skills.
 
 **Steps:**
 - Log into JIRA, load all issues, and list only those that are to be resolved by AI (they are tagged).


### PR DESCRIPTION
## Shrnutí
- Sjednotil jsem formát výstupů do JIRA napříč JIRA skilly na JIRA Wiki Markup, aby se komentáře nezobrazovaly jako plain text.
- Přidal jsem univerzální strukturu komentáře (`h3`, `h4`, odrážky, `{{...}}`, `{code}`) a jasná pravidla, co v JIRA nepoužívat (Markdown prvky).
- Doplnil jsem konkrétní ukázku univerzálního komentáře v `resolve-jira-issue`, aby byl formát snadno znovupoužitelný.

## Test plan
- [x] Spuštěn `composer build`.
- [x] Ověřeno, že změněné `SKILL.md` soubory procházejí kontrolami bez chyb.
- [ ] Ověřit na reálném JIRA komentáři, že se vykreslí nadpisy, tabulky a `{code}` bloky správně.
- [ ] Ověřit minimálně 2 různé typy komentářů (status update + review summary) podle nové šablony.

## Testing recommendations (UI/API)
- Vložit do JIRA komentář s kombinací `h3`, tabulky `||...||` a `{code:json}`.
- Vložit krátký status komentář bez tabulky a ověřit konzistentní vykreslení.
- Ověřit inline monospace formát přes `{{endpoint}}` a `{{status code}}`.

Testy napsané pro tato doporučení: no.

## Zdroje analýzy
- GitHub issue: https://github.com/pekral/cursor-rules/issues/74

Made with [Cursor](https://cursor.com)