### PR TITLE
fix(skills): add CR steps to refactoring skills

### DIFF
--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -62,4 +62,6 @@ metadata:
 - Modify existing tests (unless refactoring requires it for consistency).
 
 **After completing the tasks**
+- Run @skills/code-review/SKILL.md for the current changes.
+- Run @skills/process-code-review/SKILL.md to resolve any findings from the code review.
 - If according to @skills/test-like-human/SKILL.md the changes can be tested, do it!

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -72,6 +72,10 @@ metadata:
 - Do not change unrelated behavior while refactoring.
 - Do not create `final class` wrappers with a single static method for simple utility logic — use a global helper function in `app/helpers.php` instead (see Custom Helpers in `@rules/laravel/architecture.mdc`).
 
+**After completing the tasks**
+- Run @skills/code-review/SKILL.md for the current changes.
+- Run @skills/process-code-review/SKILL.md to resolve any findings from the code review.
+
 **Definition of done:**
 - Target entry point method is thin and delegates to a dedicated Action.
 - Action respects all project Action-pattern constraints.

--- a/skills/seo-fix/SKILL.md
+++ b/skills/seo-fix/SKILL.md
@@ -42,6 +42,8 @@ metadata:
 - All new or modified production code must follow @skills/class-refactoring/SKILL.md.
 - If new database migrations were created during the changes, run them (`php artisan migrate`) before running tests or creating a PR.
 - Run existing tests that hit robots, sitemap, or assert head meta. Fix any failing assertions.
+- Run @skills/code-review/SKILL.md for the current changes.
+- Run @skills/process-code-review/SKILL.md to resolve any findings from the code review.
 
 **Checklist — new public page**
 - Page/route added; uses public (guest) layout and head with index,follow, canonical, sitemap link, title, description.


### PR DESCRIPTION
## Summary
- Skills that trigger `class-refactoring` (`class-refactoring`, `seo-fix`, `refactor-entry-point-to-action`) now automatically run `code-review` and `process-code-review` after completing work
- Ensures highest quality output by enforcing CR cycle on all refactoring-related skills

Closes #299

## Test plan
- [ ] Verify `class-refactoring/SKILL.md` contains code-review + process-code-review in "After completing" section
- [ ] Verify `seo-fix/SKILL.md` contains code-review + process-code-review in "After SEO changes" section
- [ ] Verify `refactor-entry-point-to-action/SKILL.md` has new "After completing the tasks" section with both CR steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)