### PR TITLE
fix(rules): add parallel test execution rule

### DIFF
--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -43,5 +43,8 @@ globs: []
 ## Scope
 - Focus tests on behavior, not implementation details.
 
+## Execution
+- Run tests in parallel whenever possible (e.g. `php artisan test --parallel` or `pest --parallel`).
+
 ## Quality
 - Prefer simple, readable tests over complex setups.


### PR DESCRIPTION
## Summary
Closes #317

Přidáno pravidlo do `rules/code-testing/general.mdc`:

- Spouštět testy paralelně kdykoli je to možné (`php artisan test --parallel` nebo `pest --parallel`).

Pravidlo je v nové sekci "Execution" a automaticky se aplikuje ve všech skills odkazujících na `@rules/code-testing/general.mdc`.

## Test plan
- [ ] Ověřit správné zařazení pravidla
- [ ] Ověřit, že existující pravidla nebyla změněna
- Tests: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)