### PR TITLE
feat(skills): add seo-geo agent skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 📝 **Changed**: Laravel testing rules and test-writing skills require Eloquent rows in tests to be created only via model factories (#147)
 - 📝 **Changed**: Laravel rules and test-writing skills clarify database schema defaults as source of truth—avoid duplicating them in PHP/factories (#152)
 - 📝 **Changed**: Laravel testing rules and test-writing skills require queueing jobs in tests via `JobClass::dispatch()` only (#153)
+- ✨ **Added**: new Agent skill `seo-geo` for SEO and generative-engine optimization strategy (#164)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - unified PHP coding guidelines for PHP 8.4 projects
 - Pest-based testing with mandatory code analysis and 100% coverage
 - strong focus on clean code: typed properties, SRP, no redundant comments
-- **27 comprehensive Agent skills** for automated workflows (v0.5)
+- **28 comprehensive Agent skills** for automated workflows (v0.5)
 - fast onboarding inside development repositories
 
 ## Installation
@@ -116,6 +116,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `rewrite-tests-pest`     | Rewrites existing tests to PEST syntax following project conventions. Ensures DRY principles, uses data providers, maintains 100% coverage, and verifies test functionality. |
 | `package-review`         | Reviews composer.json packages by validating structure, checking required fields, verifying links, and ensuring proper configuration of autoloading, dependencies, and metadata. |
 | `seo-fix`                | Maintains and extends SEO setup (robots.txt, sitemap.xml, meta tags). Use when adding or changing public routes, disallow rules, sitemap entries, canonical/robots/OG tags, or when the user asks about SEO, sitemap, or robots. |
+| `seo-geo`                | SEO plus GEO (AI search citation optimization): audits, keywords, structured data strategy, content patterns, platform notes; pairs with `seo-fix` for Laravel implementation. |
 
 ---
 

--- a/skills/seo-fix/SKILL.md
+++ b/skills/seo-fix/SKILL.md
@@ -56,3 +56,6 @@ metadata:
 - Test added or updated so robots response contains that `Disallow`.
 - Area uses private (app/auth) layout with noindex,nofollow.
 - Area not included in sitemap.
+
+**Related**
+- For GEO (generative engines), AI-search citation strategy, keyword research, and JSON-LD/content patterns beyond robots/sitemap wiring, use @.cursor/skills/seo-geo/SKILL.md.

--- a/skills/seo-geo/SKILL.md
+++ b/skills/seo-geo/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: seo-geo
+description: "Use when improving SEO and GEO (Generative Engine Optimization): AI search visibility, keywords, JSON-LD, meta tags, content structure, robots/sitemap strategy, or when the user asks about ChatGPT/Perplexity/Gemini/Copilot/Claude citation or traditional Google/Bing ranking."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+**Constraint:**
+- Read project.mdc file
+- First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
+- I want the texts to be in the language in which the assignment was written.
+- All messages formatted as markdown for output.
+- Do not rely on bundled scripts or external example files; use project code, public URLs, and available tools (e.g. WebSearch, HTTP fetch) only.
+- For **implementing** `robots.txt`, `sitemap.xml`, route-level meta, canonical, and OG tags in a Laravel/PHP codebase, follow @.cursor/skills/seo-fix/SKILL.md. Use this skill for **strategy, audits, GEO content patterns, and schema design** that complements that implementation work.
+
+**Steps:**
+
+**Understand GEO**
+- **GEO (Generative Engine Optimization)** — optimizing so AI search systems **cite** your content; citation is the primary success signal, not classic blue-link rank alone.
+- Combine traditional SEO (crawl, index, snippets) with GEO (clear answers, citations, structured facts).
+
+**Audit (technical, no custom scripts)**
+- Obtain the target URL(s). Check HTML for `<title>`, `<meta name="description">`, Open Graph tags, and `application/ld+json` (e.g. via HTTP fetch or local template output).
+- Fetch `/robots.txt` and verify important user-agents are not blocked for public content: e.g. `Googlebot`, `Bingbot`, `Perplexity-User`, `ChatGPT-User`, `GPTBot`, `ClaudeBot` / `anthropic-ai`, as required by product policy.
+- Fetch `/sitemap.xml` (or app sitemap route) and confirm important public URLs appear under `<loc>`.
+- Note page speed and mobile usability from project context or public signals when relevant.
+
+**Keyword and competitor research**
+- Use WebSearch for difficulty, volume hints, and competitor pages (e.g. `site:competitor.com keyword`).
+- Capture long-tail variants and locale-specific ambiguity (same acronym, different industries).
+
+**GEO content methods (Princeton-style checklist)**
+- Prioritize: **authoritative citations**, **concrete statistics**, **attributed quotations**, confident expert tone, plain-language explanations, domain terminology where appropriate, varied vocabulary, strong readability (fluency). **Avoid keyword stuffing** (hurts visibility).
+- **Strong pair:** fluency + statistics.
+- Prefer **answer-first** layout: direct answer before detail; clear `H1` > `H2` > `H3`; lists and tables for comparisons; short paragraphs.
+
+**Structured data**
+- Recommend JSON-LD types that match the page: `WebPage` / `Article`, `FAQPage`, `Product`, `Organization`, `SoftwareApplication`, etc.
+- For FAQ-style GEO lift, suggest `FAQPage` with questions and answers that include citations or numbers where truthful.
+- Validate with Google Rich Results Test and Schema.org validator (share URLs; do not assume GUI automation).
+
+**Traditional on-page SEO**
+- Title: primary keyword, brand, secondary keyword where natural.
+- Meta description ~150–160 characters, compelling, aligned with query intent.
+- Align OG and Twitter Card tags with title/description and a 1200×630 image when available.
+- Checklist: primary keyword in `H1`; descriptive image `alt`; internal links; external links with `rel="noopener noreferrer"` when appropriate; public pages indexable; reasonable load time.
+
+**Platform-oriented notes (high level)**
+- **ChatGPT / OpenAI:** brand and freshness matter; backlinks and clear structure support citation.
+- **Perplexity:** allow Perplexity-related crawling per `robots.txt` policy; FAQ schema and semantically tight copy help; PDFs may be cited where applicable.
+- **Google (incl. AI Overviews):** E-E-A-T, structured data, topical clusters and internal links, citations where appropriate.
+- **Bing / Copilot:** Bing index coverage; fast pages; clear entity definitions.
+- **Claude (via search partners):** factual density and clear structure aid extraction.
+
+**Deliverable**
+- Produce a concise markdown report: current status (meta, schema, robots, sitemap, AI bot access), prioritized recommendations, GEO tactics applied or proposed, and validation links/tests to run in the project.
+
+**After completing the tasks**
+- If code changes to robots, sitemap, or layouts are required, hand off implementation steps to @.cursor/skills/seo-fix/SKILL.md and keep tests green.
+- Summarize what was audited, what to change first, and what to validate after deploy.


### PR DESCRIPTION
## Odkaz na issue

https://github.com/pekral/cursor-rules/issues/164

## Shrnutí

Přidán nový Agent skill `seo-geo` podle konceptu upstreamu ReScienceLab (SEO + GEO pro AI vyhledávání), ve stejném stylu jako `seo-fix`, bez odkazů na skripty, references a examples z upstream balíčku. Aktualizován README (počet skillů, řádek v tabulce), CHANGELOG a v `seo-fix` odkaz na `seo-geo` pro strategii GEO vs. implementaci robots/sitemap v Laravelu.

## Zdroje použité při analýze

- https://github.com/ReScienceLab/opc-skills/tree/main/skills/seo-geo (upstream `SKILL.md` a struktura skillu)
- Lokální vzor: `skills/seo-fix/SKILL.md`

## Jak otestovat

- Spusť `composer build` — musí projít včetně skill-check a testů.
- Ověř v repozitáři obsah `skills/seo-geo/SKILL.md` (frontmatter, kroky, absence odkazů na scripts/examples).
- Po merge: v cílovém projektu spusť instalátor cursor-rules a zkontroluj, že se skill zkopíruje do cílové složky skillů.

## Testy v PR

- Ano — `composer build` spouští existující PHPUnit testy s pokrytím; žádné nové testy pro markdown nejsou vyžadovány skill-checkem.

Made with [Cursor](https://cursor.com)