### PR TITLE
Revert "fix(skills): enforce English for GitHub-facing outputs"

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -11,7 +11,6 @@ metadata:
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Switch to the main branch and make sure you have the updated main branch. Then switch to the branch where the PR is and, to be on the safe side, update the branch for the PR as well, then continue with the code review.
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
-- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - NEVER CHANGE THE CODE! Generate the output only.
 - All messages formatted as markdown for output.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -11,7 +11,6 @@ metadata:
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Switch to the main branch and make sure you have the updated main branch. Then switch to the branch where the PR is and, to be on the safe side, update the branch for the PR as well, then continue with the code review.
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
-- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - NEVER CHANGE THE CODE! Generate the output only.
 - All messages formatted as markdown for output.
 - For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -10,7 +10,6 @@ metadata:
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - I want the texts to be in the language in which the assignment was written.
-- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - Never push direct changes to the main branch.
 - If the pull request has merge conflicts with the base branch, stop and report that the code review processing is blocked.
 - For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown) and follow the universal structure from JIRA-focused skills.

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -11,7 +11,6 @@ metadata:
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
-- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -10,7 +10,6 @@ metadata:
 **Constraint:**
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - I want the texts to be in the language in which the assignment was written.
-- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - If you are not on the main git branch in the project, switch to it.
 
 **Steps:**

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -10,7 +10,6 @@ metadata:
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want the texts to be in the language in which the assignment was written.
-- All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.


### PR DESCRIPTION
Reverts pekral/cursor-rules#77