### PR TITLE
fix: Faster Livewire component testing guidance

### DIFF
--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -29,6 +29,7 @@ metadata:
 - If the test requires persisted Laravel Eloquent rows, create them only via `Model::factory()` (see `@.cursor/rules/laravel/architecture.mdc` Testing). For other test data, follow `@.cursor/rules/php/standards.mdc`. Never mock it or circumvent this in any other way!
 - In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@.cursor/rules/laravel/architecture.mdc` Schema defaults and Testing).
 - In Laravel tests, dispatch queue jobs only via `JobClass::dispatch(...)` (see `@.cursor/rules/laravel/architecture.mdc` Testing — Dispatching jobs in tests).
+- In Livewire component tests, prefer explicit `set()` calls for form state updates over `fill()`. `fill()` can trigger multiple Livewire round-trips (one per field) and significantly slow down tests.
 - Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Use data providers when they simplify writing and readability.
 - Analyze the created tests and all tests that are similar and can be simplified using data providers, then modify them.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -38,6 +38,7 @@ Write one minimal test showing expected behavior.
 - If the test requires persisted Laravel Eloquent rows, create them only via `Model::factory()` (see `@.cursor/rules/laravel/architecture.mdc` Testing). For other test data, follow `@.cursor/rules/php/standards.mdc`. Never mock it or circumvent this in any other way!
 - In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@.cursor/rules/laravel/architecture.mdc` Schema defaults and Testing).
 - In Laravel tests, dispatch queue jobs only via `JobClass::dispatch(...)` (see `@.cursor/rules/laravel/architecture.mdc` Testing — Dispatching jobs in tests).
+- In Livewire component tests, prefer `set()` for form state updates instead of `fill()` to avoid one round-trip per field and keep the suite fast.
 - Tests must not contain conditions (e.g., `if`, `switch`); split conditional logic into separate test cases instead.
 - Use data providers when they simplify writing and readability.
 - Never generate the `covers()` method.


### PR DESCRIPTION
## Summary
- Update `skills/create-test/SKILL.md` with an explicit rule to prefer `set()` over `fill()` in Livewire component tests to reduce test round-trips.
- Mirror the same optimization guidance in `skills/test-driven-development/SKILL.md` so TDD flow uses the same fast pattern.
- Keep the change documentation-only and aligned with the issue request and referenced article.

## Sources
- Issue: https://github.com/pekral/cursor-rules/issues/195
- Article: https://dyrynda.com.au/blog/speed-up-your-livewire-tests
- Livewire testing docs: https://livewire.laravel.com/docs/4.x/testing#testing-properties

## Test plan
- [x] Run `composer build`
- [x] Verify `skill-check` passes for all skills
- [x] Confirm only intended skill files changed
- [ ] Interactive UI/API testing recommendations: no (documentation-only change)
- [ ] Additional automated tests for these recommendations: no

Closes #195

Made with [Cursor](https://cursor.com)