### PR TITLE
feat(skills): add pre-existing bug resolution to code-creating skills

### DIFF
--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 - Apply @rules/testing-conventions.mdc
 
 **Steps:**
+- Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 - Analyze the class and complete the TODO list tasks.
 - Verify code coverage after refactoring.
 - For all changes in the current branch, analyze code coverage and ensure that all changes are covered by tests. Add any missing tests to ensure 100% coverage.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -16,6 +16,7 @@ metadata:
 - Apply @rules/jira-operations.mdc
 
 **Steps:**
+- Before applying review fixes, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main review-fix commit.
 - Identify the task from the provided issue code or URL.
 - Find all open pull requests for that task. If there are multiple open PRs, process each one sequentially — apply the full review-feedback resolution cycle to each PR independently before moving to the next.
 - In each pull request, locate code review output and all review comments (including review threads and general comments).

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -49,6 +49,7 @@ metadata:
 - Add or update PHPDoc where needed so PHPStan can infer intent/types without ambiguity (especially DTO shapes, iterable generics, and non-obvious contracts).
 
 **Steps:**
+0. Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 1. Analyze current implementation of the target entry point method and identify orchestration steps.
 2. Create a dedicated Action (one use case = one Action) in the correct domain folder under `app/Actions/**`.
 3. Move orchestration from controller method into Action `__invoke(...)`.

--- a/skills/resolve-bugsnag-issue/SKILL.md
+++ b/skills/resolve-bugsnag-issue/SKILL.md
@@ -17,6 +17,7 @@ metadata:
 - **Safe error messages:** All user-facing error and validation messages must be written so they do not reveal internal implementation details, database structure, file paths, or technology specifics that could help an attacker deduce an exploit vector. Messages should be helpful for the user but not informative for an attacker.
 
 **Steps:**
+- Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 - Analyze all comments in the issue tracker and check what needs to be done accordingly. Stick strictly to the assignment and comments!
 - I want you to fix the bug from Bugsnag (you either got an ID or a link to Bugsnag). Use the MCP server to get all the necessary information about the bug so you can fix it. If you have other resources available that you could use to understand the problem, load them and analyze them. Use the available CLI tools or MCP servers to load them. If you cannot load the issue, find out the available tools in the system and choose the most suitable tool to download the information.
 - Bugsnag issues always represent runtime errors or exceptions and are therefore always treated as bugs. Follow strict TDD:

--- a/skills/resolve-github-issue/SKILL.md
+++ b/skills/resolve-github-issue/SKILL.md
@@ -15,6 +15,7 @@ metadata:
 - **Safe error messages:** All user-facing error and validation messages must be written so they do not reveal internal implementation details, database structure, file paths, or technology specifics that could help an attacker deduce an exploit vector. Messages should be helpful for the user but not informative for an attacker.
 
 **Steps:**
+- Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - I want you to fix the bug from Github (you either got an ID or a link to Github). Use the available GitHub tools to get all the necessary information about the bug so you can fix it.
 - Classify the task type before writing any code:

--- a/skills/resolve-jira-issue/SKILL.md
+++ b/skills/resolve-jira-issue/SKILL.md
@@ -55,6 +55,7 @@ h4. Testing recommendations
 ```
 
 **Steps:**
+- Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 - Analyze all comments in the issue and create a list of tasks from the assignment and comments so that you can resolve all issues, if they have not already been resolved.
 - I want you to fix the bug from JIRA (you have either the ID or a link to JIRA).
   Use the preferred JIRA tool (see @rules/jira-operations.mdc) to retrieve all issue details (including comments and attachments).

--- a/skills/seo-fix/SKILL.md
+++ b/skills/seo-fix/SKILL.md
@@ -19,6 +19,7 @@ metadata:
 - **Tests** — Feature or E2E tests for robots response, sitemap response, and head meta (e.g. sitemap link, robots meta). Keep them green after changes.
 
 **Steps:**
+- Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 
 **robots.txt**
 - Response headers: `Content-Type: text/plain; charset=UTF-8`, `X-Robots-Tag: noindex`.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -21,6 +21,7 @@ NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
 Write code before the test? Delete it. Start over. No exceptions.
 
 **Steps:**
+- Before implementing the main change, scan the affected files for pre-existing bugs (broken logic, incorrect behavior, type errors, deprecated patterns). Fix all identified pre-existing bugs in a separate commit before the main implementation commit.
 
 ## 1. RED - Write Failing Test
 


### PR DESCRIPTION
## Summary
- All skills that create or modify production code now include a mandatory step to scan affected files for pre-existing bugs before the main implementation
- Pre-existing bugs are fixed in a separate commit to keep the main change clean and traceable
- Affected skills: `resolve-github-issue`, `resolve-jira-issue`, `resolve-bugsnag-issue`, `class-refactoring`, `refactor-entry-point-to-action`, `process-code-review`, `seo-fix`, `test-driven-development`

Closes #300

## Test plan
- [ ] Verify each of the 8 affected SKILL.md files contains the pre-existing bug resolution step
- [ ] Verify the step is placed at the beginning of the **Steps** section
- [ ] Verify test-only skills (create-test, rewrite-tests-pest, create-missing-tests-in-pr) are NOT affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)