### PR TITLE
fix(rules): prefer partial mocks over full mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 🐛 **Fixed**: `code-review` skill now enforces English-only output — Czech Deliver/Communication sections translated (#235)
 - 🔧 **Changed**: move shared rule files from `rules/skills/` to `rules/`, update all skill references (#238)
 - 🐛 **Fixed**: `create-missing-tests-in-pr` and `test-like-human` skills now use shared `github-operations.mdc` / `jira-operations.mdc` rules instead of inline preferences (#237)
+- 🐛 **Fixed**: all mock rules now prefer partial mocks (`makePartial()`) over full mocks (#241)
 
 ## [0.6.2] - 2026-04-07
 

--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -112,14 +112,14 @@ final class CreateUserData extends Data
 - Laravel: prefer Http::fake() over Mockery
 - **Queue/Bus/Event assertions** — Do not pass a callback (closure) as the second argument to `Queue::assertPushed()`, `Queue::assertNotPushed()`, `Bus::assertDispatched()`, `Bus::assertNotDispatched()`, or `Event::assertDispatched()`. Assert only that the job/event class was pushed or dispatched (and optionally the count). Use `Queue::assertPushed(JobClass::class)` or `Queue::assertPushed(JobClass::class, $count)`; never use a callback to inspect job payload or filter matches.
 - Always call console commands using Artisan::call(MyCommand::class)
-- Mocking services is only allowed for classes that use external service calls or if it is necessary to simulate an exception throw.
+- Mocking services is only allowed for classes that use external service calls or if it is necessary to simulate an exception throw. **Prefer partial mocks** (`Mockery::mock(Service::class)->makePartial()` or `$this->partialMock(Service::class)`) so that real method implementations are preserved and only the needed methods are overridden.
 - **Eloquent rows in tests:** Persisted database rows that map to Eloquent models must be created only via model factories (`Model::factory()->create()`, `make()`, `count()`, `state()`, `for()`, `has()`, `afterCreating()`, etc.). Do not persist such data using `Model::create()`, `new Model([...])->save()`, `DB::table(...)->insert()`, `DB::insert()`, or raw SQL. If a model has no factory yet, add a factory before writing tests that need persisted rows for that model.
 - Factory: multiple records with the same attributes — When creating multiple instances of a model with the same attributes in your tests, use Model::factory()->count(n)->create([...]) instead of repeatedly calling Model::factory()->create([...]). Do not pass attributes that are not verified by the test (e.g., name); a single call is clearer and consistent with Laravel style. Omit factory attributes that are already covered by a database `DEFAULT` unless the test needs a non-default value.
 - If the PEST test requires calling a method that is in an abstract class, use the notation `test()->methodName()`.
 - **Dispatching jobs in tests:** Push jobs using the job class static `dispatch()` method (`Dispatchable` trait) — e.g. `ExportActivityRecurring::dispatch($payload)`. Do not use `dispatch(new ExportActivityRecurring(...))`, `Bus::dispatch(new ExportActivityRecurring(...))`, or `new ExportActivityRecurring(...)` without dispatching when the test should queue the job. Never combine `new` with `::dispatch()` (invalid PHP); call `JobClass::dispatch(...)` only.
-- Mocking the necessary classes only via app()->instance(Mock::class), e.g. 
+- Mocking the necessary classes only via app()->instance(Mock::class). Prefer partial mocks, e.g.
 ```
-$intercomServiceMock = Mockery::mock(IntercomService::class);
+$intercomServiceMock = Mockery::mock(IntercomService::class)->makePartial();
     $intercomServiceMock->shouldNotReceive('updateOrCreateCompanyData');
     $intercomServiceMock->shouldNotReceive('updateOrCreateUser');
 

--- a/rules/php/standards.mdc
+++ b/rules/php/standards.mdc
@@ -63,6 +63,7 @@ globs: ["*"]
 - Data providers via argument, not PHPDoc
 - Mock only external services (HTTP clients) or for testing catch exceptions
 - Only mock methods that communicate with third-party services or if you need to simulate an exception. Otherwise, avoid mocking!
+- **Prefer partial mocks** over full mocks — use `Mockery::mock(Service::class)->makePartial()` so real methods run and only the needed methods are overridden.
 - Final test classes, local variables only
 - In tests, avoid reflection and use mocks instead (even partial ones, if they are effective and easy to read).
 - For new test flows, follow the concept of existing flows, unless they are new tests. Write new tests according to the defined rules.

--- a/rules/testing-conventions.mdc
+++ b/rules/testing-conventions.mdc
@@ -13,5 +13,6 @@ alwaysApply: false
 - In Laravel factories, do not set attributes whose values are already defined by a database column default unless the test explicitly needs a different value (see `@rules/laravel/architecture.mdc` Schema defaults and Testing).
 - In Laravel tests, dispatch queue jobs only via `JobClass::dispatch(...)` (see `@rules/laravel/architecture.mdc` Testing — Dispatching jobs in tests).
 - Mock only external services (HTTP clients) or to simulate exceptions; remove any constructor mocks, unnecessary mocks, or mocks that can be replaced with real service logic.
+- **Prefer partial mocks** over full mocks whenever possible. Partial mocks keep real method implementations and only override the methods you need to control, making tests more realistic and less brittle. Use `Mockery::mock(Service::class)->makePartial()` or `$this->partialMock(Service::class)` in Laravel.
 - After generating or modifying tests, verify that all new tests comply with the testing rules in `@rules/php/standards.mdc`.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -91,7 +91,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Explicitly detect and report **DRY violations** (duplicated logic, duplicated validation rules, repeated branching/condition blocks, and copy-pasted code paths) as findings with actionable refactoring recommendations.
 - Issues static analysis may not fully trace: business-logic flaws, missing authorization checks, data flow to sensitive sinks.
 - Coverage for changed files only (target 100% for changes). Run tests only for changed files.
-- New code is tested: arrange-act-assert; error cases first; descriptive names; data providers via argument; mock only external services.
+- New code is tested: arrange-act-assert; error cases first; descriptive names; data providers via argument; mock only external services. **Prefer partial mocks** over full mocks — flag full mocks as **Minor** when a partial mock would suffice.
 - Identify missing test variations.
 - For new or changed behavior, suggest concrete test scenarios where coverage is missing or unclear (e.g. "Unit: method X with null/empty input"; "Integration: POST without auth must return 401"). This supports testing readiness alongside coverage metrics.
 - Laravel: prefer `Http::fake()` over Mockery.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -28,7 +28,7 @@ Write one minimal test showing expected behavior.
 
 - One behavior per test.
 - Clear, descriptive name that describes the behavior.
-- Real code paths — mock only external services (HTTP clients) or to simulate exceptions. Do not use constructor mocking!
+- Real code paths — mock only external services (HTTP clients) or to simulate exceptions. Do not use constructor mocking! **Prefer partial mocks** (`Mockery::mock(Service::class)->makePartial()`) so real methods run and only needed methods are overridden.
 - Arrange-act-assert pattern, error cases first.
 - In tests, avoid reflection; use mocks instead (even partial ones, if they are effective and easy to read).
 - In Livewire component tests, prefer `set()` for form state updates instead of `fill()` to avoid one round-trip per field and keep the suite fast.


### PR DESCRIPTION
## Summary

All testing rules and CR skills now explicitly prefer **partial mocks** (`Mockery::mock()->makePartial()` / `$this->partialMock()`) over full mocks:

- `rules/testing-conventions.mdc` — new rule: prefer partial mocks
- `rules/php/standards.mdc` — added partial mock preference after mock restriction
- `rules/laravel/architecture.mdc` — updated mock guidance + example uses `makePartial()`
- `skills/test-driven-development/SKILL.md` — added partial mock note to mock rule
- `skills/code-review/SKILL.md` — CR flags full mocks as Minor when partial would suffice

Closes #241

## Test plan

- [ ] Run `create-test` skill — verify generated mocks use `makePartial()` by default
- [ ] Run `code-review` on a PR with full mocks — verify Minor finding is raised suggesting partial mocks
- [ ] Run `test-driven-development` — verify mock examples use partial mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)