### PR TITLE
feat(skill): mark ?array as error in code-review and class-refactoring

### DIFF
--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -27,6 +27,7 @@ metadata:
 - Prefer small, focused functions.
 - English comments only.
 - Spatie DTOs instead of arrays (except Job constructors).
+- **`?array` is forbidden:** Any use of `?array` as a type hint must be replaced with a typed collection, DTO, or explicit `array<Type>|null`. Vague nullable arrays hide structure and break static analysis.
 - Laravel helpers over native PHP when appropriate.
 - DRY principle — eliminate duplicates.
 - Remove obvious comments; keep PHPStan-relevant docs.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -77,6 +77,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Scalability: locking, queue depth, missing caching for hot paths, data structures or algorithms that do not scale with volume.
 - Naming: purpose-revealing; PascalCase/camelCase/kebab-case per type.
 - Single responsibility; DTOs not `array<mixed>`; DRY; clear interfaces; no magic numbers (use constants).
+- **`?array` is forbidden (**Critical**):** Any use of `?array` as a type hint is an error. Replace with a typed collection, DTO, or explicit `array<Type>|null`. Vague nullable arrays hide structure and break static analysis.
 - Do not re-check style, types, or issues that PHPStan/Rector/PHPCS/Pint already report.
 - Unnecessary complexity; large functions; repeated logic; oversized classes; mixed responsibilities.
 - Recommend: simplify structure, improve cohesion, split large units.


### PR DESCRIPTION
## Summary

- Added a **Critical** rule to `code-review` skill: any use of `?array` as a type hint is an error — must be replaced with a typed collection, DTO, or explicit `array<Type>|null`
- Added the same rule to `class-refactoring` skill to enforce consistent replacement during refactoring

## Motivation

`?array` hides structure, breaks static analysis, and prevents proper type checking. DTOs or typed arrays should always be used instead.

## Test plan

- [ ] Verify that `skill-check` still passes (`composer build`)
- [ ] Confirm the rule appears in `skills/code-review/SKILL.md` under type/DRY findings
- [ ] Confirm the rule appears in `skills/class-refactoring/SKILL.md` under array/DTO guidance

Closes https://github.com/pekral/cursor-rules/issues/88

🤖 Generated with [Claude Code](https://claude.com/claude-code)