### PR TITLE
Add direct app links to testing recommendations

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -30,7 +30,7 @@ metadata:
 - If there are any, I want you to add comments to the PR about where you found these errors. If that is not possible, I want you to create a new comment on the PR with a list of errors from the CR. If you do not find any errors, write that you have done the CR but did not find any serious errors. Every text in English.
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. Format the PR comment as: (1) One-line summary by severity (e.g. "Summary: 2 Critical, 1 Moderate"); (2) List of findings grouped by severity, each with file/line (or file) and a short, actionable recommendation. Do not list "What was checked," only the findings.
 - Use readable Markdown with clear section separators and include short code suggestions for simple fixes when helpful.
-- Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
+- Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - If is needed use interactive-testing skill for testing
 
 **After completing the tasks**

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -23,6 +23,7 @@ metadata:
 - One short business-readable paragraph (non-technical wording)
 - `h4. Findings summary` and bullet list using `*`
 - If needed, `h4. Testing recommendations` and bullet list using `*`
+- For every testing recommendation item, include a direct in-app link (full URL) so testers can open the exact screen immediately
 - Inline references with `{{...}}` (ticket id, endpoint, env, status code)
 - Use `{code}` / `{code:json}` only for short examples; never include markdown fences in JIRA comments
 - Keep comments understandable for project managers and testers, not only developers
@@ -42,7 +43,7 @@ metadata:
 - I don't want to enter technical data into the JIRA issue tracker after code review, but I want to edit the text so that project managers and testers can understand it.
 - For simple fixes, include a minimal example using JIRA `{code}` blocks only when it improves clarity.
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. Format the PR comment as: (1) One-line summary by severity (e.g. "Summary: 2 Critical, 1 Moderate"); (2) List of findings grouped by severity, each with file/line (or file) and a short, actionable recommendation. Do not list "What was checked," only the findings.
-- Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
+- Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - If is needed use interactive-testing skill for testing
 
 **After completing the tasks**

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -24,7 +24,7 @@ metadata:
 - If everything is OK create a pull request, create it according to the pr.mdc rules.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
-- Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
+- Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After creating the PR, perform a code review @.cursor/skills/code-review/SKILL.md for the current task.
 - If you are not on the main git branch in the project, switch to it.

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -23,7 +23,7 @@ metadata:
 - If everything is OK create a pull request, create it according to the pr.mdc rules.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
-- Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
+- Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After creating the PR, perform a code review @.cursor/skills/code-review-github/SKILL.md for the current task.
 - If you are not on the main git branch in the project, switch to it.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -20,6 +20,7 @@ metadata:
 - Short context paragraph (1-3 lines, plain text)
 - Optional sections with `h4. <section title>`
 - Bullets with `* item`
+- For testing recommendations, include direct in-app links as full URLs in each bullet item
 - Inline code/paths/endpoints in monospace using `{{...}}`
 - Code examples only via `{code[:language]}` blocks
 - Tables only with JIRA table syntax (`||` header row, `|` data row)
@@ -63,7 +64,7 @@ h4. Testing recommendations
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment on the core revision on GitHub, but I want you to post only critical or medium-severity issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue as ready for review.
 - After completing all tasks for GitHub, link the created PR in the JIRA issue, change the status of the JIRA issue to ready for review.
-- Run the tests and let me know if the current changes meet the requirements.  If so, add a new comment to the issue with a recommendation on what to test (briefly). If the requirements are not met or you have found critical errors, just list them for me.
+- Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
 

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -20,6 +20,8 @@ metadata:
 -   Testing instructions must be taken only from the PR conversation.
 -   Specifically search for a section named **'Doporučení k testování'**
     or **'Testing Recommendations'**.
+-   In that section, prefer recommendations that include direct in-app links
+    (full URLs) for fast click-through testing.
 -   Test the application like a **senior tester of web applications who
     is not a programmer**.
 -   Focus on visible behavior, usability, clarity, consistency, and real


### PR DESCRIPTION
## Summary
- doplněno pravidlo, že doporučení k testování musí obsahovat přímé in-app odkazy (full URL) pro rychlé prokliknutí
- sjednoceno napříč relevantními skilly pro GitHub/JIRA/Bugsnag workflow
- upravené instrukce zachovávají stávající formát a jen zpřesňují očekávaný výstup

## Sources
- [Issue #83](https://github.com/pekral/cursor-rules/issues/83)
- [resolve-github-issue/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/resolve-github-issue/SKILL.md)
- [code-review-github/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/code-review-github/SKILL.md)
- [code-review-jira/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/code-review-jira/SKILL.md)
- [resolve-bugsnag-issue/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/resolve-bugsnag-issue/SKILL.md)
- [test-like-human/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/test-like-human/SKILL.md)

## Test plan
- [x] `composer build`
- [x] ověřit, že generované instrukce explicitně požadují full URL odkazy v doporučeních k testování
- [x] ověřit, že změna je aplikovaná konzistentně ve všech dotčených skillech
- [ ] no.

Made with [Cursor](https://cursor.com)