### PR TITLE
feat(rule): add PHP array key type safety rules

### DIFF
--- a/rules/php/standards.mdc
+++ b/rules/php/standards.mdc
@@ -140,3 +140,40 @@ Simplify the tests by dividing them into multiple test cases.
 - Catch specific exceptions
 - Use finally for cleanup
 - Don't suppress errors with @
+
+## PHP Array Key Type Safety
+- Never assume `array<string, T>` is automatically runtime-safe in PHP.
+- PHP silently casts array keys: decimal integer strings like `'123'` become `123`; `bool` becomes `0`/`1`; `float` is truncated to `int`; `null` becomes `''`.
+- Treat dynamic associative array keys as unsafe unless it is clear they cannot be cast by PHP.
+
+### High-risk patterns — always flag:
+- `$map[$id] = $value;`
+- `$set[$value] = true;`
+- `$grouped[$key][] = $item;`
+- `$indexed[(string) $something] = ...;`
+- Be extra careful when the key originates from: request input, database values, imported CSV/XML/API data, `substr()`, `trim()`, `explode()`, casts, normalization helpers, or values typed as `mixed`, `scalar`, `string|int`, `bool`, `float`, or `null`.
+
+### Review expectations:
+- When reviewing associative arrays, check whether a supposed string key can actually become an integer key at runtime.
+- Do not trust `(string) $value` alone as proof that the key is safe.
+- If a key may contain decimal integer strings, report it as a type-safety issue.
+- If array keys are later passed into a method requiring `string`, verify that runtime casting cannot produce `int` keys under `declare(strict_types=1)`.
+
+### Dangerous follow-up operations — pay extra attention:
+- `array_merge()`, `array_keys()`, `in_array(..., $keys, true)`, `array_key_exists()`, `isset($map[$key])`, `foreach ($map as $key => $value)` when `$key` is then passed into a strict `string` parameter.
+
+### Preferred fixes:
+- Use stable prefixed keys when an array map is the right structure: `'user:' . $id`, `'postal:' . $postalCode`, `'ext:' . $externalReference`.
+- Prefer a dedicated collection or value object when the key is domain-significant.
+- Prefer `list<T>` when the structure is actually a list and not a map.
+- Prefer explicit validation or normalization before using external values as array keys.
+- Where relevant, prefer `array<non-decimal-int-string, T>` over misleading `array<string, T>`.
+
+### Testing expectations:
+- Add or update tests for: numeric-string keys, collisions after runtime key casting, strict lookups over `array_keys()`, `array_merge()` behavior with casted keys, runtime behavior with `declare(strict_types=1)`.
+
+### Reporting style:
+- Report the exact risky key source.
+- Explain how PHP may cast the key at runtime.
+- Explain the practical impact: overwritten entries, failed strict comparisons, unexpected reindexing, possible `TypeError`.
+- Recommend the smallest safe fix first.


### PR DESCRIPTION
## Popis

Přidá sekci **PHP Array Key Type Safety** do `rules/php/standards.mdc`.

Pravidla pokrývají problematiku tichého přetypování klíčů PHP polí za běhu a nejsou dosud obsažena v existujících pravidlech.

## Co bylo přidáno

- **Základní pravidlo:** `array<string, T>` není automaticky runtime-safe
- **Přehled PHP castingu klíčů:** `'123'` → `123`, `bool` → `0`/`1`, `float` → `int`, `null` → `''`
- **High-risk patterny** k označení při review
- **Review expectations** — jak zkoumat asociativní pole
- **Dangerous follow-up operations** — `array_merge()`, `array_keys()`, `in_array()`, atd.
- **Preferred fixes** — prefixované klíče, kolekce, value objekty
- **Testing expectations** — numeric-string klíče, kolize, strict lookups
- **Reporting style** — co reportovat a jak

## Doporučení k testování

Tato změna je čistě dokumentační (`.mdc` pravidla pro AI agenty). Testování probíhá ověřením, zda:

- Obsah sekce odpovídá požadavkům z issue #146 — **yes**
- Pravidla nejsou duplicitní s existujícím obsahem — **yes** (existující rules řeší `?array` zákaz, nikoliv key casting)
- `composer build` prošel bez chyb — **yes** (tests pass, PCOV driver není k dispozici v tomto prostředí, ale to je pouze tooling limitace)

Psaní automatizovaných testů: **no** (jde o `.mdc` soubor, nikoliv PHP kód)

## Zdroje

- GitHub issue: https://github.com/pekral/cursor-rules/issues/146