### PR TITLE
fix(skill): post test results to issue tracker after test-like-human

### DIFF
--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -206,3 +206,5 @@ The final report must:
 Summarize:
 
 -   which scenarios failed or were unclear (with technical info)
+
+-   Post the final human-readable test report as a comment to the **related issue** in the issue tracker (GitHub issue, JIRA ticket, etc.). Use available CLI tools or MCP servers to post it. The comment must be written in the language of the task assignment.


### PR DESCRIPTION
## Summary

- After completing all testing scenarios, the `test-like-human` skill now posts the final human-readable test report as a comment to the related issue in the issue tracker (GitHub issue, JIRA ticket, etc.)
- Uses available CLI tools or MCP servers to post the comment
- Report language matches the task assignment language

Closes #134

## Test plan

- [ ] Run the `test-like-human` skill on a PR — verify the test report is posted to the related issue tracker
- [ ] Verify the comment is in the correct language (matching the task assignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)