### PR TITLE
feat(skills): add answer-pr-questions skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - unified PHP coding guidelines for PHP 8.4 projects
 - Pest-based testing with mandatory code analysis and 100% coverage
 - strong focus on clean code: typed properties, SRP, no redundant comments
-- **28 comprehensive Agent skills** for automated workflows (v0.6)
+- **29 comprehensive Agent skills** for automated workflows (v0.6)
 - fast onboarding inside development repositories
 
 ## Installation
@@ -78,7 +78,7 @@ vendor/bin/cursor-rules install --symlink          # prefer symlinks (fallback t
 
 # 🎯 Skills Overview — **v0.6**
 
-> Current release includes 28 skills for issue resolution, code review, refactoring, testing, security, SQL performance, and delivery workflows.
+> Current release includes 29 skills for issue resolution, code review, refactoring, testing, security, SQL performance, and delivery workflows.
 
 Agent skills are installed into the chosen editor’s skill directory (see `--editor`). Use `--editor=all` to install for Cursor, Claude, and Codex at once. They can be invoked when relevant. Each skill follows project conventions, ensures code quality, and maintains 100% test coverage where applicable.
 
@@ -91,6 +91,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `resolve-github-issue` | End-to-end GitHub issue resolution with fixes, review loops, coverage checks, and PR creation. |
 | `resolve-jira-issue` | End-to-end JIRA issue resolution with fixes, review loops, coverage checks, and PR creation. |
 | `resolve-random-jira-issue` | Pick and resolve a random JIRA issue with the full quality workflow. |
+| `answer-pr-questions` | Find unanswered current issue/PR questions and generate short PM/client-friendly unified answers. |
 | `merge-github-pr` | Merge one GitHub PR that is ready for deployment. |
 | `create-issue` | Create a tracker issue from provided task text while preserving original meaning and structure. |
 

--- a/skills/answer-pr-questions/SKILL.md
+++ b/skills/answer-pr-questions/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: answer-pr-questions
+description: "Analyze issue and pull request discussions, find unanswered current questions, and prepare concise unified answers for project managers or clients in plain language. Use when stakeholders need non-technical answers from GitHub issue/PR threads."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+# Answer PR Questions
+
+**Constraint:**
+- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
+- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
+- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
+- First, load all the rules for the cursor editor (`.cursor/rules/.*mdc`).
+- Read `project.mdc` before starting.
+- Analyze both issue and pull request discussions from the provided link.
+- Work only with questions relevant to the current PR and current issue state.
+- Ignore questions that were already clearly answered in the same issue/PR context.
+- Output must be understandable for non-programmers (project manager or client).
+- Output must be in the language in which the assignment was written.
+
+**Steps:**
+- Open the provided issue link and identify its current branch/related PR.
+- Collect all comments from:
+  - the issue timeline,
+  - the related PR timeline,
+  - PR review comments and review threads.
+- Build a list of all current stakeholder questions.
+- Filter out questions that are already answered.
+- Keep only unanswered and still relevant questions for the current PR.
+- For each remaining question, prepare one short unified final answer:
+  - no technical jargon,
+  - clear business meaning,
+  - maximum 2-4 short sentences.
+- If a question cannot be fully answered from available information, explicitly state what is still missing and who should provide it.
+
+**Output format (markdown):**
+- Use this structure so answers can be copied easily:
+
+```markdown
+## Nezodpovězené otázky a sjednocené odpovědi
+
+### 1) <Krátká formulace otázky>
+**Sjednocená odpověď:** <Krátká finální odpověď pro PM/klienta>
+
+### 2) <Krátká formulace otázky>
+**Sjednocená odpověď:** <Krátká finální odpověď pro PM/klienta>
+```
+
+- If there are no unanswered relevant questions, return:
+
+```markdown
+## Nezodpovězené otázky a sjednocené odpovědi
+
+V aktuálním issue a souvisejícím PR nejsou žádné nezodpovězené otázky.
+```
+
+## Output Humanization
+- Use [blader/humanizer](https://github.com/blader/humanizer) for all skill outputs to keep the text natural and human-friendly.


### PR DESCRIPTION
## Shrnutí
- Přidán nový skill `answer-pr-questions`, který z issue/PR diskuse vytáhne pouze aktuální nezodpovězené otázky a připraví krátké sjednocené odpovědi pro PM/klienta bez technického žargonu.
- Skill explicitně vyžaduje analýzu issue i PR komentářů, filtraci již zodpovězených dotazů a výstup v jazyce zadání.
- Aktualizován `README.md` (29 skillů + nový řádek v přehledu).

## Zdroje pro analýzu zadání
- [Issue #203](https://github.com/pekral/cursor-rules/issues/203)

## Test plan
- [x] `composer build`
- [x] `npx skill-check check skills --fix --no-security-scan` (součást `composer build`)
- [x] `npx skill-check check skills --no-security-scan` (součást `composer build`)
- [x] Ověření, že nový skill je uveden v `README.md`

Made with [Cursor](https://cursor.com)