### PR TITLE
fix(skill): handle multiple open PRs per issue in CR skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `cursor-rules` will be documented in this file.
 
 ## [Unreleased]
 
+- 🐛 **Fixed**: CR skills now systematically review all open PRs per issue instead of only one (#227)
+
 ## [0.6.2] - 2026-04-07
 
 - 📝 **Changed**: consolidate CHANGELOG (single [Unreleased] section, remove duplicate blocks)

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -17,6 +17,7 @@ metadata:
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 
 **Steps:**
+- **Multiple PRs per issue:** If the issue has more than one open pull request, perform a separate code review for each open PR sequentially. Review each PR independently on its own branch, post findings to the corresponding PR, and produce a per-PR summary. After all PRs are reviewed, provide a consolidated overview listing each PR with its result (clean / has findings).
 - **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.
 - Switch locally to the branch in PR and perform code review over changes locally on the filesystem.
 - Before writing findings, collect prior review comments/reports from the PR timeline and related issue discussion. Build a dedup list by problem signature (file/scope + root cause + risk) and skip findings already reported unless severity/impact changed.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -27,8 +27,9 @@ metadata:
 - Keep comments understandable for project managers and testers, not only developers
 
 **Steps:**
-- **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.
-- First, find the open pull requests that are automatically linked to JIRA via the branch name. If you can’t find a PR by the branch name, review all the comments in the issue and locate the relevant PR.  Always check only the open pull requests and ignore the rest!
+- First, find all open pull requests that are automatically linked to JIRA via the branch name. If you can’t find a PR by the branch name, review all the comments in the issue and locate the relevant PRs. Always check only the open pull requests and ignore the rest!
+- **Multiple PRs per issue:** If the issue has more than one open pull request, perform a separate code review for each open PR sequentially. Review each PR independently on its own branch, post findings to the corresponding PR, and produce a per-PR summary. After all PRs are reviewed, provide a consolidated overview listing each PR with its result (clean / has findings).
+- **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review for that PR; cancel and report that the CR was skipped due to conflicts. Continue with the next PR.
 - Switch locally to the branch in PR and perform code review over changes locally on the filesystem.
 - Before writing findings, collect prior review comments/reports from the PR timeline and JIRA discussion. Build a dedup list by problem signature (file/scope + root cause + risk) and skip findings already reported unless severity/impact changed.
 - **Plan Alignment Analysis:** Compare the implementation against the original issue description, planning documents, or step description. Identify deviations from the planned approach, architecture, or requirements. Assess whether deviations are justified improvements or problematic departures. Verify that all planned functionality has been implemented — list any missing or only partially met items.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -15,8 +15,8 @@ metadata:
 
 **Steps:**
 - Identify the task from the provided issue code or URL.
-- Find the latest pull request for that task.
-- In the pull request, locate code review output and all review comments (including review threads and general comments).
+- Find all open pull requests for that task. If there are multiple open PRs, process each one sequentially — apply the full review-feedback resolution cycle to each PR independently before moving to the next.
+- In each pull request, locate code review output and all review comments (including review threads and general comments).
 - If there is only a generic `CR` comment, treat it as `code review` feedback.
 - Build a checklist from all review findings and map each item to a concrete code or test change.
 - Ensure the checklist explicitly contains all reported **DRY violations** and tracks their resolution before triggering the next CR cycle.


### PR DESCRIPTION
## Summary

- CR skills (`code-review-github`, `code-review-jira`, `process-code-review`) now systematically review **all open PRs** for an issue instead of picking only one
- Each PR is reviewed independently on its own branch with findings posted to the corresponding PR
- After all PRs are reviewed, a consolidated overview is produced listing each PR with its result

Closes #227

## Test plan

- [ ] Trigger `code-review-github` on an issue with multiple open PRs — verify all PRs are reviewed
- [ ] Trigger `code-review-jira` on a JIRA issue with multiple linked PRs — verify all PRs are reviewed
- [ ] Trigger `process-code-review` on an issue with multiple open PRs — verify each PR is processed sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)