### PR TITLE
fix(skill): use shared gh/acli rules in remaining skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 🐛 **Fixed**: CR skills now include mandatory regression analysis to verify changes don't break existing functionality outside ticket scope (#233)
 - 🐛 **Fixed**: `code-review` skill now enforces English-only output — Czech Deliver/Communication sections translated (#235)
 - 🔧 **Changed**: move shared rule files from `rules/skills/` to `rules/`, update all skill references (#238)
+- 🐛 **Fixed**: `create-missing-tests-in-pr` and `test-like-human` skills now use shared `github-operations.mdc` / `jira-operations.mdc` rules instead of inline preferences (#237)
 
 ## [0.6.2] - 2026-04-07
 

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -11,10 +11,8 @@ metadata:
 ---
 
 **Constraint:**
--   For all GitHub operations, prefer GitHub CLI (`gh`) as the primary tool.
--   If `gh` is not available or cannot be used, use an available GitHub MCP server as fallback.
--   If neither `gh` nor a GitHub MCP server is available, stop and return a failed result explaining that required GitHub tools are missing.
 -   Apply @rules/base-constraints.mdc
+-   Apply @rules/github-operations.mdc
 -   Apply @rules/testing-conventions.mdc
 -   If you are not on the main git branch in the project, switch to it.
 -   This task is based on the existing pull request review.

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -14,6 +14,7 @@ metadata:
 
 -   Apply @rules/base-constraints.mdc
 -   Apply @rules/github-operations.mdc
+-   Apply @rules/jira-operations.mdc
 -   Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 -   **Before starting to test**, analyze all comments and discussions in the issue so that you fully understand what the final state should be and what logic should have been created. Only then begin testing.
 -   Work only with the **current pull request**. Testing instructions must be taken only from the PR conversation.
@@ -161,5 +162,5 @@ Produce a human-readable markdown report containing:
 
 **After completing the tasks**
 
--   Post the final human-readable test report as a comment to the **related issue** in the issue tracker (GitHub issue, JIRA ticket, etc.). For GitHub, use `gh` CLI; for JIRA, prefer `acli` console tool (fallback to JIRA MCP server). The comment must be written in the language of the task assignment.
+-   Post the final human-readable test report as a comment to the **related issue** in the issue tracker (GitHub issue, JIRA ticket, etc.) using the preferred tool for the tracker (see @rules/github-operations.mdc and @rules/jira-operations.mdc). The comment must be written in the language of the task assignment.
 -   Summarize which scenarios failed or were unclear (with technical info for the developer).


### PR DESCRIPTION
## Summary

- `create-missing-tests-in-pr`: replaced inline `gh` CLI preference (3 lines) with `@rules/github-operations.mdc` reference
- `test-like-human`: added `@rules/jira-operations.mdc` to constraints, replaced inline `acli` preference in "After completing" section with shared rule reference

All skills that communicate with GitHub or JIRA now consistently use the shared operation rules instead of inlining the preference/fallback chain.

Closes #237

## Test plan

- [ ] Verify no skill file inlines `gh` CLI preference — grep for `prefer GitHub CLI` should return 0 matches in `skills/`
- [ ] Verify no skill file inlines `acli` preference — grep for `acli console tool first` should return 0 matches in `skills/`
- [ ] Run `create-missing-tests-in-pr` — verify GitHub operations use `gh` CLI
- [ ] Run `test-like-human` on a JIRA-linked PR — verify JIRA posting uses `acli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)