### PR TITLE
fix(skills): prefer gh cli in github workflows

### DIFF
--- a/.claude/skills/resolve-bugsnag-issue/SKILL.md
+++ b/.claude/skills/resolve-bugsnag-issue/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Always apply @.cursor/skills/smartest-project-addition/SKILL.md internally to identify one highest-impact, low-risk addition candidate; include it only if it maps to a real finding and keep the final output in the required findings-only format.
@@ -36,7 +39,7 @@ metadata:
 - **Data Validator pattern (only when `vendor/pekral/arch-app-services` exists):** If an Action throws `ValidationException` directly or calls `Validator::make()` inline, flag it as **Critical**. Validation must be delegated to a Data Validator class in `app/DataValidators/{Domain}/`.
 - **BaseModelService pattern (only when `vendor/pekral/arch-app-services` exists):** All services that primarily work with a specific Eloquent Model must extend `BaseModelService` and implement `getModelManager()`, `getRepository()`, and `getModelClass()`. If a service works with a model but does not extend `BaseModelService`, flag it as **Critical**. If a service does not primarily serve a single model but exists as a plain service class, flag it as **Moderate** and recommend refactoring to an Action pattern class.
 - Find the Git branch and switch to it.
-- If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR. Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
+- If possible, find links to the assignment and analyze it so you can do a quality CR. For GitHub sources, use GitHub CLI (`gh`) first; if `gh` is not available, use a GitHub MCP server; if neither is available, stop and return a failed result about missing GitHub tools.
 - List findings using exactly three severity levels: **Critical**, **Moderate**, **Minor**.
 - If there are any findings, add comments to the PR about where you found these errors. If that is not possible, create a new comment on the PR with the list of findings. If you do not find any issues, post a short comment stating that **no findings were identified**. Every text in English.
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. The PR comment must contain **only findings** grouped by severity (Critical → Moderate → Minor), each with file/line (or file) and a short, actionable recommendation. Do not include any summary, “what was checked”, or praise.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Always apply @.cursor/skills/smartest-project-addition/SKILL.md internally to identify one highest-impact, low-risk addition candidate; include it only if it maps to a real finding and keep the final output in the required findings-only format.

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -11,6 +11,9 @@ metadata:
 ---
 
 **Constraint:**
+-   For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+-   If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+-   If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 -   Read project.mdc file
 -   First, load all the rules for the cursor editor
     (.cursor/rules/.\*mdc).
@@ -29,8 +32,9 @@ metadata:
 
 **Steps:**
 
--   Load the current pull request context using available CLI tools or
-    MCP servers.
+-   Load the current pull request context using GitHub CLI (`gh`) first.
+    If `gh` is not available, use a GitHub MCP server. If neither is
+    available, stop and return a failed result about missing GitHub tools.
 -   Read your existing code review for the pull request.
 -   Extract all recommendations related to missing tests, missing
     scenarios, edge cases, regression coverage, and coverage gaps.

--- a/skills/merge-github-pr/SKILL.md
+++ b/skills/merge-github-pr/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all rules for the cursor editor (.cursor/rules/.*mdc).
 - I want the texts to be in the language in which the assignment was written.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - I want the texts to be in the language in which the assignment was written.
@@ -16,7 +19,7 @@ metadata:
 
 **Steps:**
 - Identify the task from the provided issue code or URL.
-- Find the latest pull request for that task using available CLI tools or MCP servers.
+- Find the latest pull request for that task using GitHub CLI (`gh`) first; if `gh` is not available, use a GitHub MCP server; if neither is available, stop and return a failed result about missing GitHub tools.
 - In the pull request, locate code review output and all review comments (including review threads and general comments).
 - If there is only a generic `CR` comment, treat it as `code review` feedback.
 - Build a checklist from all review findings and map each item to a concrete code or test change.

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -8,6 +8,9 @@ metadata:
 
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - I want the texts to be in the language in which the assignment was written.
 - If you are not on the main git branch in the project, switch to it.
@@ -16,7 +19,7 @@ metadata:
 **Steps:**
 - Read project.mdc file
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
-- I want you to fix the bug from Github (you either got an ID or a link to Github). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
+- I want you to fix the bug from Github (you either got an ID or a link to Github). Use GitHub CLI (`gh`) first to get all the necessary information about the bug so you can fix it. If `gh` is not available, use a GitHub MCP server. If neither is available, stop and return a failed result explaining missing GitHub tools.
 - Classify the task type before writing any code:
   - **Bug**: the issue describes existing functionality that behaves incorrectly (e.g. wrong output, exception, regression, data corruption). Labels such as `bug`, `fix`, or `regression` are strong signals.
   - **Feature**: the issue requests new behaviour that does not exist yet.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want the texts to be in the language in which the assignment was written.

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -7,6 +7,9 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -12,6 +12,9 @@ metadata:
 
 **Constraint:**
 
+-   For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+-   If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+-   If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 -   Read project.mdc file!
 -   First load all cursor editor rules (.cursor/rules/.\*mdc).
 -   I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
@@ -31,7 +34,9 @@ metadata:
 
 **Steps:**
 
-1.  Load the current pull request using CLI tools or MCP servers.
+1.  Load the current pull request using GitHub CLI (`gh`) first. If
+    `gh` is not available, use a GitHub MCP server. If neither is
+    available, stop and return a failed result about missing GitHub tools.
 2.  Read the PR conversation: PR description, review comments, and discussion threads.
 3.  Locate the **"Doporučení k testování" / "Testing Recommendations"** section and extract all testing instructions.
 4.  If at least one extracted instruction requires API testing, first try to load the project's API documentation:


### PR DESCRIPTION
## Summary
- Standardized GitHub-related skills to prefer `gh` CLI for GitHub operations.
- Added explicit fallback flow to GitHub MCP and a required failure message when neither `gh` nor GitHub MCP is available.
- Updated wording in key workflow steps to remove `gh`/MCP priority ambiguity.

## Sources used
- [Issue #184](https://github.com/pekral/cursor-rules/issues/184)

## Test plan
- [x] Verified all updated skill files contain `gh`-first guidance for GitHub operations.
- [x] Verified fallback path is documented (`gh` -> GitHub MCP -> fail).
- [x] Confirmed changed files are documentation-only (`SKILL.md`) and no runtime code was modified.
- Automated tests added for this change: no.

Made with [Cursor](https://cursor.com)