### PR TITLE
feat(skill): create tracker issue draft from CR comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,4 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 📝 **Changed**: Laravel rules and test-writing skills clarify database schema defaults as source of truth—avoid duplicating them in PHP/factories (#152)
 - 📝 **Changed**: Laravel testing rules and test-writing skills require queueing jobs in tests via `JobClass::dispatch()` only (#153)
 - ✨ **Added**: new Agent skill `seo-geo` for SEO and generative-engine optimization strategy (#164)
-- ✨ **Added**: new Agent skill `create-tracker-issue-from-cr-comments` for creating tracker-ready issue drafts from technical CR comments while preserving original task text (#205)
+- ✨ **Added**: new Agent skill `create-jira-issue-from-pr` for creating JIRA-ready issue drafts from GitHub PR review context while preserving original task text (#205)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `answer-pr-questions` | Find unanswered current issue/PR questions and generate short PM/client-friendly unified answers. |
 | `merge-github-pr` | Merge one GitHub PR that is ready for deployment. |
 | `create-issue` | Create a tracker issue from provided task text while preserving original meaning and structure. |
-| `create-tracker-issue-from-cr-comments` | Draft a tracker-ready issue from technical CR comments while preserving original assignment text. |
+| `create-jira-issue-from-pr` | Draft a JIRA-ready issue from GitHub PR review context while preserving original assignment text. |
 
 ## Code Review, Security & Architecture
 

--- a/skills/create-jira-issue-from-pr/SKILL.md
+++ b/skills/create-jira-issue-from-pr/SKILL.md
@@ -1,41 +1,43 @@
 ---
-name: create-tracker-issue-from-cr-comments
-description: Use when create a tracker-ready issue draft from technical code
-  review comments while preserving original task text and making the result
+name: create-jira-issue-from-pr
+description: Use when preparing a JIRA issue draft from GitHub pull request
+  context while preserving the original assignment text and making the output
   understandable for both AI agents and non-technical stakeholders.
 license: MIT
 metadata:
   author: Petr Král (pekral.cz)
 ---
 
-# Create Tracker Issue From CR Comments
+# Create JIRA Issue From PR
 
 **Constraint:**
-- For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
-- If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
-- If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
+- For GitHub pull request analysis, prefer GitHub CLI (`gh`) as the primary tool.
+- For JIRA issue creation, prefer JIRA CLI in the local environment.
+- If a required CLI is not available, use an available MCP server fallback.
+- If neither CLI nor MCP fallback is available for a required system, stop and return a failed result explaining missing tools.
 - First, load all rules for the cursor editor (`.cursor/rules/.*mdc`) and read `project.mdc`.
 - Output must be in the language in which the assignment was written.
 - Never use a web browser for issue and PR analysis when CLI/MCP tools are available.
 - Keep the original assignment text unchanged; only improve formatting and structure.
 
 **Steps:**
-- Open the provided issue/PR/CR URL and collect:
-  - the original assignment text,
-  - technical CR comments and review thread context,
-  - any linked implementation constraints.
+- Open the provided GitHub PR URL and collect:
+  - original assignment text,
+  - technical review comments and review thread context,
+  - linked constraints and unresolved findings.
 - Analyze repository context before drafting output:
-  - if a related PR exists, load and inspect it,
-  - otherwise inspect the default branch in git.
-- Build a task list from CR comments and assignment context:
+  - inspect the PR diff and related commits,
+  - include relevant implementation context needed for delivery.
+- Build a task list from PR comments and assignment context:
   - include unresolved requirements only,
   - remove already-resolved or duplicate requests.
-- Prepare a tracker-ready markdown issue draft:
+- Prepare a JIRA-ready markdown issue draft:
   - preserve original assignment text exactly (verbatim section),
   - add a clear goal summary understandable for non-technical readers,
   - add a technical section for AI agents and developers,
   - keep acceptance criteria concrete and testable.
 - If attachments are referenced, download and analyze them via CLI/MCP and include their impact in the draft.
+- Create the resulting issue in JIRA (if user asks for creation), assign it to the current user, and return the direct issue URL.
 
 ## Output format (markdown)
 
@@ -46,7 +48,7 @@ metadata:
 ## Původní zadání (beze změn)
 <Přesně původní text zadání, bez úprav obsahu>
 
-## Technický kontext z CR
+## Technický kontext z PR
 - <Shrnutí relevantních technických zjištění>
 
 ## Požadavky pro implementaci
@@ -58,13 +60,13 @@ metadata:
 - [ ] <Měřitelné kritérium 2>
 
 ## Poznámky
-- Zdroj: <HTTP odkaz na issue/PR/CR>
-- Výstup je naformátovaný pro issue tracker, původní zadání zůstalo obsahově beze změn.
+- Zdroj: <HTTP odkaz na PR>
+- Výstup je naformátovaný pro JIRA issue, původní zadání zůstalo obsahově beze změn.
 ```
 
 ## Quality checks
 - Verify that original assignment wording in the verbatim section is identical to the source.
-- Verify that all unresolved CR comments are mapped to implementation requirements.
+- Verify that all unresolved PR review comments are mapped to implementation requirements.
 - Verify that acceptance criteria are testable and unambiguous.
 
 ## Output Humanization


### PR DESCRIPTION
## Summary
- Přidán nový skill `create-tracker-issue-from-cr-comments` pro převod technického CR zadání na issue tracker výstup.
- Skill zachovává původní text zadání beze změn a přidává čitelnou markdown strukturu pro AI i netechnické čtenáře.
- Aktualizována dokumentace v `README.md` (počet skillů + seznam) a `CHANGELOG.md`.

## Sources used for analysis
- GitHub issue: https://github.com/pekral/cursor-rules/issues/205

## Test plan
- [x] Spustit `composer build` a ověřit, že celý quality pipeline projde bez chyb.
- [x] Ověřit, že nový skill prochází `skill-check` validací.
- [x] Ověřit, že dokumentace (`README.md`, `CHANGELOG.md`) odpovídá novému skillu.
- [x] Testy pro doporučení výše existují?
  - `composer build` spouští existující test suite (`Tests\\InstallerTest`) a coverage kontrolu; pro tento docs/skills change není potřeba doplňovat nové testy.

Made with [Cursor](https://cursor.com)