### PR TITLE
fix(ci): consolidate all quality checks into a single job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,16 +6,10 @@ on:
   push:
     branches: [ master ]
 
-# To add more PHP versions, change ['8.4'] to ['8.4', '8.5'] in all matrix definitions below
-
 jobs:
-  phpcs-check:
-    name: "🔍 PHP CodeSniffer (PHP ${{ matrix.php-version }})"
+  quality-checks:
+    name: "🔍 Quality Checks (PHP 8.4)"
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version: ['8.4']
 
     steps:
       - name: Checkout code
@@ -24,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: '8.4'
           extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           coverage: pcov
 
@@ -33,188 +27,28 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-8.4-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-
+            ${{ runner.os }}-php-8.4-
             ${{ runner.os }}-php-
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-interaction
 
-      - name: Run PHPCS check
+      - name: "🔒 Security Audit"
+        run: composer security-audit
+
+      - name: "🔍 PHP CodeSniffer"
         run: composer phpcs-check
 
-  pint-check:
-    name: "🎨 Laravel Pint (PHP ${{ matrix.php-version }})"
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version: ['8.4']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
-          coverage: pcov
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
-
-      - name: Run Pint check
+      - name: "🎨 Laravel Pint"
         run: composer pint-check
 
-  rector-check:
-    name: "🔄 Rector (PHP ${{ matrix.php-version }})"
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version: ['8.4']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
-          coverage: pcov
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
-
-      - name: Run Rector check
+      - name: "🔄 Rector"
         run: composer rector-check
 
-  phpstan-analysis:
-    name: "🔎 PHPStan Analysis (PHP ${{ matrix.php-version }})"
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version: ['8.4']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
-          coverage: pcov
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
-
-      - name: Run PHPStan analysis
+      - name: "🔎 PHPStan Analysis"
         run: composer analyse
 
-  coverage-tests:
-    name: "📊 Coverage Tests (PHP ${{ matrix.php-version }})"
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version: ['8.4']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
-          coverage: pcov
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
-
-      - name: Run coverage tests
+      - name: "📊 Coverage Tests"
         run: composer test:coverage
-
-  audit-check:
-    name: "🔒 Security Audit (PHP ${{ matrix.php-version }})"
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php-version: ['8.4']
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
-          coverage: pcov
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v4
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
-
-      - name: Run security audit
-        run: composer security-audit


### PR DESCRIPTION
## Summary
- Merged 6 separate CI jobs (PHPCS, Pint, Rector, PHPStan, Coverage, Security Audit) into a single job running on one worker with PHP 8.4
- Eliminates 5 redundant checkout/setup-php/composer-install cycles, significantly reducing GitHub Actions minutes consumption

Closes #249

## Test plan
- [ ] Verify the consolidated workflow runs all 6 checks sequentially
- [ ] Confirm all checks pass on the PR
- [ ] Compare Actions minutes usage before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)