### PR TITLE
fix(skills): merge PR when GitHub CI blocked by billing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 📝 **Changed**: Laravel rules and test-writing skills clarify database schema defaults as source of truth—avoid duplicating them in PHP/factories (#152)
 - 📝 **Changed**: Laravel testing rules and test-writing skills require queueing jobs in tests via `JobClass::dispatch()` only (#153)
 - ✨ **Added**: new Agent skill `seo-geo` for SEO and generative-engine optimization strategy (#164)
+- 📝 **Changed**: `merge-github-pr` and `merge-github-prs` document GitHub billing/spending-limit CI skip — merge may proceed only in that specific case if review and mergeability still pass (#154)

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `resolve-random-jira-issue` | Resolves random JIRA issues: fix bugs, refactor, code and security review, 100% test coverage, CI checks, create PRs. Links PRs to JIRA and updates issue status. |
 | `resolve-github-issue`   | Resolves GitHub issues by fixing bugs, refactoring code, performing code and security reviews, ensuring 100% test coverage, running CI checks, and creating pull requests. Updates GitHub issues with review results. |
 | `resolve-bugsnag-issue`  | Resolve Bugsnag issues by fixing bugs, refactoring code, performing code and security reviews, ensuring 100% test coverage, running CI checks, and creating pull requests. Updates GitHub issues with review results. |
-| `merge-github-pr`        | Merge PRs when they are ready for deployment, one by one. |
-| `merge-github-prs`       | Merge multiple PRs in sequence only when CI is successful and there are no merge conflicts. |
+| `merge-github-pr`        | Merge PRs when they are ready for deployment, one by one; allows merge when GitHub Actions did not start jobs solely due to billing/spending limits (see skill). |
+| `merge-github-prs`       | Merge multiple PRs in sequence when checks pass and there are no conflicts; same billing CI exception as `merge-github-pr`. |
 | `analyze-problem`        | Analyze problems from issue trackers. Downloads and reviews attachments, provides technical analysis and solutions, and creates human-readable explanations for both technical and non-technical audiences. |
 
 ## Code Review & Quality

--- a/skills/merge-github-pr/SKILL.md
+++ b/skills/merge-github-pr/SKILL.md
@@ -16,5 +16,9 @@ metadata:
 - For each candidate PR, load all review comments and requested changes from code review (including unresolved/outdated discussion threads) and create a checklist of required fixes.
 - Verify that every checklist item from code review is fully resolved in the current PR diff.
 - If at least one code review item is not resolved, DO NOT merge the PR. Instead, report unresolved items and stop processing that PR.
-- Only when all code review checklist items are resolved and CI is green, continue with merge preparation.
-- Go through all PRs that have successfully completed the attached CI actions and systematically merge the changes into the main branch.
+- **CI / required checks:** Use `gh pr checks <PR>` (and, if needed, workflow run logs or the GitHub UI/API) to see whether required checks completed successfully.
+- **Billing / spending-limit exception (only this case):** If GitHub Actions did **not** start jobs and the reported reason matches (or clearly paraphrases) the platform message below, treat CI as **blocked by account billing**, not as a failed quality gate — you **may** continue with merge preparation **only if** the review checklist above is fully satisfied, the PR is mergeable, and there are no conflicts. Quote the detected billing wording in your summary so the decision is auditable.
+  - Canonical wording to match (substring match is enough): `The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings`
+- **Any other non-green CI** (failed tests, linters, real workflow errors, pending checks that are not explained by the billing message above): DO NOT merge. Report failing check names and conclusions and stop processing that PR.
+- When the review checklist is satisfied and either all required checks pass **or** the billing exception applies, continue with merge preparation and merge into the default branch.
+- Go through all PRs that are eligible under the rules above and systematically merge the changes into the main branch.

--- a/skills/merge-github-prs/SKILL.md
+++ b/skills/merge-github-prs/SKILL.md
@@ -12,13 +12,13 @@ metadata:
 - I want the texts to be in the language in which the assignment was written.
 - Never push direct changes to main branch! NEVER!
 - Merge only pull requests without merge conflicts.
-- Merge only pull requests with successful required checks.
+- Merge only pull requests with successful required checks, **except** the GitHub billing/spending-limit case defined in @.cursor/skills/merge-github-pr/SKILL.md (jobs not started due to payments or spending limit — then merge is allowed only when that skill’s other gates pass).
 
 **Steps:**
 - Load all open pull requests from the target repository.
 - For each pull request, evaluate:
 - whether it can be merged cleanly (no conflicts),
-- whether required checks are successful,
+- whether required checks are successful (including the billing exception from `merge-github-pr`),
 - whether the pull request is not in draft state.
 - If a pull request fails any of these conditions, skip it and record the reason.
 - For every pull request that passes all checks, apply the merge workflow from @.cursor/skills/merge-github-pr/SKILL.md.
@@ -31,5 +31,5 @@ metadata:
 - any blockers that need manual intervention.
 
 **After completing the tasks**
-- Ensure no pull request was merged with conflicts or failing checks.
+- Ensure no pull request was merged with conflicts or with failing checks **other than** the documented billing/spending-limit CI skip.
 - Summarize final merge results for fast release handoff.


### PR DESCRIPTION
## Odkaz na issue

https://github.com/pekral/cursor-rules/issues/154

## Shrnutí

Skill `merge-github-pr` nyní rozlišuje situaci, kdy GitHub Actions **vůbec nespustí joby** kvůli nezaplacenému účtu nebo limitu výdajů (kanonická anglická hláška z GitHubu je v skillu uvedena pro substring match). V tom **jednom** případě je možné pokračovat v přípravě mergi **jen pokud** je vyřešen code review checklist, PR je mergeable a bez konfliktů. Jakákoli jiná nezelená CI (testy, lintery, reálné chyby workflow) merg stále blokuje.

Skill `merge-github-prs` je s tím srovnán (výjimka + závěrečná kontrola). README a CHANGELOG doplněny.

## Zdroje

- https://github.com/pekral/cursor-rules/issues/154

## Jak otestovat

- Spusť `composer build` (projde skill-check a testy).
- Přečti `skills/merge-github-pr/SKILL.md` a ověř logiku billing vs. ostatní CI.

## Testy v PR

- Ano — existující PHPUnit + skill-check v rámci `composer build`. Žádné nové testy pro markdown.

Made with [Cursor](https://cursor.com)