### PR TITLE
style(claude): sync arrow formatting with upstream source

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -47,15 +47,15 @@ The test: Every changed line should trace directly to the user's request.
 **Define success criteria. Loop until verified.**
 
 Transform tasks into verifiable goals:
-- "Add validation" -> "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" -> "Write a test that reproduces it, then make it pass"
-- "Refactor X" -> "Ensure tests pass before and after"
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
 
 For multi-step tasks, state a brief plan:
 ```
-1. [Step] -> verify: [check]
-2. [Step] -> verify: [check]
-3. [Step] -> verify: [check]
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
 ```
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.


### PR DESCRIPTION
## Summary
- Synced `claude.md` arrow formatting (`->` → `→`) with upstream [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) repository
- No functional changes — formatting-only sync

## Context
- The CLAUDE.md installer infrastructure was added in fe25f80 (`feat(installer): add CLAUDE.md installation support (#289)`)
- This PR completes issue #309 by syncing the remaining content difference (arrow characters) with upstream

Closes #309

## Test plan
- [x] All tests pass
- [x] `claude.md` content matches upstream exactly
- [x] CLAUDE.md installation tests pass for all editor modes