### PR TITLE
fix(skill): use tracker-specific CR skill in resolve-bugsnag-issue (#245)

### DIFF
--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -41,6 +41,6 @@ metadata:
 - If you are not on the main git branch in the project, switch to it.
 
 **After completing the tasks**
-- Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @skills/code-review/SKILL.md
+- Once you have finished your work and pushed the changes to pr, perform a code review according to your skill level @skills/code-review-github/SKILL.md
 - If according to @skills/test-like-human/SKILL.md the changes can be tested, do it!
 - If the work is done, run @skills/code-review-github/SKILL.md for the current issue.


### PR DESCRIPTION
## Summary
- Fixes `resolve-bugsnag-issue` skill to use `@skills/code-review-github/SKILL.md` in the "After completing" section instead of the generic `@skills/code-review/SKILL.md`
- All other resolve-* skills already correctly use their tracker-specific CR skill (`code-review-github` for GitHub/Bugsnag, `code-review-jira` for JIRA)

Closes #245

## Test plan
- [ ] Verify `resolve-bugsnag-issue` "After completing" section references `@skills/code-review-github/SKILL.md`
- [ ] Verify all resolve-* skills consistently use tracker-specific CR skills in their "After completing" sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)