### PR TITLE
fix(skills): require pre-PR CR loop in resolve workflows

### DIFF
--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -28,7 +28,11 @@ metadata:
 - If review feedback requires additional tests, use @.cursor/skills/create-missing-tests-in-pr/SKILL.md and ensure current changes are fully covered.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - Run only checks/tests needed for the changed files and fix all errors before continuing.
-- Commit all changes and push the branch. If no pull request exists for the current branch, create one according to @.cursor/rules/git/pr.mdc rules — link it to the original issue and follow the PR description format (title in English, body in the language of the assignment).
+- Run the issue-tracker-specific code review skill before PR creation:
+  - GitHub issue flow: run @.cursor/skills/code-review-github/SKILL.md
+  - JIRA issue flow: run @.cursor/skills/code-review-jira/SKILL.md
+- Fix all Critical and Moderate findings from that review and repeat the same review skill until no Critical or Moderate findings remain.
+- Commit all changes and push the branch. If no pull request exists for the current branch, create one according to @.cursor/rules/git/pr.mdc rules — link it to the original issue and follow the PR description format (title in English, body in the language of the assignment). Do not create a new PR before the CR cycle is clean.
 - Update the review result comment in the pull request:
 - mark resolved points as checked items when possible, or
 - format resolved points as underlined text when checkbox updates are not possible.

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -31,16 +31,19 @@ metadata:
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
+- Before creating a PR, run @.cursor/skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
+- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @.cursor/skills/code-review-github/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After generating or modifying tests, verify that all new tests comply with the testing rules in `@.cursor/rules/php/standards.mdc`. Check mock usage specifically: mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
-- After creating the PR, perform a code review @.cursor/skills/code-review/SKILL.md for the current task.
+- After creating the PR, perform a final validation pass with @.cursor/skills/code-review-github/SKILL.md for the current task.
 - If you are not on the main git branch in the project, switch to it.
 
 **After completing the tasks**
 - Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @.cursor/skills/code-review/SKILL.md
 - If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
-- If work is done do @.cursor/skills/code-review/SKILL.md for actual issue
+- If the work is done, run @.cursor/skills/code-review-github/SKILL.md for the current issue.

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -35,16 +35,19 @@ metadata:
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
+- Before creating a PR, run @.cursor/skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
+- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @.cursor/skills/code-review-github/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After generating or modifying tests, verify that all new tests comply with the testing rules in `@.cursor/rules/php/standards.mdc`. Check mock usage specifically: mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
-- After creating the PR, perform a code review @.cursor/skills/code-review-github/SKILL.md for the current task.
+- After creating the PR, perform a final validation pass with @.cursor/skills/code-review-github/SKILL.md for the current task.
 - If you are not on the main git branch in the project, switch to it.
 
 **After completing the tasks**
 - Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @.cursor/skills/code-review-github/SKILL.md
 - If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
-- If work id done do @.cursor/skills/code-review-github/SKILL.md for actual issue
+- If the work is done, run @.cursor/skills/code-review-github/SKILL.md for the current issue.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -79,7 +79,10 @@ h4. Testing recommendations
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
+- Before creating a PR, run @.cursor/skills/code-review-jira/SKILL.md for the current changes and treat it as mandatory CR for JIRA flow.
+- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @.cursor/skills/code-review-jira/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment on the core revision on GitHub, but I want you to post only critical or medium-severity issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue as ready for review.
 - After completing all tasks for GitHub, link the created PR in the JIRA issue, change the status of the JIRA issue to ready for review.
@@ -87,8 +90,9 @@ h4. Testing recommendations
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After generating or modifying tests, verify that all new tests comply with the testing rules in `@.cursor/rules/php/standards.mdc`. Check mock usage specifically: mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
+- After creating the PR, run one final validation pass with @.cursor/skills/code-review-jira/SKILL.md to confirm no new Critical or Moderate findings were introduced.
 
 - **After completing the tasks**
 - Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @.cursor/skills/code-review-jira/SKILL.md
 - If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
-- If work id done do @.cursor/skills/code-review-jira/SKILL.md for actual issue
+- If the work is done, run @.cursor/skills/code-review-jira/SKILL.md for the current issue.


### PR DESCRIPTION
## Summary
- enforce a mandatory tracker-specific code review pass before PR creation in resolve workflows
- require iterative fix-and-review cycles until no Critical or Moderate findings remain
- align process-code-review workflow with the same pre-PR CR gate and clean-cycle requirement

## Sources
- [Issue #192](https://github.com/pekral/cursor-rules/issues/192)

## Test plan
- [x] verify updated instructions in `skills/resolve-github-issue/SKILL.md`
- [x] verify updated instructions in `skills/resolve-jira-issue/SKILL.md`
- [x] verify updated instructions in `skills/resolve-bugsnag-issue/SKILL.md`
- [x] verify updated instructions in `skills/process-code-review/SKILL.md`
- [ ] automated tests added for this change: no.

Made with [Cursor](https://cursor.com)