### PR TITLE
feat: add merge-github-prs skill for safe batch merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@ All notable changes to `cursor-rules` will be documented in this file.
 - ♻️ **Refactored**: optimize commands and prompts
 - ✨ **Added**: new Agent skills (resolve-github-issue, merge-github-pr, code-review, seo-fix, package-review, and others)
 - ✨ **Added**: new Agent skill `process-code-review` for handling pull request review feedback loops
+- ✨ **Added**: new Agent skill `merge-github-prs` for batch-merging PRs with successful checks and no conflicts
 - 📝 **Changed**: Update SKILL.md files and rule files (php standards, sql, git, laravel)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - unified PHP coding guidelines for PHP 8.4 projects
 - Pest-based testing with mandatory code analysis and 100% coverage
 - strong focus on clean code: typed properties, SRP, no redundant comments
-- **24 comprehensive Agent skills** for automated workflows (v0.5)
+- **25 comprehensive Agent skills** for automated workflows (v0.5)
 - fast onboarding inside development repositories
 
 ## Installation
@@ -91,6 +91,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `resolve-github-issue`   | Resolves GitHub issues by fixing bugs, refactoring code, performing code and security reviews, ensuring 100% test coverage, running CI checks, and creating pull requests. Updates GitHub issues with review results. |
 | `resolve-bugsnag-issue`  | Resolve Bugsnag issues by fixing bugs, refactoring code, performing code and security reviews, ensuring 100% test coverage, running CI checks, and creating pull requests. Updates GitHub issues with review results. |
 | `merge-github-pr`        | Merge PRs when they are ready for deployment, one by one. |
+| `merge-github-prs`       | Merge multiple PRs in sequence only when CI is successful and there are no merge conflicts. |
 | `analyze-problem`        | Analyze problems from issue trackers. Downloads and reviews attachments, provides technical analysis and solutions, and creates human-readable explanations for both technical and non-technical audiences. |
 
 ## Code Review & Quality

--- a/skills/merge-github-prs/SKILL.md
+++ b/skills/merge-github-prs/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: merge-github-prs
+description: "Use when merging multiple GitHub pull requests that are ready for deployment."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+**Constraint:**
+- Read project.mdc file
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
+- I want the texts to be in the language in which the assignment was written.
+- Never push direct changes to main branch! NEVER!
+- Merge only pull requests without merge conflicts.
+- Merge only pull requests with successful required checks.
+
+**Steps:**
+- Load all open pull requests from the target repository.
+- For each pull request, evaluate:
+- whether it can be merged cleanly (no conflicts),
+- whether required checks are successful,
+- whether the pull request is not in draft state.
+- If a pull request fails any of these conditions, skip it and record the reason.
+- For every pull request that passes all checks, apply the merge workflow from @.cursor/skills/merge-github-pr/SKILL.md.
+- Merge pull requests one by one to keep history and failure handling clear.
+- After each merge, verify the pull request is closed and branch cleanup is completed when allowed.
+- Continue until all eligible pull requests are processed.
+- Provide a final report with:
+- merged pull requests,
+- skipped pull requests and reasons,
+- any blockers that need manual intervention.
+
+**After completing the tasks**
+- Ensure no pull request was merged with conflicts or failing checks.
+- Summarize final merge results for fast release handoff.


### PR DESCRIPTION
## Shrnutí
- Přidal jsem nový skill `merge-github-prs` pro dávkové mergování PR pouze při splnění podmínek: bez konfliktů, zelené required checks a bez draft stavu.
- Nový skill explicitně navazuje na `merge-github-pr` a merguje kandidáty postupně po jednom, včetně finálního reportu merged/skipped PR.
- Aktualizoval jsem dokumentaci v `README.md` (počet skillů + nový řádek v přehledu) a `CHANGELOG.md`.

## Kontext issue
- Fixuje: https://github.com/pekral/cursor-rules/issues/157

## Zdroje použité při analýze
- Issue: https://github.com/pekral/cursor-rules/issues/157
- Existující skill: https://github.com/pekral/cursor-rules/blob/master/skills/merge-github-pr/SKILL.md
- Dokumentace repozitáře: https://github.com/pekral/cursor-rules/blob/master/README.md

## Test plan
- [x] `composer build`
- [x] `npx skill-check check skills --fix --no-security-scan` (součást `composer build`)
- [x] `vendor/bin/pest --coverage tests --min=100` (součást `composer build`)

## Návrhy testování změn
- Spusť AI s promptem na dávkové merge (`merge-github-prs`) a ověř, že přeskočí PR s konfliktem a PR s neúspěšnou CI; test v kódu: **no.**
- Ověř, že u způsobilých PR probíhá merge po jednom a že výstup obsahuje merged/skipped report; test v kódu: **no.**

Made with [Cursor](https://cursor.com)