### PR TITLE
feat(cr): add simplification analysis and unified test report to all CR skills

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -22,6 +22,7 @@ metadata:
 - Switch locally to the branch in PR and perform code review over changes locally on the filesystem.
 - Before writing findings, collect prior review comments/reports from the PR timeline and related issue discussion. Build a dedup list by problem signature (file/scope + root cause + risk) and skip findings already reported unless severity/impact changed.
 - **Plan Alignment Analysis:** Compare the implementation against the original issue description, planning documents, or step description. Identify deviations from the planned approach, architecture, or requirements. Assess whether deviations are justified improvements or problematic departures. Verify that all planned functionality has been implemented — list any missing or only partially met items.
+- **Simplification analysis:** Evaluate whether the solution can be written more simply without altering the new logic, leveraging rules and conventions already defined in `rules/**/*.mdc`. Flag unnecessary complexity as a finding.
 - **Regression analysis:** For every changed file, check whether the modifications could break existing functionality that is NOT part of the ticket scope. Trace callers and dependents of changed methods/classes. If a change alters shared logic (helpers, services, traits, base classes, interfaces), verify that all consumers still behave correctly. Flag any regression risk as a finding — even if the new code is correct in isolation, breaking unrelated features is **Critical**.
 - Always apply @skills/code-review/SKILL.md and @skills/security-review/SKILL.md. If the changes include any database-related modifications (migrations, schema changes, repositories, raw SQL, query builder, or Eloquent/queries in changed code), also apply @skills/mysql-problem-solver/SKILL.md for those parts; otherwise do not use the SQL skill. Find the issue by code or URL on GitHub.
 - **Race condition review (when shared state is modified):** If the changes contain any of the following signals — read-modify-write sequences, shared counters/balances/stock/quotas, `firstOrCreate`/`updateOrCreate`, retried or re-dispatched jobs that mutate shared records, cache write-back patterns, or bulk read-then-write operations — apply @skills/race-condition-review/SKILL.md. If none of these signals are present, skip this step.
@@ -35,7 +36,7 @@ metadata:
 - Use readable Markdown with clear section separators and include short code suggestions for simple fixes when helpful.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - If needed, use browser-based testing via available browser MCP tools
-- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, run @skills/test-like-human/SKILL.md before closing the review flow (when the changes are testable).
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, run @skills/test-like-human/SKILL.md before closing the review flow (when the changes are testable). The test-like-human skill must post its unified test report as a comment to the related issue in the issue tracker.
 
 **Communication protocol:**
 - Do not include praise/positive feedback; output must contain only findings.
@@ -44,5 +45,5 @@ metadata:
 - For implementation problems, provide clear guidance on fixes needed with code examples.
 
 **After completing the tasks**
-- Keep @skills/test-like-human/SKILL.md as a required final step only after **Critical** and **Moderate** findings are resolved and the changes are testable.
+- Keep @skills/test-like-human/SKILL.md as a required final step only after **Critical** and **Moderate** findings are resolved and the changes are testable. The test-like-human skill must post its unified test report as a comment to the related issue in the issue tracker.
 - Based on the discussion in the assignment, is the proposed solution to the problems safe and effective? Analyze the assignment and all discussions related to this task and write me your conclusion!

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -33,6 +33,7 @@ metadata:
 - Switch locally to the branch in PR and perform code review over changes locally on the filesystem.
 - Before writing findings, collect prior review comments/reports from the PR timeline and JIRA discussion. Build a dedup list by problem signature (file/scope + root cause + risk) and skip findings already reported unless severity/impact changed.
 - **Plan Alignment Analysis:** Compare the implementation against the original issue description, planning documents, or step description. Identify deviations from the planned approach, architecture, or requirements. Assess whether deviations are justified improvements or problematic departures. Verify that all planned functionality has been implemented — list any missing or only partially met items.
+- **Simplification analysis:** Evaluate whether the solution can be written more simply without altering the new logic, leveraging rules and conventions already defined in `rules/**/*.mdc`. Flag unnecessary complexity as a finding.
 - **Regression analysis:** For every changed file, check whether the modifications could break existing functionality that is NOT part of the ticket scope. Trace callers and dependents of changed methods/classes. If a change alters shared logic (helpers, services, traits, base classes, interfaces), verify that all consumers still behave correctly. Flag any regression risk as a finding — even if the new code is correct in isolation, breaking unrelated features is **Critical**.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - Always apply @skills/code-review/SKILL.md and @skills/security-review/SKILL.md. If the changes include any database-related modifications (migrations, schema changes, repositories, raw SQL, query builder, or Eloquent/queries in changed code), also apply @skills/mysql-problem-solver/SKILL.md for those parts; otherwise do not use the SQL skill.
@@ -50,7 +51,7 @@ metadata:
 - I want you to use the console cli tool to insert the CR result into the GitHub PR as a new comment. The PR comment must contain **only findings** grouped by severity (Critical → Moderate → Minor), each with file/line (or file) and a short, actionable recommendation. Do not include any summary, “what was checked”, or praise.
 - Run the tests and let me know if the current changes meet the requirements. If so, add a new comment to the issue with brief testing recommendations and include direct in-app links (full URLs) for each recommendation so testers can click through immediately. If the requirements are not met or you have found critical errors, just list them for me.
 - If needed, use browser-based testing via available browser MCP tools
-- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, run @skills/test-like-human/SKILL.md before closing the review flow (when the changes are testable).
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, run @skills/test-like-human/SKILL.md before closing the review flow (when the changes are testable). The test-like-human skill must post its unified test report as a comment to the related issue in the issue tracker.
 
 **Communication protocol:**
 - Do not include praise/positive feedback; output must contain only findings.
@@ -59,5 +60,5 @@ metadata:
 - For implementation problems, provide clear guidance on fixes needed with code examples.
 
 **After completing the tasks**
-- Keep @skills/test-like-human/SKILL.md as a required final step only after **Critical** and **Moderate** findings are resolved and the changes are testable.
+- Keep @skills/test-like-human/SKILL.md as a required final step only after **Critical** and **Moderate** findings are resolved and the changes are testable. The test-like-human skill must post its unified test report as a comment to the related issue in the issue tracker.
 - Based on the discussion in the assignment, is the proposed solution to the problems safe and effective? Analyze the assignment and all discussions related to this task and write me your conclusion!

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -17,6 +17,7 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - **Cancel CR if PR has conflicts!** If the PR has merge conflicts with the base branch, do not perform the code review; cancel and report that the CR was skipped due to conflicts.
 - Before writing findings, collect previous CR reports from the related PR/issue discussion and build a dedup list by problem signature (file/scope + risk + root cause). Do not repeat already reported findings unless severity or impact changed.
 - **Plan Alignment Analysis:** Compare the implementation against the original issue description, planning documents, or step description. Identify deviations from the planned approach, architecture, or requirements. Assess whether deviations are justified improvements or problematic departures. Verify that all planned functionality has been implemented — list any missing or only partially met items.
+- **Simplification analysis:** Evaluate whether the solution can be written more simply without altering the new logic, leveraging rules and conventions already defined in `rules/**/*.mdc`. Flag unnecessary complexity as a finding.
 - **Regression analysis:** For every changed file, check whether the modifications could break existing functionality that is NOT part of the ticket scope. Trace callers and dependents of changed methods/classes. If a change alters shared logic (helpers, services, traits, base classes, interfaces), verify that all consumers still behave correctly. Flag any regression risk as a finding — even if the new code is correct in isolation, breaking unrelated features is **Critical**.
 - **Security review (every CR):** Always apply @skills/security-review/SKILL.md for the current changes.
 - All changes must comply with `rules/**/*.mdc`.
@@ -113,4 +114,4 @@ description: Senior PHP code reviewer. Use when reviewing pull requests, examini
 - Findings are recommendations; final decisions remain with the human reviewer.
 
 **After completing the tasks**
-- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, then (and only then) run @skills/test-like-human/SKILL.md when the changes can be tested.
+- If all **Critical** and **Moderate** findings from the current CR cycle are resolved, then (and only then) run @skills/test-like-human/SKILL.md when the changes can be tested. The test-like-human skill must post its unified test report as a comment to the related issue in the issue tracker.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -21,6 +21,7 @@ metadata:
 - Build a checklist from all review findings and map each item to a concrete code or test change.
 - Ensure the checklist explicitly contains all reported **DRY violations** and tracks their resolution before triggering the next CR cycle.
 - Apply the requested changes and keep scope limited to review feedback. All new or modified production code must follow @skills/class-refactoring/SKILL.md.
+- **Simplification analysis:** Evaluate whether the solution can be written more simply without altering the new logic, leveraging rules and conventions already defined in `rules/**/*.mdc`. Flag unnecessary complexity as a finding.
 - Re-check current changes with @skills/code-review/SKILL.md and @skills/security-review/SKILL.md.  
 - If review feedback requires additional tests, use @skills/create-missing-tests-in-pr/SKILL.md and ensure current changes are fully covered.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
@@ -29,7 +30,7 @@ metadata:
   - GitHub issue flow: run @skills/code-review-github/SKILL.md
   - JIRA issue flow: run @skills/code-review-jira/SKILL.md
 - Fix all Critical and Moderate findings from that review and repeat the same review skill until no Critical or Moderate findings remain.
-- After the CR loop is clean (no **Critical** or **Moderate** findings), run @skills/test-like-human/SKILL.md when the change can be tested.
+- After the CR loop is clean (no **Critical** or **Moderate** findings), run @skills/test-like-human/SKILL.md when the change can be tested. The test-like-human skill must post its unified test report as a comment to the related issue in the issue tracker.
 - Commit all changes and push the branch. If no pull request exists for the current branch, create one according to @rules/git/pr.mdc rules — link it to the original issue and follow the PR description format (title in English, body in the language of the assignment). Do not create a new PR before the CR cycle is clean.
 - Update the review result comment in the pull request:
 - mark resolved points as checked items when possible, or


### PR DESCRIPTION
## Summary
- Added **Simplification analysis** step to all 4 code review skills (`code-review`, `code-review-github`, `code-review-jira`, `process-code-review`) — evaluates whether the solution can be written more simply without altering the new logic, leveraging existing rules defined in `rules/**/*.mdc`
- Made **test-like-human unified report** requirement explicit — every CR skill now states that test-like-human must post its unified test report as a comment to the related issue in the issue tracker

Closes #247

## Test plan
- [ ] Verify simplification analysis step is present in all 4 CR skills
- [ ] Verify unified test report requirement is explicitly stated in all CR skills
- [ ] Run a code review with any CR skill and confirm the simplification analysis is performed
- [ ] Confirm test-like-human posts report to the issue tracker after CR

🤖 Generated with [Claude Code](https://claude.com/claude-code)