### PR TITLE
feat(skills): apply class-refactoring to process-code-review and seo-fix

### DIFF
--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -21,7 +21,7 @@ metadata:
 - In the pull request, locate code review output and all review comments (including review threads and general comments).
 - If there is only a generic `CR` comment, treat it as `code review` feedback.
 - Build a checklist from all review findings and map each item to a concrete code or test change.
-- Apply the requested changes and keep scope limited to review feedback.
+- Apply the requested changes and keep scope limited to review feedback. All new or modified production code must follow @.cursor/skills/class-refactoring/SKILL.md.
 - Re-check current changes with @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md.  
 - If review feedback requires additional tests, use @.cursor/skills/create-missing-tests-in-pr/SKILL.md and ensure current changes are fully covered.
 - Run only checks/tests needed for the changed files and fix all errors before continuing.

--- a/skills/seo-fix/SKILL.md
+++ b/skills/seo-fix/SKILL.md
@@ -41,6 +41,7 @@ metadata:
 - New public route/page: use the public layout and ensure title and meta description are defined for that page.
 
 **After SEO changes**
+- All new or modified production code must follow @.cursor/skills/class-refactoring/SKILL.md.
 - Run existing tests that hit robots, sitemap, or assert head meta. Fix any failing assertions.
 
 **Checklist — new public page**


### PR DESCRIPTION
## Summary

- Added `class-refactoring` skill reference to `process-code-review` — all production code changes applied during code review processing must now follow class-refactoring standards.
- Added `class-refactoring` skill reference to `seo-fix` — all new or modified production code generated during SEO changes must now follow class-refactoring standards.

## Motivation

Skills that modify production code should consistently enforce the `class-refactoring` skill to guarantee best production code quality. The three `resolve-*` skills already had this reference; `process-code-review` and `seo-fix` were missing it.

## Test plan

- [ ] Trigger `process-code-review` on a PR with review comments — verify that applied code changes follow class-refactoring rules (SRP, no magic numbers, DRY, etc.)
- [ ] Trigger `seo-fix` on a project — verify that generated PHP/Blade code follows class-refactoring rules

No automated tests — this is a skills/documentation-only change.

Made with [Cursor](https://cursor.com)