### PR TITLE
fix(skills): enforce DRY reporting in code review skills

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -17,6 +17,7 @@ metadata:
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 - All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - Always load existing CR reports/comments in the PR and related issue before generating a new CR report, and never repeat a previously reported finding.
+- Explicitly detect and report **DRY violations** (duplicated logic, duplicated validation rules, repeated branching/condition blocks, and copy-pasted code paths) in every CR result.
 - **Before starting the review**, analyze all comments and discussions in the issue so that you fully understand what the final state should be and what logic should have been created. Only then begin reviewing.
 - NEVER CHANGE THE CODE! Generate the output only.
 - All messages formatted as markdown for output.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -16,6 +16,7 @@ metadata:
 - Switch to the main branch and make sure you have the updated main branch. Then switch to the branch where the PR is and, to be on the safe side, update the branch for the PR as well, then continue with the code review.
 - I want the texts to be in the language in which the task was assigned. Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 - All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
+- Explicitly detect and report **DRY violations** (duplicated logic, duplicated validation rules, repeated branching/condition blocks, and copy-pasted code paths) in every CR result.
 - Always load existing CR reports/comments in the PR and related tracker discussion before generating a new CR report, and never repeat a previously reported finding.
 - **Before starting the review**, analyze all comments and discussions in the issue so that you fully understand what the final state should be and what logic should have been created. Only then begin reviewing.
 - NEVER CHANGE THE CODE! Generate the output only.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -99,6 +99,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Unnecessary complexity; large functions; repeated logic; oversized classes; mixed responsibilities.
 - Recommend: simplify structure, improve cohesion, split large units.
 - Rank issues by impact (highest technical debt first) when listing findings.
+- Explicitly detect and report **DRY violations** (duplicated logic, duplicated validation rules, repeated branching/condition blocks, and copy-pasted code paths) as findings with actionable refactoring recommendations.
 - Issues static analysis may not fully trace: business-logic flaws, missing authorization checks, data flow to sensitive sinks.
 - Coverage for changed files only (target 100% for changes). Run tests only for changed files.
 - New code is tested: arrange-act-assert; error cases first; descriptive names; data providers via argument; mock only external services.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -23,6 +23,7 @@ metadata:
 - In the pull request, locate code review output and all review comments (including review threads and general comments).
 - If there is only a generic `CR` comment, treat it as `code review` feedback.
 - Build a checklist from all review findings and map each item to a concrete code or test change.
+- Ensure the checklist explicitly contains all reported **DRY violations** and tracks their resolution before triggering the next CR cycle.
 - Apply the requested changes and keep scope limited to review feedback. All new or modified production code must follow @.cursor/skills/class-refactoring/SKILL.md.
 - Re-check current changes with @.cursor/skills/code-review/SKILL.md and @.cursor/skills/security-review/SKILL.md.  
 - If review feedback requires additional tests, use @.cursor/skills/create-missing-tests-in-pr/SKILL.md and ensure current changes are fully covered.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1057,6 +1057,22 @@ test('race-condition-review skill is referenced only by code review skills', fun
     }
 });
 
+test('dry review rule is referenced by all code review flow skills', function (): void {
+    $packageDir = dirname(__DIR__);
+    $requiredPhrase = 'DRY violations';
+    $expectedFiles = [
+        $packageDir . '/skills/code-review/SKILL.md',
+        $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/code-review-jira/SKILL.md',
+        $packageDir . '/skills/process-code-review/SKILL.md',
+    ];
+
+    foreach ($expectedFiles as $expectedFile) {
+        $content = file_get_contents($expectedFile);
+        expect($content)->toContain($requiredPhrase);
+    }
+});
+
 test('install with prune on non-existent target directory does nothing', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/skills/some-skill/SKILL.md', 'content');


### PR DESCRIPTION
## Shrnutí
- Doplnil jsem explicitní požadavek na reportování **DRY violations** do všech CR flow skillů: `skills/code-review/SKILL.md`, `skills/code-review-github/SKILL.md`, `skills/code-review-jira/SKILL.md` a `skills/process-code-review/SKILL.md`.
- Přidal jsem regresní test `dry review rule is referenced by all code review flow skills`, který hlídá, že se požadavek na DRY reportování z těchto skillů už neztratí.
- PR uzavírá issue `#197`.

## Test plan
- [x] `vendor/bin/pest tests/InstallerTest.php --filter "dry review rule is referenced by all code review flow skills"`
- [x] `vendor/bin/pest tests/InstallerTest.php --filter "(dry review rule is referenced by all code review flow skills|race-condition-review skill is referenced only by code review skills)"`
- [x] `npx skill-check check skills --no-security-scan`

## Testing recommendations
- Otevři [skills/code-review/SKILL.md](https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/code-review/SKILL.md) a ověř, že je v instrukcích explicitně uvedeno reportování DRY violations.
- Otevři [skills/code-review-github/SKILL.md](https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/code-review-github/SKILL.md) a ověř stejný požadavek.
- Otevři [skills/code-review-jira/SKILL.md](https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/code-review-jira/SKILL.md) a ověř stejný požadavek.
- Otevři [skills/process-code-review/SKILL.md](https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/process-code-review/SKILL.md) a ověř, že checklist explicitně vyžaduje řešení DRY violations.

## Zdroje
- Zadání issue: https://github.com/pekral/cursor-rules/issues/197
- Upravený skill flow:
  - https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/code-review/SKILL.md
  - https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/code-review-github/SKILL.md
  - https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/code-review-jira/SKILL.md
  - https://github.com/pekral/cursor-rules/blob/feat/issue-197-dry-detect-cr-skills/skills/process-code-review/SKILL.md

Made with [Cursor](https://cursor.com)