### PR TITLE
fix(gitignore): refresh ignored editor directories

### DIFF
--- a/.cursor/skills/resolve-bugsnag-issue/SKILL.md
+++ b/.cursor/skills/resolve-bugsnag-issue/SKILL.md
@@ -7,12 +7,16 @@ metadata:
 ---
 
 **Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 - Read project.mdc file
 - First, load all the rules for the cursor editor (.cursor/rules/.*mdc).
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
+- Pull request creation is mandatory for every resolved Bugsnag issue. After checks pass, automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
 
 **Steps:**
 - Analyze all comments in the issue tracker and check what needs to be done accordingly. Stick strictly to the assignment and comments!
@@ -27,19 +31,22 @@ metadata:
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
-- If everything is OK create a pull request, create it according to the pr.mdc rules.
+- Before creating a PR, run @.cursor/skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
+- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @.cursor/skills/code-review-github/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - Write missing tests for current changes and ensure 100% coverage, fix dry and try to simplify the code base so that it is easy to read for humans, but also as simple as possible. These changes will be in a separate commit.
 - After generating or modifying tests, verify that all new tests comply with the testing rules in `@.cursor/rules/php/standards.mdc`. Check mock usage specifically: mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
-- After creating the PR, perform a code review @.cursor/skills/code-review/SKILL.md for the current task.
+- After creating the PR, perform a final validation pass with @.cursor/skills/code-review-github/SKILL.md for the current task.
 - If you are not on the main git branch in the project, switch to it.
 
 **After completing the tasks**
 - Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @.cursor/skills/code-review/SKILL.md
 - If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
-- If work is done do @.cursor/skills/code-review/SKILL.md for actual issue
+- If the work is done, run @.cursor/skills/code-review-github/SKILL.md for the current issue.
 
 ## Output Humanization
 - Use [blader/humanizer](https://github.com/blader/humanizer) for all skill outputs to keep the text natural and human-friendly.

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,9 @@ Thumbs.db
 /tests/output/
 
 
-.cursor/*
-.codex/*
-.claude/*
+/.cursor/
+/.codex/
+/.claude/
 composer.lock
 
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -40,6 +40,13 @@ test('package directory points to correct location', function (): void {
     expect(is_dir($securityRulesDir))->toBeTrue();
 });
 
+test('gitignore ignores local cursor and claude directories', function (): void {
+    $gitignore = file_get_contents(__DIR__ . '/../.gitignore');
+
+    expect($gitignore)->toContain('/.cursor/');
+    expect($gitignore)->toContain('/.claude/');
+});
+
 test('resolveRulesSource prefers development directory', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/rules/test.mdc', 'content');


### PR DESCRIPTION
## Summary
- refresh `.gitignore` to ignore editor metadata directories via explicit root directory rules (`/.cursor/`, `/.claude/`, `/.codex/`)
- add a regression test in `tests/InstallerTest.php` that verifies `.gitignore` contains the required ignore rules
- include synchronized `resolve-bugsnag-issue` skill updates produced by the build workflow

## Test plan
- [x] `vendor/bin/pest tests/InstallerTest.php --filter=\"gitignore ignores local cursor and claude directories\"` (fails before fix, passes after fix)
- [x] `composer build`
- [x] New/updated test coverage for this change: yes

## Sources
- Issue: https://github.com/pekral/cursor-rules/issues/191

Made with [Cursor](https://cursor.com)