### PR TITLE
fix(skills): enforce explicit TDD-first workflow for bug tasks

### DIFF
--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -17,7 +17,11 @@ metadata:
 **Steps:**
 - Analyze all comments in the issue tracker and check what needs to be done accordingly. Stick strictly to the assignment and comments!
 - I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
-- First, analyze the task to determine whether it’s a bug or not. If it is a bug, first reproduce the error in your tests, and then fix it! Only in this case should you follow TDD!
+- Bugsnag issues always represent runtime errors or exceptions and are therefore always treated as bugs. Follow strict TDD:
+  1. Write a test that reproduces the reported failure (the test must fail before any fix is applied).
+  2. Run the test and confirm it fails — do not proceed until you see the red failure.
+  3. Implement the minimal fix that makes the test pass.
+  4. Run the test again and confirm it is green.
 - Resolve this issue (the generated code must be according to @.cursor/skills/class-refactoring/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -16,7 +16,16 @@ metadata:
 - Read project.mdc file
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - I want you to fix the bug from Github (you either got an ID or a link to Github). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
-- First, analyze the task to determine whether it’s a bug or not. If it is a bug, first reproduce the error in your tests, and then fix it! Only in this case should you follow TDD!
+- Classify the task type before writing any code:
+  - **Bug**: the issue describes existing functionality that behaves incorrectly (e.g. wrong output, exception, regression, data corruption). Labels such as `bug`, `fix`, or `regression` are strong signals.
+  - **Feature**: the issue requests new behaviour that does not exist yet.
+  - If the classification is unclear, treat the task as a feature.
+- If the task is a **bug**, follow strict TDD:
+  1. Write a test that reproduces the reported failure (the test must fail before any fix is applied).
+  2. Run the test and confirm it fails — do not proceed until you see the red failure.
+  3. Implement the minimal fix that makes the test pass.
+  4. Run the test again and confirm it is green.
+- If the task is a **feature**, implement it directly without the failing-test-first requirement.
 - Resolve this issue (the generated code must be according to @.cursor/skills/class-refactoring/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -56,7 +56,16 @@ h4. Testing recommendations
 - Read project.mdc file
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli tool or MCP server to get all the information you need about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
-- First, analyze the task to determine whether it’s a bug or not. If it is a bug, first reproduce the error in your tests, and then fix it! Only in this case should you follow TDD!
+- Classify the task type before writing any code:
+  - **Bug**: the issue describes existing functionality that behaves incorrectly (e.g. wrong output, exception, regression, data corruption). Issue types such as `Bug` or `Defect`, or labels such as `bug`, `fix`, or `regression` are strong signals.
+  - **Feature**: the issue requests new behaviour that does not exist yet.
+  - If the classification is unclear, treat the task as a feature.
+- If the task is a **bug**, follow strict TDD:
+  1. Write a test that reproduces the reported failure (the test must fail before any fix is applied).
+  2. Run the test and confirm it fails — do not proceed until you see the red failure.
+  3. Implement the minimal fix that makes the test pass.
+  4. Run the test again and confirm it is green.
+- If the task is a **feature**, implement it directly without the failing-test-first requirement.
 - Resolve this issue (the generated code must be according to @.cursor/skills/class-refactoring/SKILL.md), then review the code according to @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md for current changes. If you find any critical issues in the new changes, resolve them and perform further iterations of the defined code review (repeat until the bug is fixed).
 - Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.


### PR DESCRIPTION
## Summary

Resolves #102.

The three issue-tracker resolve skills (`resolve-github-issue`, `resolve-jira-issue`, `resolve-bugsnag-issue`) previously contained only a brief, one-sentence hint about TDD for bugs. This left ambiguity about:

- how to determine whether a task is a bug or a feature,
- whether to confirm the test actually fails before writing the fix,
- what to do for feature tasks.

This PR replaces that hint with a structured, ordered workflow.

## Changes

### `resolve-github-issue` and `resolve-jira-issue`

Added an explicit classification block and a four-step TDD cycle:

1. **Classify** — bug if existing behaviour is broken (wrong output, exception, regression, data corruption); feature if new behaviour is requested. When unclear, default to feature. JIRA version also considers issue type (`Bug`, `Defect`).
2. **Bug path (strict TDD)**:
   1. Write a test that reproduces the failure.
   2. Run the test and confirm it fails — block until red.
   3. Implement the minimal fix.
   4. Run the test and confirm it is green.
3. **Feature path** — implement directly without the failing-test-first step.

### `resolve-bugsnag-issue`

Bugsnag issues are always runtime errors or exceptions, so no classification is needed. The skill now states this explicitly and applies the same four-step TDD cycle unconditionally.

## Sources

- GitHub issue: https://github.com/pekral/cursor-rules/issues/102

## Testing recommendations

These are documentation/instruction changes only (SKILL.md files). No PHP code was changed.

- Verify `npx skill-check check skills --no-security-scan` passes — **tests written**: yes (run as part of CI via `composer skill-check`).
- Verify PHP unit tests pass: `vendor/bin/pest tests/InstallerTest.php --no-coverage` — **tests written**: existing suite covers installer behaviour; no new PHP code introduced.