### PR TITLE
fix(skill): stop immediately when GitHub issues cannot be loaded

### DIFF
--- a/skills/resolve-random-github-issue/SKILL.md
+++ b/skills/resolve-random-github-issue/SKILL.md
@@ -12,8 +12,9 @@ metadata:
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want the texts to be in the language in which the assignment was written.
 - If you are not on the main git branch in the project, switch to it.
+- **If the agent is unable to load the issue details, it must stop immediately and not proceed with any work.**
 
 **Steps:**
 - Load all open GitHub issues from the current repository and list only those that are to be resolved by AI (they are labeled).
-  Look for issues labeled "Resolve_by_AI." If you cannot load the issues, find out the available tools in the system and choose the most suitable tool to download the information. Only open (not resolved) issues should be listed!
+  Look for issues labeled "Resolve_by_AI." Only open (not resolved) issues should be listed! If you cannot load the issues, stop immediately — do not proceed with the work.
 - Randomly select one and try to resolve it. Use the skill @.cursor/skills/resolve-github-issue/SKILL.md.


### PR DESCRIPTION
## Summary

- Adds a hard-stop constraint to `resolve-random-github-issue/SKILL.md`: if the agent cannot load issue details, it must stop immediately and not proceed with any work.
- Removes the previous instruction that told the agent to search for alternative tools when issues could not be loaded — that behaviour could cause unintended actions when issue context was missing.

Closes #103

## Sources
- Issue: https://github.com/pekral/cursor-rules/issues/103
- Related skill: `skills/resolve-random-github-issue/SKILL.md`

## How to test

- Trigger the `resolve-random-github-issue` skill in an environment where GitHub issues cannot be fetched (e.g. no network access or missing `gh` CLI credentials).
- **Expected:** The agent stops immediately and reports that it could not load issues — no further work is performed.
- **Previously:** The agent would attempt to find alternative tools and continue, risking unintended actions.

Tests written for this suggestion: **no** (the change is a SKILL.md instruction file, not executable code — no automated tests apply).