### PR TITLE
feat(rules): add SSL, HTTP methods, and auth testing rules

### DIFF
--- a/.claude/rules/security/backend.md
+++ b/.claude/rules/security/backend.md
@@ -1,0 +1,50 @@
+---
+description: Backend security rules based on SecureCodeWarrior AI Security Rules. Apply when reviewing or writing server-side code.
+alwaysApply: true
+---
+
+## General Secure Coding Practices
+- Validate and sanitize all user inputs to prevent injection attacks.
+- Use error handling without revealing sensitive information.
+- Avoid exposing sensitive data in API responses.
+- Do not hardcode any secrets (credentials, API keys, etc) in the source code or configuration files.
+
+## HTTP Security headers and Cookies
+- Enforce SSL/TLS for all HTTP traffic in production environments.
+- Use a Content Security Policy (CSP) to protect against XSS and clickjacking attacks.
+- Set cookies with `HttpOnly`, `Secure`, and `SameSite` attributes.
+- Enforce strict CORS policies for cookies.
+
+### CSRF Protection
+Apply the following rules only if authentication relies on cookies instead of tokens.
+- Use anti-CSRF tokens for state-changing operations.
+- Validate `Origin` and `Referer` headers for non-GET requests.
+- Require re-authentication before performing sensitive actions.
+
+## Output Rendering
+- Ensure output is encoded correctly for the corresponding context.
+- Escape special characters in output to prevent injection attacks.
+
+## Database
+- Use parameterized queries or ORM to prevent injections.
+- Implement proper authentication and authorization.
+- Handle sensitive data properly.
+- Monitor security issues.
+- Apply the principle of least privilege to database users.
+
+## API Security
+- Apply authentication and integrity checks on all API requests.
+- Use the appropriate HTTP method for each route action (e.g. POST/PUT for mutations, DELETE for removals — never GET for state-changing operations).
+- Configure CORS policies to restrict cross-origin access to trusted domains only.
+- Apply rate limiting to manage traffic.
+- Enforce security headers.
+- Handle errors securely without revealing sensitive details to end users.
+- Log access and actions for monitoring, auditing, and detecting abnormal activity.
+- Include automated tests to verify that authorization rules are enforced and only permitted users can access protected functionality.
+
+## External Requests
+- Restrict outbound requests to only necessary external services and internal endpoints.
+- Use allowlists to define permitted destinations instead of blocking known bad domains.
+- Disable unnecessary URL fetching capabilities in your application.
+- Validate and sanitize all user-supplied URLs before making requests.
+- Implement request timeouts and rate limits to prevent abuse.


### PR DESCRIPTION
## Summary
Closes #319

Analyzoval jsem navržená pravidla z issue a přidal je do `.claude/rules/security/backend.md`:

- **SSL/TLS** — přidáno do sekce "HTTP Security headers and Cookies": vynucení SSL pro veškerý HTTP provoz v produkci
- **Správné HTTP metody** — přidáno do sekce "API Security": použití odpovídajících HTTP metod pro akce (POST/PUT pro mutace, DELETE pro mazání, nikdy GET pro změny stavu)
- **Testy autorizace** — přidáno do sekce "API Security": automatické testy ověřující, že autorizační pravidla fungují správně

**Přeskočeno:** CSRF token pravidlo — již pokryto v sekci "CSRF Protection".

## Test plan
- [ ] Ověřit, že přidaná pravidla odpovídají návrhům z issue
- [ ] Zkontrolovat, že existující pravidla nebyla změněna
- [ ] Ověřit správné zařazení do sekcí

🤖 Generated with [Claude Code](https://claude.com/claude-code)