### PR TITLE
fix(skill): prefer acli for all JIRA operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 ## [Unreleased]
 
 - 🐛 **Fixed**: CR skills now systematically review all open PRs per issue instead of only one (#227)
+- 🐛 **Fixed**: JIRA skills now consistently prefer `acli` console tool via shared `jira-operations.mdc` rule (#228)
 
 ## [0.6.2] - 2026-04-07
 

--- a/rules/skills/jira-operations.mdc
+++ b/rules/skills/jira-operations.mdc
@@ -1,0 +1,12 @@
+---
+description: JIRA CLI (acli) preference and fallback strategy for skills
+globs:
+alwaysApply: false
+---
+
+## JIRA Operations
+
+- For all JIRA operations (reading issues, writing comments, updating status, loading attachments), prefer the `acli` console tool as the primary tool.
+- If `acli` is not available, use an available JIRA MCP server as fallback.
+- If neither `acli` nor a JIRA MCP server is available, stop and return a failed result explaining that required JIRA tools are missing.
+- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -10,11 +10,11 @@ metadata:
 - Apply @rules/skills/base-constraints.mdc
 - Apply @rules/skills/review-only.mdc
 - Apply @rules/skills/github-operations.mdc
+- Apply @rules/skills/jira-operations.mdc
 - Always apply @skills/smartest-project-addition/SKILL.md internally to identify one highest-impact, low-risk addition candidate; include it only if it maps to a real finding and keep the final output in the required findings-only format.
 - Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 - All comments or outputs posted to GitHub (issues, pull requests, review comments, and PR descriptions) must be written in English.
 - Explicitly detect and report **DRY violations** (duplicated logic, duplicated validation rules, repeated branching/condition blocks, and copy-pasted code paths) in every CR result.
-- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.
 
 **Universal JIRA Comment Formatting**
 - Use this output shape for every JIRA update from this skill:
@@ -35,12 +35,12 @@ metadata:
 - **Plan Alignment Analysis:** Compare the implementation against the original issue description, planning documents, or step description. Identify deviations from the planned approach, architecture, or requirements. Assess whether deviations are justified improvements or problematic departures. Verify that all planned functionality has been implemented — list any missing or only partially met items.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - Always apply @skills/code-review/SKILL.md and @skills/security-review/SKILL.md. If the changes include any database-related modifications (migrations, schema changes, repositories, raw SQL, query builder, or Eloquent/queries in changed code), also apply @skills/mysql-problem-solver/SKILL.md for those parts; otherwise do not use the SQL skill.
-  Retrieve the JIRA issue (by code or URL) using the acli console tool first. If acli is not available, use the JIRA MCP server if available. If neither is available, stop and display a message stating that at least one of these tools must be installed to use the skill.
+  Retrieve the JIRA issue (by code or URL) using the preferred JIRA tool (see @rules/skills/jira-operations.mdc).
 - **Race condition review (when shared state is modified):** If the changes contain any of the following signals — read-modify-write sequences, shared counters/balances/stock/quotas, `firstOrCreate`/`updateOrCreate`, retried or re-dispatched jobs that mutate shared records, cache write-back patterns, or bulk read-then-write operations — apply @skills/race-condition-review/SKILL.md. If none of these signals are present, skip this step.
 - **I/O bottleneck review (when changes touch file, storage, or external I/O):** If the changes include any of the following signals — synchronous file reads/writes on large or unbounded files, blocking HTTP calls without timeouts, storage operations executed in the request lifecycle, large file responses not streamed, or export/import operations loading all records into memory — flag each occurrence and recommend the appropriate async/streaming pattern. If none of these signals are present, skip this step.
 - Apply @rules/skills/architecture-patterns.mdc
 - Find the Git branch and switch to it (if needed pull the latest changes).
-- I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the acli console tool first to retrieve all the information you need about the bug (including comments and attachments). If acli is not available, use the JIRA MCP server if available. If neither is available, stop and display a message stating that at least one of these tools must be installed to use the skill. If you have other resources available that you could use to understand the problem, load them and analyze them.
+- I want you to fix the bug from JIRA (you have either the ID or a link to JIRA). Use the preferred JIRA tool (see @rules/skills/jira-operations.mdc) to retrieve all the information you need about the bug (including comments and attachments). If you have other resources available that you could use to understand the problem, load them and analyze them.
 - If possible, find links to the assignment and analyze it so that you understand it and can do a quality CR. Find the attachments for the assignment and analyze them. Again, use the available MCP servers or CLI tools for the specific issue tracker. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - List findings using exactly three severity levels: **Critical**, **Moderate**, **Minor**.
 - If there are any findings, add comments to the PR about where you found these errors. If that is not possible, create a new comment on the PR with the list of findings. If you do not find any issues, post a short comment stating that **no findings were identified**. Every text in English.

--- a/skills/create-jira-issue-from-pr/SKILL.md
+++ b/skills/create-jira-issue-from-pr/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 **Constraint:**
 - Apply @rules/skills/base-constraints.mdc
 - Apply @rules/skills/github-operations.mdc
-- For JIRA issue creation, prefer JIRA CLI in the local environment. If not available, use an available MCP server fallback. If neither is available, stop and return a failed result explaining missing tools.
+- Apply @rules/skills/jira-operations.mdc
 - Never use a web browser for issue and PR analysis when CLI/MCP tools are available.
 - Keep the original assignment text unchanged; only improve formatting and structure.
 

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 - Apply @rules/skills/github-operations.mdc
 - Never push direct changes to the main branch.
 - If the pull request has merge conflicts with the base branch, stop and report that the code review processing is blocked.
-- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown) and follow the universal structure from JIRA-focused skills.
+- Apply @rules/skills/jira-operations.mdc
 
 **Steps:**
 - Identify the task from the provided issue code or URL.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -9,10 +9,10 @@ metadata:
 **Constraint:**
 - Apply @rules/skills/base-constraints.mdc
 - Apply @rules/skills/github-operations.mdc
+- Apply @rules/skills/jira-operations.mdc
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
-- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown). Never use fenced code blocks (```), markdown headings (#), or markdown tables.
 - Pull request creation is mandatory for every resolved JIRA issue. After checks pass, automatically push the branch and create a GitHub PR, then link it back to the JIRA issue. Do not finish without a PR URL.
 
 **Universal JIRA Comment Formatting**
@@ -56,9 +56,7 @@ h4. Testing recommendations
 **Steps:**
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - I want you to fix the bug from JIRA (you have either the ID or a link to JIRA).
-  Use the acli console tool first to retrieve all issue details (including comments and attachments).
-  If acli is not available, use the JIRA MCP server if available.
-  If neither acli nor a JIRA MCP server is available, stop and display a message stating that at least one of these tools must be installed to use the skill.
+  Use the preferred JIRA tool (see @rules/skills/jira-operations.mdc) to retrieve all issue details (including comments and attachments).
   If you have other resources available that you could use to understand the problem, load them and analyze them.
 - Classify the task type before writing any code:
   - **Bug**: the issue describes existing functionality that behaves incorrectly (e.g. wrong output, exception, regression, data corruption). Issue types such as `Bug` or `Defect`, or labels such as `bug`, `fix`, or `regression` are strong signals.

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -9,13 +9,13 @@ metadata:
 **Constraint:**
 - Apply @rules/skills/base-constraints.mdc
 - Apply @rules/skills/github-operations.mdc
+- Apply @rules/skills/jira-operations.mdc
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - If you are not on the main git branch in the project, switch to it.
-- For comments posted to JIRA, always use JIRA Wiki Markup (not Markdown) and follow the universal structure from JIRA-focused skills.
 - Pull request creation is mandatory for every resolved JIRA issue selected by this skill. Do not finish without a GitHub PR URL linked to the selected JIRA issue.
 
 **Steps:**
-- Log into JIRA and load all issues using the acli console tool first. If acli is not available, use the JIRA MCP server if available. If neither is available, stop and display a message stating that at least one of these tools must be installed to use the skill.
+- Log into JIRA and load all issues using the preferred JIRA tool (see @rules/skills/jira-operations.mdc).
   List only those issues that are to be resolved by AI (they are tagged). Look for tasks labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only not resolved issues should be listed!
 - Randomly select one and try to resolve it. Use the skill @skills/resolve-jira-issue/SKILL.md.
 - Completion is valid only when the delegated flow creates a GitHub PR and links it in the selected JIRA issue.

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -161,5 +161,5 @@ Produce a human-readable markdown report containing:
 
 **After completing the tasks**
 
--   Post the final human-readable test report as a comment to the **related issue** in the issue tracker (GitHub issue, JIRA ticket, etc.). Use available CLI tools or MCP servers to post it. The comment must be written in the language of the task assignment.
+-   Post the final human-readable test report as a comment to the **related issue** in the issue tracker (GitHub issue, JIRA ticket, etc.). For GitHub, use `gh` CLI; for JIRA, prefer `acli` console tool (fallback to JIRA MCP server). The comment must be written in the language of the task assignment.
 -   Summarize which scenarios failed or were unclear (with technical info for the developer).


### PR DESCRIPTION
## Summary

- New shared rule `rules/skills/jira-operations.mdc` — defines `acli` as primary tool for all JIRA operations with MCP server fallback
- All JIRA skills (`code-review-jira`, `resolve-jira-issue`, `resolve-random-jira-issue`, `create-jira-issue-from-pr`, `process-code-review`, `test-like-human`) now reference this shared rule instead of duplicating the acli/MCP fallback chain inline

Closes #228

## Test plan

- [ ] Verify `code-review-jira` prefers `acli` for JIRA issue retrieval
- [ ] Verify `resolve-jira-issue` uses `acli` for reading/writing JIRA issues
- [ ] Verify `resolve-random-jira-issue` loads issues via `acli`
- [ ] Verify `create-jira-issue-from-pr` creates issues via `acli`
- [ ] Verify all skills fall back to JIRA MCP server when `acli` is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)