### PR TITLE
feat(laravel): enforce validation rules as traits in App\Concerns

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -15,6 +15,11 @@ globs: ["*"]
 - **Events**: Slim, delegate to Services
 - **Commands**: Slim, delegate to Services
 
+## Validation Rules
+- Store reusable validation rules as traits in the `App\Concerns` namespace (e.g. `PasswordValidationRules`).
+- Each trait should provide focused, well-typed methods that return validation rule arrays with proper PHPDoc generics.
+- Use these traits in FormRequest classes and anywhere validation rules are needed to ensure DRY and consistent validation across the application.
+
 ## Controllers
 - Inject services by method injection
 - Plural names (ContactsController)

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -30,6 +30,7 @@ metadata:
 - **`?array` is forbidden:** Any use of `?array` as a type hint must be replaced with a typed collection, DTO, or explicit `array<Type>|null`. Vague nullable arrays hide structure and break static analysis.
 - Laravel helpers over native PHP when appropriate.
 - DRY principle — eliminate duplicates.
+- **Validation rules as traits:** Extract reusable validation rules into traits in `App\Concerns` (e.g. `PasswordValidationRules`). Use these traits in FormRequest classes instead of duplicating rule arrays.
 - Remove obvious comments; keep PHPStan-relevant docs.
 - Single Responsibility Principle.
 - Extract private methods if body exceeds ~30 lines.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -58,6 +58,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Short transactions; batch writes in one transaction where appropriate.
 - Use `SHOW ENGINE INNODB STATUS` to diagnose lock waits when investigating issues.
 - Controllers: slim; delegate to Services; accept FormRequest only; never `validate()` in controller.
+- **Validation rules as traits:** Reusable validation rules must be stored as traits in `App\Concerns`. Duplicated rule arrays across FormRequests should be flagged as **Moderate**.
 - Services: hold business logic; return DTOs or models.
 - Repositories: read-only. ModelManagers: write-only.
 - Jobs, Events, Commands: slim; delegate to Services.


### PR DESCRIPTION
## Summary
- Přidáno pravidlo pro ukládání znovupoužitelných validačních pravidel jako traits v namespace `App\Concerns` (např. `PasswordValidationRules`).
- Aktualizován `architecture.mdc`, `class-refactoring` skill a `code-review` skill.

## Změny
- **rules/laravel/architecture.mdc** — nová sekce `## Validation Rules` s konvencí pro validační traits
- **skills/class-refactoring/SKILL.md** — pravidlo pro extrakci validačních pravidel do traits při refaktoringu
- **skills/code-review/SKILL.md** — CR pravidlo pro flagování duplicitních rule arrays jako **Moderate**

## Zdroje
- https://github.com/pekral/cursor-rules/issues/110

## Test plan
- [ ] Ověřit, že `composer build` prochází (skill-check, PHPStan, Rector, Pint, PHPCS)
- [ ] Ověřit, že nová pravidla jsou konzistentní s existujícími Laravel konvencemi
- [ ] Ověřit, že code-review skill správně flaguje duplicitní validační pravidla