### PR TITLE
fix(installer): support Claude force+editor combined flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 📝 **Changed**: Laravel testing rules and test-writing skills require queueing jobs in tests via `JobClass::dispatch()` only (#153)
 - ✨ **Added**: new Agent skill `seo-geo` for SEO and generative-engine optimization strategy (#164)
 - ✨ **Added**: new Agent skill `create-jira-issue-from-pr` for creating JIRA-ready issue drafts from GitHub PR review context while preserving original task text (#205)
+- 🐛 **Fixed**: installer now correctly parses combined CLI flags like `--force--editor=claude` so Claude rules/skills are overwritten with force as expected (#209)

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -22,10 +22,11 @@ final class Installer
      */
     public static function run(array $argv): int
     {
-        $command = $argv[1] ?? 'help';
-        $force = in_array('--force', $argv, true);
-        $symlink = in_array('--symlink', $argv, true);
-        $prune = in_array('--prune', $argv, true);
+        $normalizedArgv = InstallerPath::normalizeCliArguments($argv);
+        $command = $normalizedArgv[1] ?? 'help';
+        $force = in_array('--force', $normalizedArgv, true);
+        $symlink = in_array('--symlink', $normalizedArgv, true);
+        $prune = in_array('--prune', $normalizedArgv, true);
 
         try {
             if ($command === 'help') {
@@ -38,7 +39,7 @@ final class Installer
                 return 1;
             }
 
-            $editor = self::parseEditor($argv);
+            $editor = self::parseEditor($normalizedArgv);
 
             if ($editor === null) {
                 fwrite(STDERR, 'Invalid --editor value. Allowed: cursor, claude, codex, all.' . PHP_EOL);

--- a/src/InstallerPath.php
+++ b/src/InstallerPath.php
@@ -28,6 +28,18 @@ final class InstallerPath
         return self::findProjectRoot();
     }
 
+    /**
+     * @param array<int, string> $argv
+     * @return array<int, string>
+     */
+    public static function normalizeCliArguments(array $argv): array
+    {
+        $rawArguments = implode(' ', $argv);
+        $parts = preg_split('/\s+|(?=--(?:force|symlink|prune|editor=))/', trim($rawArguments), -1, PREG_SPLIT_NO_EMPTY);
+
+        return is_array($parts) && $parts !== [] ? $parts : $argv;
+    }
+
     public static function resolveRulesSource(string $root): string
     {
         $developmentSource = $root . '/rules';

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -783,6 +783,34 @@ test('install with editor=claude copies to .claude only', function (): void {
     }
 });
 
+test('install supports combined force and editor flags for claude', function (): void {
+    $root = installerCreateProjectRoot();
+    installerWriteFile($root . '/rules/example.mdc', 'new rules');
+    installerWriteFile($root . '/skills/test-skill/SKILL.md', 'new skill');
+    installerWriteFile($root . '/.claude/rules/example.mdc', 'old rules');
+    installerWriteFile($root . '/.claude/skills/test-skill/SKILL.md', 'old skill');
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--force--editor=claude']);
+        ob_end_clean();
+
+        expect(file_get_contents($root . '/.claude/rules/example.mdc'))->toBe('new rules');
+        expect(file_get_contents($root . '/.claude/skills/test-skill/SKILL.md'))->toContain('new skill');
+        expect(is_dir($root . '/.cursor/rules'))->toBeFalse();
+        expect(is_dir($root . '/.codex/rules'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
 test('install with editor=codex copies to .codex only', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/rules/example.mdc', 'rules');


### PR DESCRIPTION
## Shrnutí
- Opravil jsem parser CLI argumentů v installeru tak, aby správně rozpoznal kombinovaný zápis `--force--editor=claude`.
- Díky tomu se při tomto zápisu korektně aplikuje `force` přepis i cílení na editor `claude`, stejně jako u Cursoru.
- Přidal jsem regresní test, který chybu reprodukuje a ověřuje fix.

Closes #209

## Zdroje k analýze
- Zadání issue: [#209](https://github.com/pekral/cursor-rules/issues/209)
- Kontext repozitáře: [README](https://github.com/pekral/cursor-rules/blob/master/README.md)

## Testovací doporučení
- [x] Spustit `composer build` a ověřit průchod celé quality pipeline.
- [x] Ověřit regresní scénář: `Installer::run(['cursor-rules', 'install', '--force--editor=claude'])` přepíše existující soubory v `.claude`.
- [x] Ověřit, že standardní scénáře (`--editor=claude`, `--force`) zůstaly funkční.
- UI/API testy pro tuto změnu: no.


Made with [Cursor](https://cursor.com)