### PR TITLE
feat(installer): add --prune flag to remove orphaned skills from target

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -20,6 +20,7 @@ final class Installer
         $command = $argv[1] ?? 'help';
         $force = in_array('--force', $argv, true);
         $symlink = in_array('--symlink', $argv, true);
+        $prune = in_array('--prune', $argv, true);
 
         try {
             if ($command === 'help') {
@@ -40,7 +41,7 @@ final class Installer
                 return 1;
             }
 
-            return self::install($force, $symlink, $editor);
+            return self::install($force, $symlink, $prune, $editor);
         } catch (InstallerFailure $exception) {
             fwrite(STDERR, $exception->getMessage() . PHP_EOL);
 
@@ -68,37 +69,63 @@ final class Installer
     private static function showHelp(): int
     {
         echo "Usage:\n";
-        echo "  vendor/bin/cursor-rules install [--force] [--symlink] [--editor=EDITOR]\n\n";
+        echo "  vendor/bin/cursor-rules install [--force] [--symlink] [--prune] [--editor=EDITOR]\n\n";
         echo "Options:\n";
         echo "  --force         Overwrite existing files.\n";
         echo "  --symlink       Create symlinks instead of copying (falls back to copy on Windows).\n";
+        echo "  --prune         Remove files in target that no longer exist in source.\n";
         echo "  --editor=EDITOR Target editor: cursor (default), claude, codex, all.\n";
 
         return 0;
     }
 
-    private static function install(bool $force, bool $symlink, string $editor): int
+    private static function install(bool $force, bool $symlink, bool $prune, string $editor): int
     {
         $root = InstallerPath::resolveProjectRoot();
-        $totalCopied = 0;
 
         $rulesSource = InstallerPath::resolveRulesSource($root);
-
-        foreach (InstallerPath::resolveRulesTargetDirectories($root, $editor) as $rulesTarget) {
-            $totalCopied += self::installDirectory($rulesSource, $rulesTarget, $force, $symlink);
-        }
+        [$rulesCopied, $rulesPruned] = self::syncDirectories(
+            $rulesSource,
+            InstallerPath::resolveRulesTargetDirectories($root, $editor),
+            $force,
+            $symlink,
+            $prune,
+        );
 
         $skillsSource = InstallerPath::resolveSkillsSource($root);
+        [$skillsCopied, $skillsPruned] = $skillsSource !== null
+            ? self::syncDirectories(
+                $skillsSource,
+                InstallerPath::resolveSkillsTargetDirectories($root, $editor),
+                $force,
+                $symlink,
+                $prune,
+            )
+            : [0, 0];
 
-        if ($skillsSource !== null) {
-            foreach (InstallerPath::resolveSkillsTargetDirectories($root, $editor) as $skillsTarget) {
-                $totalCopied += self::installDirectory($skillsSource, $skillsTarget, $force, $symlink);
+        echo sprintf('Cursor rules installed (%d files, %d pruned).%s', $rulesCopied + $skillsCopied, $rulesPruned + $skillsPruned, PHP_EOL);
+
+        return 0;
+    }
+
+    /**
+     * @param array<int, string> $targets
+     * @return array{int, int}
+     */
+    private static function syncDirectories(string $source, array $targets, bool $force, bool $symlink, bool $prune): array
+    {
+        $copied = 0;
+        $pruned = 0;
+
+        foreach ($targets as $target) {
+            $copied += self::installDirectory($source, $target, $force, $symlink);
+
+            if ($prune) {
+                $pruned += InstallerPruner::pruneDirectory($source, $target);
             }
         }
 
-        echo sprintf('Cursor rules installed (%d files).%s', $totalCopied, PHP_EOL);
-
-        return 0;
+        return [$copied, $pruned];
     }
 
     private static function installDirectory(string $source, string $targetDir, bool $force, bool $symlink): int

--- a/src/InstallerPruner.php
+++ b/src/InstallerPruner.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Pekral\CursorRules;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Removes files from the install target that no longer exist in the source directory.
+ */
+final class InstallerPruner
+{
+
+    public static function pruneDirectory(string $source, string $targetDir): int
+    {
+        if (!is_dir($targetDir)) {
+            return 0;
+        }
+
+        $sourceFiles = array_flip(self::listFiles($source));
+        $targetFiles = self::listFiles($targetDir);
+        $pruned = 0;
+
+        foreach ($targetFiles as $relativePath) {
+            if (isset($sourceFiles[$relativePath])) {
+                continue;
+            }
+
+            $target = $targetDir . '/' . $relativePath;
+
+            set_error_handler(static fn (): bool => true);
+            $deleted = unlink($target);
+            restore_error_handler();
+
+            if (!$deleted) {
+                continue;
+            }
+
+            $pruned++;
+            self::removeEmptyDirectories(dirname($target), $targetDir);
+        }
+
+        return $pruned;
+    }
+
+    private static function removeEmptyDirectories(string $directory, string $stopAt): void
+    {
+        while ($directory !== $stopAt && is_dir($directory)) {
+            $iterator = new FilesystemIterator($directory);
+
+            if ($iterator->valid()) {
+                break;
+            }
+
+            set_error_handler(static fn (): bool => true);
+            $removed = rmdir($directory);
+            restore_error_handler();
+
+            if (!$removed) {
+                break;
+            }
+
+            $directory = dirname($directory);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function listFiles(string $base): array
+    {
+        if (!is_dir($base)) {
+            return [];
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($base, FilesystemIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+        $files = [];
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof SplFileInfo) {
+                // @codeCoverageIgnoreStart
+                continue;
+                // @codeCoverageIgnoreEnd
+            }
+
+            $pathname = $file->getPathname();
+            $files[] = ltrim(str_replace($base, '', $pathname), '/');
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+}

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 use Pekral\CursorRules\Installer;
 use Pekral\CursorRules\InstallerFailure;
 use Pekral\CursorRules\InstallerPath;
+use Pekral\CursorRules\InstallerPruner;
 
 test('run shows help when executed without arguments', function (): void {
     ob_start();
@@ -364,7 +365,7 @@ test('install with editor=all copies all files to all rule and skill directories
             expect($actualSkillsCount)->toBe($expectedSkillsCount, 'Skills: all source files in ' . $skillsTarget);
         }
 
-        expect($output)->toContain(sprintf('(%d files)', $expectedTotalFiles));
+        expect($output)->toContain(sprintf('(%d files,', $expectedTotalFiles));
     } finally {
         installerRestoreEnvAndCleanup($homeBefore, $originalCwd, $root);
     }
@@ -848,6 +849,135 @@ test('install fails when copy fails due to unwritable destination', function ():
     }
 });
 
+test('run shows prune option in help output', function (): void {
+    ob_start();
+    $exitCode = Installer::run(['cursor-rules']);
+    $output = (string) ob_get_clean();
+
+    expect($exitCode)->toBe(0);
+    expect($output)->toContain('--prune');
+});
+
+test('install with prune removes files from target that no longer exist in source', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/skills/current-skill/SKILL.md', 'current skill');
+    installerWriteFile($root . '/.cursor/skills/current-skill/SKILL.md', 'current skill');
+    installerWriteFile($root . '/.cursor/skills/orphaned-skill/SKILL.md', 'orphaned content');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--prune']);
+        ob_end_clean();
+
+        expect(is_file($root . '/.cursor/skills/current-skill/SKILL.md'))->toBeTrue();
+        expect(is_file($root . '/.cursor/skills/orphaned-skill/SKILL.md'))->toBeFalse();
+        expect(is_dir($root . '/.cursor/skills/orphaned-skill'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install without prune keeps orphaned files in target', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/skills/current-skill/SKILL.md', 'current skill');
+    installerWriteFile($root . '/.cursor/skills/orphaned-skill/SKILL.md', 'orphaned content');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install']);
+        ob_end_clean();
+
+        expect(is_file($root . '/.cursor/skills/orphaned-skill/SKILL.md'))->toBeTrue();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with prune also removes rules that no longer exist in source', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/rules/active.mdc', 'active rule');
+    installerWriteFile($root . '/.cursor/rules/active.mdc', 'active rule');
+    installerWriteFile($root . '/.cursor/rules/removed.mdc', 'removed rule');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--prune']);
+        ob_end_clean();
+
+        expect(is_file($root . '/.cursor/rules/active.mdc'))->toBeTrue();
+        expect(is_file($root . '/.cursor/rules/removed.mdc'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with prune reports pruned file count in output', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/skills/keep-skill/SKILL.md', 'keep');
+    installerWriteFile($root . '/.cursor/skills/keep-skill/SKILL.md', 'keep');
+    installerWriteFile($root . '/.cursor/skills/drop-skill/SKILL.md', 'drop');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--prune']);
+        $output = (string) ob_get_clean();
+
+        expect($output)->toContain('1 pruned');
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with prune on non-existent target directory does nothing', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/skills/some-skill/SKILL.md', 'content');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        $exitCode = Installer::run(['cursor-rules', 'install', '--prune']);
+        ob_end_clean();
+
+        expect($exitCode)->toBe(0);
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
 test('install fails when existing file cannot be removed', function (): void {
     if (posix_getuid() === 0) {
         expect(true)->toBeTrue();
@@ -880,6 +1010,126 @@ test('install fails when existing file cannot be removed', function (): void {
             chdir($originalCwd);
         }
 
+        installerRemoveDirectory($root);
+    }
+});
+
+test('InstallerPruner returns 0 when target directory does not exist', function (): void {
+    $result = InstallerPruner::pruneDirectory('/some/source', '/nonexistent/target');
+
+    expect($result)->toBe(0);
+});
+
+test('InstallerPruner prunes all files when source directory does not exist', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/target/some-skill/SKILL.md', 'content');
+
+    try {
+        $pruned = InstallerPruner::pruneDirectory(
+            $root . '/nonexistent-source',
+            $root . '/target',
+        );
+
+        expect($pruned)->toBe(1);
+        expect(is_file($root . '/target/some-skill/SKILL.md'))->toBeFalse();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('InstallerPruner prune keeps non-orphaned files in nested directory', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/source/skill-a/SKILL.md', 'source content');
+    installerWriteFile($root . '/target/skill-a/SKILL.md', 'target content');
+    installerWriteFile($root . '/target/skill-a/extra.md', 'extra content');
+
+    try {
+        $pruned = InstallerPruner::pruneDirectory(
+            $root . '/source',
+            $root . '/target',
+        );
+
+        expect($pruned)->toBe(1);
+        expect(is_file($root . '/target/skill-a/SKILL.md'))->toBeTrue();
+        expect(is_file($root . '/target/skill-a/extra.md'))->toBeFalse();
+        expect(is_dir($root . '/target/skill-a'))->toBeTrue();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('InstallerPruner removes empty parent directories after pruning', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/source/keep/SKILL.md', 'keep');
+    installerWriteFile($root . '/target/keep/SKILL.md', 'keep');
+    installerWriteFile($root . '/target/orphaned/SKILL.md', 'orphaned');
+
+    try {
+        $pruned = InstallerPruner::pruneDirectory(
+            $root . '/source',
+            $root . '/target',
+        );
+
+        expect($pruned)->toBe(1);
+        expect(is_dir($root . '/target/orphaned'))->toBeFalse();
+        expect(is_dir($root . '/target/keep'))->toBeTrue();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('InstallerPruner handles unwritable file gracefully when pruning', function (): void {
+    if (posix_getuid() === 0) {
+        expect(true)->toBeTrue();
+
+        return;
+    }
+
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/source/keep/SKILL.md', 'keep');
+    installerWriteFile($root . '/target/keep/SKILL.md', 'keep');
+    installerWriteFile($root . '/target/locked/SKILL.md', 'locked');
+    chmod($root . '/target/locked', 0555);
+
+    try {
+        set_error_handler(static fn (): bool => true);
+        $pruned = InstallerPruner::pruneDirectory(
+            $root . '/source',
+            $root . '/target',
+        );
+        restore_error_handler();
+
+        expect($pruned)->toBe(0);
+    } finally {
+        chmod($root . '/target/locked', 0755);
+        installerRemoveDirectory($root);
+    }
+});
+
+test('InstallerPruner handles unwritable parent directory when removing empty dirs', function (): void {
+    if (posix_getuid() === 0) {
+        expect(true)->toBeTrue();
+
+        return;
+    }
+
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/source/keep/SKILL.md', 'keep');
+    installerWriteFile($root . '/target/keep/SKILL.md', 'keep');
+    installerWriteFile($root . '/target/orphaned/SKILL.md', 'orphaned');
+    chmod($root . '/target', 0555);
+
+    try {
+        set_error_handler(static fn (): bool => true);
+        InstallerPruner::pruneDirectory(
+            $root . '/source',
+            $root . '/target',
+        );
+        restore_error_handler();
+
+        expect(true)->toBeTrue();
+    } finally {
+        chmod($root . '/target', 0755);
         installerRemoveDirectory($root);
     }
 });


### PR DESCRIPTION
## Summary

- Adds `--prune` CLI flag to the installer that removes files from the target directory which no longer exist in the source
- Extracts prune logic into a dedicated `InstallerPruner` class to keep `Installer` within the 250-line class length limit
- Refactors `install()` into `syncDirectories()` helper to reduce cognitive complexity
- Updates install output to report both copied and pruned file counts: `(N files, M pruned)`

## Motivation

Resolves #80 — Claude Code skills (`~/.claude/skills/`) were out of sync with Cursor skills:
- 9 missing skills were not present in Claude Code
- 15 skills were outdated (Cursor versions were newer)
- 1 orphaned skill (`test-skill`, empty file) needed removal

Running the installer without `--prune` would not remove orphaned skills. The new flag enables a full sync:

```bash
vendor/bin/cursor-rules install --editor=claude --force --prune
```

## Test plan

- [ ] Run `vendor/bin/cursor-rules install --editor=claude --force --prune` — verify all 24 skills are synced to `~/.claude/skills/` and `test-skill` is removed
- [ ] Run without `--prune` — verify orphaned files are preserved (no regression)
- [ ] Run with `--prune` on a clean install — verify `0 pruned` in output
- [ ] Check help output includes `--prune` description: `vendor/bin/cursor-rules help`

Tests added: 7 new tests covering `InstallerPruner` (non-existent target, non-existent source, empty dir cleanup, unwritable files/dirs) and `--prune` integration via `Installer::run()`.

## Sources

- Issue: https://github.com/pekral/cursor-rules/issues/80