### PR TITLE
fix(skill): enforce architecture review loop in refactor-entry-point

### DIFF
--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 - Read `project.mdc` and all architecture rules that define Action pattern requirements before writing any code.
 - Keep all texts in the language used in the assignment.
 - Preserve behavior: refactor orchestration location, not business result.
+- In this iteration, do not report code review output to any third-party service.
+- After generating or updating code, run immediate internal code review focused on architecture and fix findings ASAP.
 
 **Use when:**
 - A controller entry point (or job/command/listener entry point) contains orchestration logic and must be migrated to Action pattern.
@@ -32,9 +34,12 @@ metadata:
 - New Action must be placed under `app/Actions/**` in a domain-specific subfolder.
 - Action class must be `final readonly`.
 - Action must expose exactly one public business entry point: `__invoke(...)` with explicit return type.
+- Action must stay clean and simple: minimal orchestration surface, no duplicated branches, no dead paths.
+- Action should be as optimized as possible for readability and runtime (avoid redundant mapping, calls, or temporary structures).
 - No direct Eloquent queries and no `DB::` calls inside the Action.
 - Action orchestrates only: validation/mapping/delegation; heavy shared logic belongs to Services.
 - Entry point method must become thin and only delegate to Action.
+- Add or update PHPDoc where needed so PHPStan can infer intent/types without ambiguity (especially DTO shapes, iterable generics, and non-obvious contracts).
 
 **Steps:**
 1. Analyze current implementation of the target entry point method and identify orchestration steps.
@@ -44,8 +49,11 @@ metadata:
 5. Update controller method to dependency-inject and call the Action only.
 6. Keep account/multitenancy scope intact in all delegated calls.
 7. Ensure method signatures and returned response format stay backward compatible.
-8. If PHP files changed, run required project checks/fixers and resolve all issues.
-9. Add or update tests to fully cover touched logic and preserve behavior.
+8. Add or update PHPDoc to satisfy static analysis quality for touched PHP code.
+9. Run an internal architecture-first code review of the generated changes (no third-party reporting in this iteration).
+10. If the review finds critical or medium issues, fix them immediately and repeat the review until no such findings remain.
+11. If PHP files changed, run required project checks/fixers and resolve all issues.
+12. Add or update tests to fully cover touched logic and preserve behavior.
 
 **Do not:**
 - Do not keep business branching/orchestration in the controller method.
@@ -57,5 +65,8 @@ metadata:
 **Definition of done:**
 - Target entry point method is thin and delegates to a dedicated Action.
 - Action respects all project Action-pattern constraints.
+- Internal architecture-focused review was executed and all critical/medium findings were fixed before completion.
+- Action implementation is clean, simple, and optimized without changing behavior.
+- Required PHPDoc for PHPStan is present on touched PHP code where needed.
 - Tests cover the refactored flow (including failure/edge paths where applicable).
 - Required project quality checks pass for changed files.


### PR DESCRIPTION
## Shrnutí
- Aktualizoval jsem `skills/refactor-entry-point-to-action/SKILL.md` tak, aby po vygenerování/úpravě kódu povinně proběhl interní architecture-first code review.
- Skill nyní vyžaduje okamžité opravy kritických a středně závažných nálezů a opakování review smyčky, dokud tyto nálezy nezmizí.
- Doplnil jsem explicitní požadavky na čistou/jednoduchou/optimalizovanou Action implementaci a na PHPDoc potřebné pro kvalitní průchod PHPStan.

## Zdroje pro analýzu zadání
- [Issue #95](https://github.com/pekral/cursor-rules/issues/95)
- [Upravovaný skill](https://github.com/pekral/cursor-rules/blob/master/skills/refactor-entry-point-to-action/SKILL.md)

## Testovací doporučení
- [ ] Spustit `composer build` a ověřit, že celý quality pipeline projde bez chyb.
- [ ] Ověřit, že `skill-check` nehlásí žádné nové warningy/error pro `skills/refactor-entry-point-to-action/SKILL.md`.
- [ ] Projít ručně text skillu a potvrdit, že obsahuje explicitně: interní CR smyčku, ASAP opravy nálezů, zákaz third-party reportingu v této iteraci, požadavek na PHPDoc pro PHPStan.

Testy napsané pro tato doporučení: no.

Made with [Cursor](https://cursor.com)