### PR TITLE
fix(skills): validate issue belongs to current project before resolving

### DIFF
--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -40,24 +40,28 @@ If the source cannot be determined, ask the user.
 
 ## Execution
 
-1. Fetch and analyze the issue from the detected source.
-2. Define exact requirements and expected behavior.
-3. Classify the task (bug or feature).
+1. Verify the issue belongs to the current project before proceeding:
+   - **GitHub:** the issue repository must match the current Git remote origin.
+   - **JIRA:** the issue project key must match the configured JIRA project for this repository.
+   - If the issue does not belong to the current project, refuse to process it and inform the user.
+2. Fetch and analyze the issue from the detected source.
+3. Define exact requirements and expected behavior.
+4. Classify the task (bug or feature).
 
 ### If bug
-4. Reproduce the issue if possible.
-5. Write or update a test capturing the failure.
-6. Confirm the failure before applying the fix.
+5. Reproduce the issue if possible.
+6. Write or update a test capturing the failure.
+7. Confirm the failure before applying the fix.
 
 ### If feature
-4. Design a minimal implementation aligned with project architecture.
+5. Design a minimal implementation aligned with project architecture.
 
 ### Continue
-7. Implement the solution.
-8. Ensure no sensitive data is exposed in error/validation messages.
-9. Run tests for affected areas and confirm correctness.
-10. Add or update tests to cover the new or fixed behavior.
-11. Run project fixers and resolve issues for changed files.
+8. Implement the solution.
+9. Ensure no sensitive data is exposed in error/validation messages.
+10. Run tests for affected areas and confirm correctness.
+11. Add or update tests to cover the new or fixed behavior.
+12. Run project fixers and resolve issues for changed files.
 
 ## Code quality and review
 - Run `@skills/code-review/SKILL.md`


### PR DESCRIPTION
## Summary
Closes #316

Přidána validace do `skills/resolve-issue/SKILL.md` jako první krok v execution flow:

- **GitHub:** issue repozitář musí odpovídat aktuálnímu Git remote origin
- **JIRA:** project key issue musí odpovídat nakonfigurovanému JIRA projektu pro tento repozitář
- Pokud issue nepatří do aktuálního projektu, skill odmítne zpracování a informuje uživatele

## Test plan
- [ ] Ověřit, že validační krok je správně zařazen jako krok 1
- [ ] Ověřit, že navazující číslování kroků je konzistentní
- [ ] Ověřit, že existující chování nebylo změněno
- Tests: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)