### PR TITLE
fix(skill): add PR creation step to process-code-review skill

### DIFF
--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -25,6 +25,7 @@ metadata:
 - If review feedback requires additional tests, use @.cursor/skills/create-missing-tests-in-pr/SKILL.md and ensure current changes are fully covered.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - Run only checks/tests needed for the changed files and fix all errors before continuing.
+- Commit all changes and push the branch. If no pull request exists for the current branch, create one according to @.cursor/rules/git/pr.mdc rules — link it to the original issue and follow the PR description format (title in English, body in the language of the assignment).
 - Update the review result comment in the pull request:
 - mark resolved points as checked items when possible, or
 - format resolved points as underlined text when checkbox updates are not possible.


### PR DESCRIPTION
## Popis změny

Skill `process-code-review` po zpracování všech úkolů z code review nyní:
- Commitne změny a pushne větev
- Pokud PR pro danou větev neexistuje, vytvoří ho podle pravidel `@.cursor/rules/git/pr.mdc`

## Doporučení k testování

- Spusť skill `process-code-review` na existující issue s CR komentáři
- Ověř, že po zpracování všech bodů se vytvoří (nebo existující) PR zobrazuje aktualizované změny

## Zdroje

- Issue: https://github.com/pekral/cursor-rules/issues/132
- Upravený soubor: `skills/process-code-review/SKILL.md`

Closes #132