### PR TITLE
fix(skills): code review before push and PR creation

### DIFF
--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 - Never combine multiple languages in your answer, e.g., one part in English and the other in Czech.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
-- Pull request creation is mandatory for every resolved Bugsnag issue. After checks pass, automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
+- Pull request creation is mandatory for every resolved Bugsnag issue. After the code review cycle is clean (no Critical, Moderate, or Minor findings), automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
 - **Safe error messages:** All user-facing error and validation messages must be written so they do not reveal internal implementation details, database structure, file paths, or technology specifics that could help an attacker deduce an exploit vector. Messages should be helpful for the user but not informative for an attacker.
 
 **Steps:**

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 - Apply @rules/base-constraints.mdc
 - Apply @rules/github-operations.mdc
 - If you are not on the main git branch in the project, switch to it.
-- Pull request creation is mandatory for every resolved GitHub issue. After checks pass, automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
+- Pull request creation is mandatory for every resolved GitHub issue. After the code review cycle is clean (no Critical, Moderate, or Minor findings), automatically push the branch and create a GitHub PR. Do not finish without a PR URL.
 - **Safe error messages:** All user-facing error and validation messages must be written so they do not reveal internal implementation details, database structure, file paths, or technology specifics that could help an attacker deduce an exploit vector. Messages should be helpful for the user but not informative for an attacker.
 
 **Steps:**

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 - Before resolving a task, always switch to the main branch, download the latest changes, and make sure you have the latest code in the main branch.
 - If you are not on the main git branch in the project, switch to it.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
-- Pull request creation is mandatory for every resolved JIRA issue. After checks pass, automatically push the branch and create a GitHub PR, then link it back to the JIRA issue. Do not finish without a PR URL.
+- Pull request creation is mandatory for every resolved JIRA issue. After the code review cycle is clean (no Critical, Moderate, or Minor findings), automatically push the branch and create a GitHub PR, then link it back to the JIRA issue. Do not finish without a PR URL.
 - **Safe error messages:** All user-facing error and validation messages must be written so they do not reveal internal implementation details, database structure, file paths, or technology specifics that could help an attacker deduce an exploit vector. Messages should be helpful for the user but not informative for an attacker.
 
 **Universal JIRA Comment Formatting**

--- a/skills/resolve-random-github-issue/SKILL.md
+++ b/skills/resolve-random-github-issue/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   List only those issues that are to be resolved by AI (they are tagged). Look for issues labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only open (not resolved) issues should be listed!
 - Randomly select one and try to resolve it. Use the skill @skills/resolve-github-issue/SKILL.md.
 - Completion is valid only when the delegated flow creates a GitHub PR and links it to the selected GitHub issue.
-- Before pushing changes to PR, run @skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
+- Before creating the PR, run @skills/code-review-github/SKILL.md for the current changes and treat it as mandatory CR.
 - Fix all Critical, Moderate, and Minor findings from that CR directly in code/tests, then run @skills/code-review-github/SKILL.md again.
 - Repeat the CR + fix cycle until there are no Critical, Moderate, or Minor findings left.
 

--- a/skills/resolve-random-jira-issue/SKILL.md
+++ b/skills/resolve-random-jira-issue/SKILL.md
@@ -20,7 +20,7 @@ metadata:
   List only those issues that are to be resolved by AI (they are tagged). Look for tasks labeled "Resolve_by_AI." If you are supposed to search in other places as well, find those other places too. Only not resolved issues should be listed!
 - Randomly select one and try to resolve it. Use the skill @skills/resolve-jira-issue/SKILL.md.
 - Completion is valid only when the delegated flow creates a GitHub PR and links it in the selected JIRA issue.
-- Before pushing changes to PR, run @skills/code-review-jira/SKILL.md for the current changes and treat it as mandatory CR.
+- Before creating the PR, run @skills/code-review-jira/SKILL.md for the current changes and treat it as mandatory CR.
 - Fix all Critical, Moderate, and Minor findings from that CR directly in code/tests, then run @skills/code-review-jira/SKILL.md again.
 - Repeat the CR + fix cycle until there are no Critical, Moderate, or Minor findings left.
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1110,6 +1110,35 @@ test('dry review rule is referenced by all code review flow skills', function ()
     }
 });
 
+test('resolve skills require code review cycle before PR creation', function (): void {
+    $packageDir = dirname(__DIR__);
+    $resolveSkills = [
+        $packageDir . '/skills/resolve-github-issue/SKILL.md',
+        $packageDir . '/skills/resolve-jira-issue/SKILL.md',
+        $packageDir . '/skills/resolve-bugsnag-issue/SKILL.md',
+    ];
+
+    foreach ($resolveSkills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->not->toContain('After checks pass, automatically push');
+        expect($content)->toContain('code review cycle is clean');
+    }
+});
+
+test('resolve-random skills use clear CR-before-PR phrasing', function (): void {
+    $packageDir = dirname(__DIR__);
+    $randomSkills = [
+        $packageDir . '/skills/resolve-random-github-issue/SKILL.md',
+        $packageDir . '/skills/resolve-random-jira-issue/SKILL.md',
+    ];
+
+    foreach ($randomSkills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain('Before creating the PR');
+        expect($content)->not->toContain('Before pushing changes to PR');
+    }
+});
+
 test('install with prune on non-existent target directory does nothing', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/skills/some-skill/SKILL.md', 'content');


### PR DESCRIPTION
## Summary
- Fixes constraint sections in 5 resolve skills that incorrectly suggested pushing/creating PR immediately after checks pass
- Now all constraints correctly state PR creation happens only after the CR cycle is clean (no Critical, Moderate, or Minor findings)
- Clarifies ambiguous "Before pushing changes to PR" phrasing in resolve-random skills to "Before creating the PR"

**Skills updated:**
- `resolve-github-issue`
- `resolve-jira-issue`
- `resolve-bugsnag-issue`
- `resolve-random-github-issue`
- `resolve-random-jira-issue`

Closes #291

## Test plan
- [x] 2 new regression tests ensuring correct phrasing in all resolve skills
- [x] All 75 tests pass
- [x] PHPCS, PHPStan, Pint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)