### PR TITLE
fix(rules): add Pest.php base test class rule for Laravel projects

### DIFF
--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -13,6 +13,7 @@ globs: []
 - Never use `describe()`; use top-level `it()` / `test()` only.
 - Test classes should be `final`.
 - Prefer local variables; avoid shared mutable state.
+- In Laravel Pest projects, define `uses(Tests\TestCase::class)` in `tests/Pest.php` instead of repeating it in every test file.
 
 ## Data Handling
 - For Laravel:


### PR DESCRIPTION
## Summary
Closes #318

Přidáno pravidlo do `rules/code-testing/general.mdc`:

- V Laravel Pest projektech definovat `uses(Tests\TestCase::class)` centrálně v `tests/Pest.php` místo opakování v každém testovacím souboru.

Pravidlo se automaticky aplikuje ve všech skills, které odkazují na `@rules/code-testing/general.mdc` (`create-test`, `rewrite-tests-pest`, `create-missing-tests-in-pr`).

## Test plan
- [ ] Ověřit, že pravidlo je správně zařazeno v sekci Testing Rules
- [ ] Ověřit, že existující pravidla nebyla změněna
- Tests: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)