### PR TITLE
fix(tests): align test-writing skills with testing rules in standards.mdc

### DIFF
--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -43,10 +43,15 @@ metadata:
     abstractions.
 -   Prefer updating existing tests first. Create new tests only if
     required.
+-   Create deterministic every time!
 -   Make sure tests are deterministic and not flaky.
 -   Never use describe() in tests.
--   Mock only external services or exception scenarios.
+-   Test classes must be `final`; use only local variables inside tests.
+-   Mock only external services or exception scenarios. Do not use constructor mocking!
 -   Remove unnecessary mocks if found while updating tests.
+-   In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
+-   If the test requires test data, always create it via the factory or insert it directly into the specific database. Never mock it or circumvent this in any other way!
+-   Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 -   After generating or modifying tests, verify that all new tests comply with the testing rules in `@.cursor/rules/php/standards.mdc`. Check mock usage specifically: mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
 -   Use data providers where they improve readability and simplify
     repeated test cases.

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -15,17 +15,21 @@ metadata:
 **Steps:**
 - Locate existing tests or create new ones following project conventions.
 - Never modify production code!
-- Create deterministic everytime!
+- Create deterministic every time!
 - Use existing test patterns, helpers, and conventions.
 - Arrange-act-assert pattern, error cases first
 - Before writing tests, always analyze the abstractions that will be used in the tests and always use helper methods if it simplifies the code.
 - **Never use the `describe()` function** in tests. Write tests at the top level using `it()` / `test()` only; do not wrap them in `describe()` blocks.
 - If the PEST test requires calling a method that is in an abstract class, use the notation `test()->methodName()`.
 - Never generate the covers() method!
+- Test classes must be `final`; use only local variables inside tests.
 - Remove unnecessary mocks.
-- Mock only external API communication services or if you need simulate exceptions. Do not Constructor mocking!
+- Mock only external API communication services or if you need to simulate exceptions. Do not use constructor mocking!
+- In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
+- If the test requires test data, always create it via the factory or insert it directly into the specific database. Never mock it or circumvent this in any other way!
+- Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Use data providers when they simplify writing and readability.
-- Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them. 
+- Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them.
 - Make sure of 100% coverage required for changes. Add tests so that 100% coverage is achieved. Prioritize modifying existing test cases; if tests do not exist, add them according to the valid rules for writing tests.
 - If new database migrations exist in the current branch, run them (`php artisan migrate`) before running tests.
 - After creating or modifying tests, check that they are not flaky.

--- a/skills/rewrite-tests-pest/SKILL.md
+++ b/skills/rewrite-tests-pest/SKILL.md
@@ -14,14 +14,21 @@ metadata:
 - For tests that do not use PEST syntax, I want you to rewrite them in PEST syntax.
 - Never generate the covers() method!
 - Follow the rules for writing tests.
+- Create deterministic every time!
 - Arrange-act-assert pattern, error cases first
 - Before writing tests, always analyze the abstractions that will be used in the tests and always use helper methods if it simplifies the code.
 - **Never use the `describe()` function** in tests. Write tests at the top level using `it()` / `test()` only; do not wrap them in `describe()` blocks.
 - If there are any "shared" helper functions such as `bindSparkpostMailerNever($this->app);`, I want all these functions to be defined in the Pest.php file.
 - If the PEST test requires calling a method that is in an abstract class, use the notation `test()->methodName()`.
+- Test classes must be `final`; use only local variables inside tests.
+- Remove unnecessary mocks.
+- Mock only external API communication services or if you need to simulate exceptions. Do not use constructor mocking!
+- In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
+- If the test requires test data, always create it via the factory or insert it directly into the specific database. Never mock it or circumvent this in any other way!
+- Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Correct DRY, use data providers, and try to write tests as simply as possible.
 - After creating or modifying tests, check that they are not flaky.
-- Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them. 
+- Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them.
 - Tests must have 100% coverage.
 - If new database migrations exist in the current branch, run them (`php artisan migrate`) before running tests.
 - After writing the tests, verify that they are functional and follow the rules.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -31,8 +31,12 @@ Write one minimal test showing expected behavior.
 
 - One behavior per test.
 - Clear, descriptive name that describes the behavior.
-- Real code paths — mock only external services (HTTP clients) or to simulate exceptions.
+- Real code paths — mock only external services (HTTP clients) or to simulate exceptions. Do not use constructor mocking!
 - Arrange-act-assert pattern, error cases first.
+- Test classes must be `final`; use only local variables inside tests.
+- In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
+- If the test requires test data, always create it via the factory or insert it directly into the specific database. Never mock it or circumvent this in any other way!
+- Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Use data providers when they simplify writing and readability.
 - Never generate the `covers()` method.
 


### PR DESCRIPTION
## Summary

- Added missing test-writing requirements to `create-test`, `rewrite-tests-pest`, `create-missing-tests-in-pr`, and `test-driven-development` skills
- Requirements added: final test classes, local variables only, no conditions in tests, factory/database for test data, no reflection, no constructor mocking, deterministic test creation
- Fixed typo `everytime` → `every time` in `create-test`

## Changes per skill

**`create-test`**
- Added: test classes must be `final`; use only local variables inside tests
- Added: avoid reflection; use mocks instead
- Added: test data must come from factory or database, never mocked
- Added: tests must not contain conditions — split into separate test cases
- Fixed: typo `everytime` → `every time`
- Clarified: "Do not use constructor mocking!"

**`rewrite-tests-pest`**
- Added: `Create deterministic every time!`
- Added: test classes must be `final`; use only local variables inside tests
- Added: remove unnecessary mocks; no constructor mocking
- Added: avoid reflection; use mocks instead
- Added: test data must come from factory or database
- Added: tests must not contain conditions

**`create-missing-tests-in-pr`**
- Added: `Create deterministic every time!`
- Added: test classes must be `final`; use only local variables inside tests
- Added: no constructor mocking
- Added: avoid reflection; use mocks instead
- Added: test data must come from factory or database
- Added: tests must not contain conditions

**`test-driven-development`**
- Added: test classes must be `final`; use only local variables inside tests
- Added: no constructor mocking
- Added: avoid reflection; use mocks instead
- Added: test data must come from factory or database
- Added: tests must not contain conditions

## Test plan

- [ ] Verify skill-check passes (score 100/100 for all skills)
- [ ] Verify all PHP tests pass
- [ ] Verify phpstan, pint, phpcs, rector checks pass

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)