### PR TITLE
fix(skill): enforce CR checklist gate before merge

### DIFF
--- a/skills/merge-github-pr/SKILL.md
+++ b/skills/merge-github-pr/SKILL.md
@@ -13,4 +13,8 @@ metadata:
 - Never send PRs that have conflicts
 
 **Steps:**
+- For each candidate PR, load all review comments and requested changes from code review (including unresolved/outdated discussion threads) and create a checklist of required fixes.
+- Verify that every checklist item from code review is fully resolved in the current PR diff.
+- If at least one code review item is not resolved, DO NOT merge the PR. Instead, report unresolved items and stop processing that PR.
+- Only when all code review checklist items are resolved and CI is green, continue with merge preparation.
 - Go through all PRs that have successfully completed the attached CI actions and systematically merge the changes into the main branch.


### PR DESCRIPTION
## Summary
- Add explicit pre-merge gate to `skills/merge-github-pr/SKILL.md`.
- Require loading review comments/requested changes and building a checklist for every candidate PR.
- Block merge when any review checklist item is unresolved; allow merge only when all items are resolved and CI is green.

## Issue
- Closes #98
- https://github.com/pekral/cursor-rules/issues/98

## Sources used for analysis
- https://github.com/pekral/cursor-rules/issues/98

## Testing recommendations
- [ ] Verify that a PR with unresolved review comments is not merged by the skill.
- [ ] Verify that a PR with all review checklist items resolved and green CI can proceed to merge.
- [ ] Verify that unresolved items are reported before merge is blocked.

## Tests
- Automated tests added for this change: no.
- Validation run: `composer build` (PASS)