### PR TITLE
fix(skills): enforce automatic PR creation for resolve workflows

### DIFF
--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
+- Pull request creation is mandatory for every resolved Bugsnag issue. After checks pass, automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
 
 **Steps:**
 - Analyze all comments in the issue tracker and check what needs to be done accordingly. Stick strictly to the assignment and comments!
@@ -27,7 +28,7 @@ metadata:
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK create a pull request, create it according to the pr.mdc rules.
+- If everything is OK, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -11,6 +11,7 @@ metadata:
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - I want the texts to be in the language in which the assignment was written.
 - If you are not on the main git branch in the project, switch to it.
+- Pull request creation is mandatory for every resolved GitHub issue. After checks pass, automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
 
 **Steps:**
 - Read project.mdc file
@@ -31,7 +32,7 @@ metadata:
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK create a pull request, create it according to the pr.mdc rules.
+- If everything is OK, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.
+- Pull request creation is mandatory for every resolved JIRA issue. After checks pass, automatically push the branch and create a GitHub PR, then link it back to the JIRA issue. Do not finish without a PR URL.
 
 **Universal JIRA Comment Formatting**
 - Use this structure for every JIRA comment type (status update, testing recommendation, CR summary, implementation summary):
@@ -75,7 +76,7 @@ h4. Testing recommendations
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK, create a pull request according to the pr.mdc rules.
+- If everything is OK, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment on the core revision on GitHub, but I want you to post only critical or medium-severity issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue as ready for review.
 - After completing all tasks for GitHub, link the created PR in the JIRA issue, change the status of the JIRA issue to ready for review.

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -13,8 +13,10 @@ metadata:
 - I want the texts to be in the language in which the assignment was written.
 - If you are not on the main git branch in the project, switch to it.
 - For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown) and follow the universal structure from JIRA-focused skills.
+- Pull request creation is mandatory for every resolved JIRA issue selected by this skill. Do not finish without a GitHub PR URL linked to the selected JIRA issue.
 
 **Steps:**
 - Log into JIRA and load all issues using the acli console tool first. If acli is not available, use the JIRA MCP server if available. If neither is available, stop and display a message stating that at least one of these tools must be installed to use the skill.
   List only those issues that are to be resolved by AI (they are tagged). Look for tasks labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only not resolved issues should be listed!
 - Randomly select one and try to resolve it. Use the skill @.cursor/skills/resolve-jira-issue/SKILL.md.
+- Completion is valid only when the delegated flow creates a GitHub PR and links it in the selected JIRA issue.


### PR DESCRIPTION
## Shrnutí
- Zpřesnil jsem všechny `resolve-*` skilly tak, aby bylo vytvoření PR povinný krok po úspěšném dokončení změn.
- U `resolve-jira-issue` a `resolve-random-jira-issue` je nyní explicitně vyžadováno i propojení vytvořeného GitHub PR zpět do JIRA issue.
- Upravena je i delegovaná random JIRA flow, kde je dokončení validní pouze s existujícím PR URL.

Closes #186

## Zdroje
- [Issue #186](https://github.com/pekral/cursor-rules/issues/186)

## Doporučení k testování
- [ ] Otevři každý skill `resolve-*` a ověř, že obsahuje explicitní povinnost automaticky vytvořit PR.
- [ ] Ověř, že `resolve-jira-issue` navíc vyžaduje zpětné propojení PR do JIRA issue.
- [ ] Ověř, že `resolve-random-jira-issue` nepovažuje úkol za dokončený bez PR URL.

## Testy v repozitáři
- no.

Made with [Cursor](https://cursor.com)