### PR TITLE
fix(skills): run test-like-human after CR findings are resolved

### DIFF
--- a/.cursor/skills/code-review/SKILL.md
+++ b/.cursor/skills/code-review/SKILL.md
@@ -123,7 +123,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Findings are recommendations; final decisions remain with the human reviewer.
 
 **After completing the tasks**
-- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, then (and only then) run @.cursor/skills/test-like-human/SKILL.md when the changes can be tested.
 
 ## Output Humanization
 - Use [blader/humanizer](https://github.com/blader/humanizer) for all skill outputs to keep the text natural and human-friendly.

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -46,6 +46,7 @@ metadata:
 - Use readable Markdown with clear section separators and include short code suggestions for simple fixes when helpful.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - If needed, use browser-based testing via available browser MCP tools
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, run @.cursor/skills/test-like-human/SKILL.md before closing the review flow (when the changes are testable).
 
 **Communication protocol:**
 - Do not include praise/positive feedback; output must contain only findings.
@@ -54,5 +55,5 @@ metadata:
 - For implementation problems, provide clear guidance on fixes needed with code examples.
 
 **After completing the tasks**
-- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
+- Keep @.cursor/skills/test-like-human/SKILL.md as a required final step only after **Critical** and **Moderate** findings are resolved and the changes are testable.
 - Based on the discussion in the assignment, is the proposed solution to the problems safe and effective? Analyze the assignment and all discussions related to this task and write me your conclusion!

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -58,6 +58,7 @@ metadata:
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. The PR comment must contain **only findings** grouped by severity (Critical → Moderate → Minor), each with file/line (or file) and a short, actionable recommendation. Do not include any summary, “what was checked”, or praise.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - If needed, use browser-based testing via available browser MCP tools
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, run @.cursor/skills/test-like-human/SKILL.md before closing the review flow (when the changes are testable).
 
 **Communication protocol:**
 - Do not include praise/positive feedback; output must contain only findings.
@@ -66,5 +67,5 @@ metadata:
 - For implementation problems, provide clear guidance on fixes needed with code examples.
 
 **After completing the tasks**
-- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
+- Keep @.cursor/skills/test-like-human/SKILL.md as a required final step only after **Critical** and **Moderate** findings are resolved and the changes are testable.
 - Based on the discussion in the assignment, is the proposed solution to the problems safe and effective? Analyze the assignment and all discussions related to this task and write me your conclusion!

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -123,4 +123,4 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Findings are recommendations; final decisions remain with the human reviewer.
 
 **After completing the tasks**
-- If according to @.cursor/skills/test-like-human/SKILL.md the changes can be tested, do it!
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, then (and only then) run @.cursor/skills/test-like-human/SKILL.md when the changes can be tested.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -32,6 +32,7 @@ metadata:
   - GitHub issue flow: run @.cursor/skills/code-review-github/SKILL.md
   - JIRA issue flow: run @.cursor/skills/code-review-jira/SKILL.md
 - Fix all Critical and Moderate findings from that review and repeat the same review skill until no Critical or Moderate findings remain.
+- After the CR loop is clean (no **Critical** or **Moderate** findings), run @.cursor/skills/test-like-human/SKILL.md when the change can be tested.
 - Commit all changes and push the branch. If no pull request exists for the current branch, create one according to @.cursor/rules/git/pr.mdc rules — link it to the original issue and follow the PR description format (title in English, body in the language of the assignment). Do not create a new PR before the CR cycle is clean.
 - Update the review result comment in the pull request:
 - mark resolved points as checked items when possible, or


### PR DESCRIPTION
## Summary
- make CR skills explicitly require `test-like-human` only after the CR loop is clean (no Critical/Moderate findings)
- apply the same rule consistently across `code-review`, `code-review-github`, `code-review-jira`, and `process-code-review`
- keep existing behavior intact while clarifying execution order in skill steps

## Linked issue
- Closes #198

## Sources used for analysis
- [Issue #198](https://github.com/pekral/cursor-rules/issues/198)
- [skills/code-review/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/code-review/SKILL.md)
- [skills/code-review-github/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/code-review-github/SKILL.md)
- [skills/code-review-jira/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/code-review-jira/SKILL.md)
- [skills/process-code-review/SKILL.md](https://github.com/pekral/cursor-rules/blob/master/skills/process-code-review/SKILL.md)

## Testing recommendations
- [ ] Run `composer build` and confirm all checks pass (automated test for this recommendation: yes)
- [ ] Validate each updated skill contains explicit ordering: resolve Critical/Moderate findings first, then run `test-like-human` (automated test for this recommendation: no)


Made with [Cursor](https://cursor.com)