### PR TITLE
fix(refactoring): prefer direct invocation syntax for invokeable Action classes

### DIFF
--- a/rules/laravel/arch-app-services.mdc
+++ b/rules/laravel/arch-app-services.mdc
@@ -12,6 +12,7 @@ globs: ["vendor/pekral/arch-app-services/**", "app/Actions/**", "app/DataValidat
 - All classes implementing the Action pattern must be stored under `app/Actions/**/` (domain-based subfolders are required; do not place Actions in Controllers, Services, Jobs, or other directories).
 - For new orchestration in Jobs, Controller actions, and Console Commands, delegation to an Action class from `app/Actions/**/` is mandatory.
 - `app/Actions/` — one use case per class, `final readonly`, constructor DI only, **single public entry point `__invoke()`** (no additional public business methods).
+- **Invokeable call syntax:** Always call Action classes using direct invocation `$action($params)` instead of `$action->__invoke($params)`. PHP automatically routes `$action(...)` to `__invoke(...)` on invokeable classes — the explicit `->__invoke()` form is redundant and less readable.
 - Actions are orchestration-only: validation, DTO/data transformation, and delegation. **No direct Eloquent storage/query calls** and no `DB::` queries in Actions.
 - `app/Services/` (especially classes extending `BaseModelService`) orchestrate repository + model manager contracts; keep them stateless and focused. Service naming follows package convention (`*ModelService` for model services).
 - `app/Repositories/` — read-only access layer (querying, filtering, pagination, optional cache wrapper); no writes, no side effects.
@@ -46,5 +47,6 @@ globs: ["vendor/pekral/arch-app-services/**", "app/Actions/**", "app/DataValidat
 - If a new Job / Controller action / Console Command does not use the Action pattern, mark this finding as **critical severity** in the CR report.
 - **Request changes** if a PR introduces multi-step orchestration, branching business rules, or repeated controller/job logic without an Action; extracting or reusing an Action is the default fix.
 - **Inline validation in Actions is forbidden**: if an Action throws `ValidationException` directly or calls `Validator::make()` inline, flag it as **critical severity**. Validation must be delegated to a dedicated Data Validator class.
+- **Invokeable call syntax in CR**: if code calls an Action via `->__invoke()` instead of direct invocation `$action(...)`, flag it as **Moderate** and recommend the shorter form.
 - **Legacy carve-out**: do not block a CR solely to rewrite untouched surrounding code; still require Actions for **new** behavior and for **refactored** paths you touch.
 - **Exceptions** (no Action required): trivial pass-through, pure DTO mapping with no domain rules, config-only changes, or frontend-only diffs with no new PHP orchestration.

--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -36,7 +36,7 @@ globs: ["*"]
 - Implement proper request validation using Form Requests
 - Aim for "slim" Controllers and put larger logic pieces in Service classes
 - Ensure that every route checks permissions (e.g., auth/can middleware). Every CRUD action validates input.
-- Call actions or service
+- Call actions or service using direct invocation syntax: `$action($params)` (never `$action->__invoke($params)`)
 - NO Database Queries in Controller!
 - For validation rule `['required', 'string']` verify that an empty string does not pass.
 

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -37,6 +37,7 @@ metadata:
 - No single-use variables.
 - Extract intention-revealing private methods
 - **All business logic is allowed only in classes that follow the action pattern!**
+- **Invokeable call convention:** When calling Action classes, always use direct invocation `$action($params)` — never `$action->__invoke($params)`.
 - **Action pattern (only when `vendor/pekral/arch-app-services` exists):** Apply @.cursor/skills/refactor-entry-point-to-action/SKILL.md when the refactored class is a controller, job, command, or listener that contains orchestration logic.
 - **Data Validator extraction (only when `vendor/pekral/arch-app-services` exists):** If an Action class contains inline validation logic (throwing `ValidationException` directly or calling `Validator::make()`), extract it into a dedicated Data Validator class under `app/DataValidators/{Domain}/`.
 - Separate orchestration layer from business logic

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -82,6 +82,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Naming: purpose-revealing; PascalCase/camelCase/kebab-case per type.
 - Single responsibility; DTOs not `array<mixed>`; DRY; clear interfaces; no magic numbers (use constants).
 - **`?array` is forbidden (**Critical**):** Any use of `?array` as a type hint is an error. Replace with a typed collection, DTO, or explicit `array<Type>|null`. Vague nullable arrays hide structure and break static analysis.
+- **Invokeable call syntax (**Moderate**):** If code calls an Action (or any invokeable class) via `->__invoke()` instead of direct invocation `$action(...)`, flag as **Moderate** and recommend the shorter form.
 - Do not re-check style, types, or issues that PHPStan/Rector/PHPCS/Pint already report.
 - Unnecessary complexity; large functions; repeated logic; oversized classes; mixed responsibilities.
 - Recommend: simplify structure, improve cohesion, split large units.

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -42,7 +42,8 @@ metadata:
 - **Actions must not contain inline validation logic**: do not throw `ValidationException` directly or call `Validator::make()` inside Actions. Extract all validation into a dedicated Data Validator class under `app/DataValidators/{Domain}/`.
 - Data Validators are `final readonly` classes with constructor DI and a single `validate()` method that throws `ValidationException` on failure.
 - Actions call the Data Validator before proceeding with business orchestration.
-- Entry point method must become thin and only delegate to Action.
+- Entry point method must become thin and only delegate to Action using direct invocation syntax `$action($params)`.
+- **Invokeable call convention:** Always use `$action($params)` to call Actions — never use `$action->__invoke($params)`. PHP natively routes the call to `__invoke()`, making the explicit form redundant.
 - Add or update PHPDoc where needed so PHPStan can infer intent/types without ambiguity (especially DTO shapes, iterable generics, and non-obvious contracts).
 
 **Steps:**
@@ -50,7 +51,7 @@ metadata:
 2. Create a dedicated Action (one use case = one Action) in the correct domain folder under `app/Actions/**`.
 3. Move orchestration from controller method into Action `__invoke(...)`.
 4. Keep reads in Repository and writes in ModelManager; if missing, introduce or reuse proper layer classes.
-5. Update controller method to dependency-inject and call the Action only.
+5. Update controller method to dependency-inject and call the Action using direct invocation syntax `$action($params)` (never `$action->__invoke($params)`).
 6. Keep account/multitenancy scope intact in all delegated calls.
 7. Ensure method signatures and returned response format stay backward compatible.
 8. Add or update PHPDoc to satisfy static analysis quality for touched PHP code.


### PR DESCRIPTION
## Summary
- Enforce `$action($params)` syntax instead of `$action->__invoke($params)` across all rules and skills
- Updated architecture rules (`arch-app-services.mdc`, `architecture.mdc`) with invokeable call convention
- Updated skills (`class-refactoring`, `code-review`, `refactor-entry-point-to-action`) to enforce and check the pattern
- Added CR check: `->__invoke()` usage is flagged as **Moderate** in code reviews

## Changed files
- `rules/laravel/arch-app-services.mdc` — added invokeable call syntax rule + CR check
- `rules/laravel/architecture.mdc` — updated controller call convention
- `skills/class-refactoring/SKILL.md` — added invokeable call convention
- `skills/code-review/SKILL.md` — added Moderate-severity check for `->__invoke()` usage
- `skills/refactor-entry-point-to-action/SKILL.md` — updated delegation step + added call convention

## Sources
- https://github.com/pekral/cursor-rules/issues/116

## Test plan
- [ ] Verify that all rules and skills consistently reference `$action($params)` syntax
- [ ] Verify that `->__invoke()` is flagged as **Moderate** in code review rules
- [ ] Run `composer build` — all checks pass (skill-check 100/100, PHPStan, Pint, Rector, PHPCS)
- [ ] Run tests — all 58 tests pass