### PR TITLE
fix: align Laravel rules with SQL schema column defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ All notable changes to `cursor-rules` will be documented in this file.
 - ✨ **Added**: new Agent skill `understand-propose-implement-verify` for strict problem-solving workflow
 - 📝 **Changed**: Update SKILL.md files and rule files (php standards, sql, git, laravel)
 - 📝 **Changed**: Laravel testing rules and test-writing skills require Eloquent rows in tests to be created only via model factories (#147)
+- 📝 **Changed**: Laravel rules and test-writing skills clarify database schema defaults as source of truth—avoid duplicating them in PHP/factories (#152)

--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -94,10 +94,12 @@ final class CreateUserData extends Data
 - Use Casts for Type Safety
 - Chunking for Large Datasets
 - Don't Query in Loops
+- **Schema defaults:** If a column has a default in the database schema (migration `->default(...)` or SQL `DEFAULT`), that is the single source of truth at insert time. Do not duplicate the same default in PHP (`$attributes` on the model, redundant fields in factories/seeders, form `default()`, DTOs) unless you intentionally override it for a specific flow or test.
 
 ## Migrations
 - Only `up()` methods, no `down()`
 - When adding columns in a migration, update the model's `$fillable` array to include those new attributes
+- Prefer defining column defaults in the migration so the database applies them; then avoid mirroring that default again in application layers when it adds no value.
 - Never chain multiple migration-creating commands (e.g., `make:model -m`, `make:migration`) with `&&` or `;` — they may get identical timestamps; run each command separately and wait for completion before running the next
 
 ## Blade / Views
@@ -112,7 +114,7 @@ final class CreateUserData extends Data
 - Always call console commands using Artisan::call(MyCommand::class)
 - Mocking services is only allowed for classes that use external service calls or if it is necessary to simulate an exception throw.
 - **Eloquent rows in tests:** Persisted database rows that map to Eloquent models must be created only via model factories (`Model::factory()->create()`, `make()`, `count()`, `state()`, `for()`, `has()`, `afterCreating()`, etc.). Do not persist such data using `Model::create()`, `new Model([...])->save()`, `DB::table(...)->insert()`, `DB::insert()`, or raw SQL. If a model has no factory yet, add a factory before writing tests that need persisted rows for that model.
-- Factory: multiple records with the same attributes — When creating multiple instances of a model with the same attributes in your tests, use Model::factory()->count(n)->create([...]) instead of repeatedly calling Model::factory()->create([...]). Do not pass attributes that are not verified by the test (e.g., name); a single call is clearer and consistent with Laravel style.
+- Factory: multiple records with the same attributes — When creating multiple instances of a model with the same attributes in your tests, use Model::factory()->count(n)->create([...]) instead of repeatedly calling Model::factory()->create([...]). Do not pass attributes that are not verified by the test (e.g., name); a single call is clearer and consistent with Laravel style. Omit factory attributes that are already covered by a database `DEFAULT` unless the test needs a non-default value.
 - If the PEST test requires calling a method that is in an abstract class, use the notation `test()->methodName()`.
 - All calls to asynchronous jobs in tests will be made via the `UpdateOrCreateCompanyAndUsers` method, e.g., `UpdateOrCreateCompanyAndUsers::dispatch()`.
 - Mocking the necessary classes only via app()->instance(Mock::class), e.g. 

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -31,6 +31,7 @@ metadata:
 - **`?array` is forbidden:** Any use of `?array` as a type hint must be replaced with a typed collection, DTO, or explicit `array<Type>|null`. Vague nullable arrays hide structure and break static analysis.
 - **PHP array key type safety:** When refactoring associative arrays with dynamic keys, apply safe key strategies: use stable prefixed keys (`'user:' . $id`, `'postal:' . $postalCode`, `'ext:' . $externalReference`); prefer a dedicated collection or value object when the key is domain-significant; prefer `list<T>` when the structure is a list, not a map; prefer explicit validation or normalization before using external values as array keys; where relevant, prefer `array<non-decimal-int-string, T>` over misleading `array<string, T>`.
 - Laravel helpers over native PHP when appropriate.
+- When changing Eloquent models, migrations, or factories, do not duplicate column defaults that already exist in the database schema; see `@.cursor/rules/laravel/architecture.mdc` (Schema defaults, Migrations).
 - DRY principle — eliminate duplicates.
 - **Validation rules as traits:** Extract reusable validation rules into traits in `App\Concerns` (e.g. `PasswordValidationRules`). Use these traits in FormRequest classes instead of duplicating rule arrays.
 - Remove obvious comments; keep PHPStan-relevant docs.

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -51,6 +51,7 @@ metadata:
 -   Remove unnecessary mocks if found while updating tests.
 -   In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
 -   If the test requires persisted Laravel Eloquent rows, create them only via `Model::factory()` (see `@.cursor/rules/laravel/architecture.mdc` Testing). For other test data, follow `@.cursor/rules/php/standards.mdc`. Never mock it or circumvent this in any other way!
+-   In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@.cursor/rules/laravel/architecture.mdc` Schema defaults and Testing).
 -   Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 -   After generating or modifying tests, verify that all new tests comply with the testing rules in `@.cursor/rules/php/standards.mdc`. Check mock usage specifically: mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
 -   Use data providers where they improve readability and simplify

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -27,6 +27,7 @@ metadata:
 - Mock only external API communication services or if you need to simulate exceptions. Do not use constructor mocking!
 - In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
 - If the test requires persisted Laravel Eloquent rows, create them only via `Model::factory()` (see `@.cursor/rules/laravel/architecture.mdc` Testing). For other test data, follow `@.cursor/rules/php/standards.mdc`. Never mock it or circumvent this in any other way!
+- In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@.cursor/rules/laravel/architecture.mdc` Schema defaults and Testing).
 - Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Use data providers when they simplify writing and readability.
 - Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them.

--- a/skills/rewrite-tests-pest/SKILL.md
+++ b/skills/rewrite-tests-pest/SKILL.md
@@ -25,6 +25,7 @@ metadata:
 - Mock only external API communication services or if you need to simulate exceptions. Do not use constructor mocking!
 - In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
 - If the test requires persisted Laravel Eloquent rows, create them only via `Model::factory()` (see `@.cursor/rules/laravel/architecture.mdc` Testing). For other test data, follow `@.cursor/rules/php/standards.mdc`. Never mock it or circumvent this in any other way!
+- In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@.cursor/rules/laravel/architecture.mdc` Schema defaults and Testing).
 - Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Correct DRY, use data providers, and try to write tests as simply as possible.
 - After creating or modifying tests, check that they are not flaky.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -36,6 +36,7 @@ Write one minimal test showing expected behavior.
 - Test classes must be `final`; use only local variables inside tests.
 - In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
 - If the test requires persisted Laravel Eloquent rows, create them only via `Model::factory()` (see `@.cursor/rules/laravel/architecture.mdc` Testing). For other test data, follow `@.cursor/rules/php/standards.mdc`. Never mock it or circumvent this in any other way!
+- In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@.cursor/rules/laravel/architecture.mdc` Schema defaults and Testing).
 - Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Use data providers when they simplify writing and readability.
 - Never generate the `covers()` method.


### PR DESCRIPTION
## Shrnutí
- V `rules/laravel/architecture.mdc` je nové pravidlo **Schema defaults**: pokud má sloupec `DEFAULT` ve schématu, je to jediný zdroj pravdy při insertu; stejnou hodnotu znovu nenastavovat v PHP (`$attributes`, factory, seedery, formuláře, DTO), pokud to nemá konkrétní důvod.
- V sekci **Migrations** doplněno upřednostnění definice defaultů v migraci a vyhnutí se zrcadlení v aplikačních vrstvách bez přínosu.
- V **Testing** u factory rozšířeno: vynechat atributy pokryté DB `DEFAULT`, pokud test nepotřebuje jinou hodnotu.
- Skilly `create-test`, `rewrite-tests-pest`, `test-driven-development`, `create-missing-tests-in-pr` a `class-refactoring` odkazují na stejnou konvenci.
- `CHANGELOG.md` aktualizován.

## Kontext issue
- https://github.com/pekral/cursor-rules/issues/152

## Zdroje
- https://github.com/pekral/cursor-rules/issues/152
- https://github.com/pekral/cursor-rules/blob/master/rules/laravel/architecture.mdc

## Test plan
- [x] `composer build`

## Návrhy testování změn
- Ověř sekci Schema defaults a Migrations: https://github.com/pekral/cursor-rules/blob/fix/issue-152-schema-defaults/rules/laravel/architecture.mdc (test v kódu: **no.**)
- Ověř skill create-test: https://github.com/pekral/cursor-rules/blob/fix/issue-152-schema-defaults/skills/create-test/SKILL.md (test v kódu: **no.**)