### PR TITLE
feat(skills): fix all CR findings (Critical+Moderate+Minor) before push in resolve skills

### DIFF
--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -30,8 +30,8 @@ metadata:
 - Apply @rules/testing-conventions.mdc
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
 - Before creating a PR, run @skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
-- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @skills/code-review-github/SKILL.md again.
-- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Fix all Critical, Moderate, and Minor findings from that CR directly in code/tests, then run @skills/code-review-github/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical, Moderate, or Minor findings left.
 - Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -33,8 +33,8 @@ metadata:
 - Apply @rules/testing-conventions.mdc
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
 - Before creating a PR, run @skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
-- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @skills/code-review-github/SKILL.md again.
-- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Fix all Critical, Moderate, and Minor findings from that CR directly in code/tests, then run @skills/code-review-github/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical, Moderate, or Minor findings left.
 - Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment into the pull request on GitHub regarding the core review, but I want you to only post critical or moderately serious issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue with the label ready for review.

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -75,8 +75,8 @@ h4. Testing recommendations
 - Apply @rules/testing-conventions.mdc
 - If there are any automatic fixers in the project that are called through another layer, such as Phing or composer scripts, run them and ensure automatic error correction (find and load local configs for tools if exists). If there are any CI (or local) checkers, run them (never run all tests for the entire codebase, only for the current changes). Fix any errors, run the fixers again, and keep fixing until all errors are fixed. Never try to format PHP code outside of these fixers yourself.
 - Before creating a PR, run @skills/code-review-jira/SKILL.md for the current changes and treat it as mandatory CR for JIRA flow.
-- Fix all Critical and Moderate findings from that CR directly in code/tests, then run @skills/code-review-jira/SKILL.md again.
-- Repeat the CR + fix cycle until there are no Critical or Moderate findings left.
+- Fix all Critical, Moderate, and Minor findings from that CR directly in code/tests, then run @skills/code-review-jira/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical, Moderate, or Minor findings left.
 - Only after the CR cycle is clean, automatically push the branch and create a GitHub pull request according to the pr.mdc rules. This step is mandatory; do not wait for additional confirmation.
 - If there is no link to the issue tracker, add a link to the issue tracker entry to the CR summary and, if possible, link it directly according to the issue tracker recommendations. Be sure to include an HTTP link.
 - I want you to post a comment on the core revision on GitHub, but I want you to post only critical or medium-severity issues, ideally including the lines of code that are affected. If there are none, don't post anything! If possible, mark the issue as ready for review.

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -19,8 +19,11 @@ metadata:
   List only those issues that are to be resolved by AI (they are tagged). Look for tasks labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only not resolved issues should be listed!
 - Randomly select one and try to resolve it. Use the skill @skills/resolve-jira-issue/SKILL.md.
 - Completion is valid only when the delegated flow creates a GitHub PR and links it in the selected JIRA issue.
+- Before pushing changes to PR, run @skills/code-review-jira/SKILL.md for the current changes and treat it as mandatory CR.
+- Fix all Critical, Moderate, and Minor findings from that CR directly in code/tests, then run @skills/code-review-jira/SKILL.md again.
+- Repeat the CR + fix cycle until there are no Critical, Moderate, or Minor findings left.
 
 **After completing the tasks**
-- Once the PR is created and pushed, perform a code review using @skills/code-review-jira/SKILL.md for the selected JIRA issue.
+- Once the PR is created and pushed, perform a final validation pass with @skills/code-review-jira/SKILL.md for the selected JIRA issue.
 - If according to @skills/test-like-human/SKILL.md the changes can be tested, do it!
 - If the work is done, run @skills/code-review-jira/SKILL.md for the current issue.


### PR DESCRIPTION
## Summary
- Updated all `resolve-*` skills to require fixing **Critical, Moderate, AND Minor** findings before pushing to PR (previously only Critical and Moderate)
- The CR + fix cycle now iterates until all severity levels are resolved
- Added explicit CR + fix cycle to `resolve-random-jira-issue` which previously lacked its own

### Updated skills:
- `resolve-github-issue` — uses `code-review-github`, now fixes all severities
- `resolve-bugsnag-issue` — uses `code-review-github`, now fixes all severities
- `resolve-jira-issue` — uses `code-review-jira`, now fixes all severities
- `resolve-random-jira-issue` — added full CR + fix cycle with `code-review-jira`

## Test plan
- [ ] Verify resolve skills iterate CR until all findings are resolved
- [ ] Verify Minor findings are now blocking (not just Critical/Moderate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)