### PR TITLE
fix(rules + skills): PHP Data Validators encapsulation

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -38,7 +38,7 @@ globs:
 - **Single-use Service/Facade method rule (Action pattern):** If an Action calls a Service or Facade method that is used only once in the entire codebase, move the business logic from that Service/Facade method directly into the Action and remove the original Service/Facade method.
 - **Invokeable controller rule:** Any controller method that is not a standard CRUD method (`index`, `create`, `store`, `show`, `edit`, `update`, `destroy`) must be extracted into a dedicated single-action invokeable controller with only `__invoke()`. Resource controllers must only contain CRUD methods.
 - **BaseModelService pattern (only when `vendor/pekral/arch-app-services` exists):** All services that primarily work with a specific Eloquent Model must extend `BaseModelService` and implement `getModelManager()`, `getRepository()`, and `getModelClass()` (see `vendor/pekral/arch-app-services/examples/Services/User/UserModelService.php`). Services that do not primarily serve a single model must be refactored into Action pattern classes.
-- **Data Validator extraction (only when `vendor/pekral/arch-app-services` exists):** If an Action class contains inline validation logic (throwing `ValidationException` directly or calling `Validator::make()`), extract it into a dedicated Data Validator class under `app/DataValidators/{Domain}/`.
+- **Data Validator extraction (only when `vendor/pekral/arch-app-services` exists):** If an Action class contains inline validation logic (throwing `ValidationException` directly or calling `Validator::make()`), extract it into a dedicated Data Validator class. Default location is `app/DataValidators/{Domain}/`, but follow the project's existing convention if different.
 - **Livewire components (only in Livewire projects):** Livewire components are entry points — they must not contain business logic. Split every component into a PHP class (`app/Livewire/`) and a Blade view (`resources/views/livewire/`). Never use single-file (Volt) components. Delegate all business logic to Action classes.
 - **Validation rules as traits:** Extract reusable validation rules into traits in `App\Concerns`. Use these traits in FormRequest classes instead of duplicating rule arrays.
 - **Custom Rule classes reuse:** Before adding inline validation logic to a FormRequest, scan `app/Rules/` for existing custom Rule classes that already implement the required validation. Use existing custom rules instead of duplicating logic. During code review, flag any FormRequest that duplicates logic already covered by an existing custom Rule class.
@@ -112,7 +112,7 @@ globs:
 - Actions must not call `Validator::make()` inline.
 - Controllers must not call `Validator::make()` inline — use FormRequest or delegate to a Data Validator via an Action.
 - Data Validators are responsible for validating input data and throwing `ValidationException` when needed.
-- Store Data Validators under `app/DataValidators/{Domain}`.
+- Store Data Validators under `app/DataValidators/{Domain}` by default, but follow the project's existing namespace convention if different.
 - Use the `DataValidator` suffix.
 - Data Validators should be `final readonly` with constructor injection and a single public method `validate()`.
 - **When `pekral/arch-app-services` is installed:** Data Validator classes must use the `Pekral\Arch\DataValidation\DataValidator` trait, which provides the `$this->validate($data, $rules, $messages)` method. Do not call `Validator::make()` directly — always use `$this->validate()` from the trait.

--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -107,13 +107,16 @@ globs:
 - Place DTOs under `app/Dto/{Domain}` and use a `Data` suffix.
 
 ## Data Validators
-- Validation logic inside Actions must be encapsulated in dedicated Data Validator classes.
+- All data validation logic must be encapsulated in dedicated Data Validator classes — never inline in Actions, controllers, jobs, commands, listeners, or Livewire components.
 - Actions must not throw `ValidationException` directly.
 - Actions must not call `Validator::make()` inline.
+- Controllers must not call `Validator::make()` inline — use FormRequest or delegate to a Data Validator via an Action.
 - Data Validators are responsible for validating input data and throwing `ValidationException` when needed.
 - Store Data Validators under `app/DataValidators/{Domain}`.
 - Use the `DataValidator` suffix.
-- Data Validators should be `final readonly` with constructor injection and a single public method such as `validate()`.
+- Data Validators should be `final readonly` with constructor injection and a single public method `validate()`.
+- **When `pekral/arch-app-services` is installed:** Data Validator classes must use the `Pekral\Arch\DataValidation\DataValidator` trait, which provides the `$this->validate($data, $rules, $messages)` method. Do not call `Validator::make()` directly — always use `$this->validate()` from the trait.
+- **When `pekral/arch-app-services` is installed:** Data Validator classes may implement the `Pekral\Arch\DataValidation\ValidationRules` interface to expose validation rules via a static `rules()` method for reuse.
 - Reusable validation traits in `App\Concerns` may be used inside Data Validators.
 - Actions must call Data Validators before business orchestration.
 
@@ -167,12 +170,15 @@ globs:
   - new orchestration that bypasses Actions
   - inline `Validator::make()` inside Actions
   - `ValidationException` thrown directly inside Actions
+  - validation logic not encapsulated in a dedicated Data Validator class (e.g. inline validation in controllers, jobs, commands, listeners, or Livewire components outside of FormRequest)
+  - Data Validator class calling `Validator::make()` directly when `pekral/arch-app-services` is installed (must use `DataValidator` trait and `$this->validate()`)
   - services tied to one model that do not extend `BaseModelService`
   - non-CRUD methods inside resource controllers
 - Mark as moderate:
   - calling Actions via `->__invoke()` instead of `$action(...)`
   - DTOs overriding `from()` only for key renaming instead of using mapping attributes
   - plain service classes used where an Action is the better fit
+  - Data Validator class not implementing `ValidationRules` interface when rules could be reused
 
 ## Exceptions
 - No Action is required for:

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -24,10 +24,12 @@ globs:
 - Data Builders: transform DTOs only, never query the database.
 
 ## Validation
-- Use FormRequest classes for controller validation.
+- Use FormRequest classes for controller input validation.
 - Store reusable validation rules as traits in `App\\Concerns`.
 - Use custom Rule classes in `App\\Rules` for complex reusable validation.
 - Before adding inline validation logic, check whether a reusable rule already exists.
+- All non-FormRequest validation logic must be encapsulated in dedicated Data Validator classes under `app/DataValidators/{Domain}/`. Never inline `Validator::make()` or throw `ValidationException` directly in Actions, controllers, jobs, commands, listeners, or Livewire components.
+- When `pekral/arch-app-services` is installed, Data Validators must use the `DataValidator` trait and call `$this->validate()` — see `@rules/laravel/architecture.mdc` for details.
 
 ## DTOs
 - Prefer typed DTOs over raw arrays across layer boundaries.

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -28,7 +28,7 @@ globs:
 - Store reusable validation rules as traits in `App\\Concerns`.
 - Use custom Rule classes in `App\\Rules` for complex reusable validation.
 - Before adding inline validation logic, check whether a reusable rule already exists.
-- All non-FormRequest validation logic must be encapsulated in dedicated Data Validator classes under `app/DataValidators/{Domain}/`. Never inline `Validator::make()` or throw `ValidationException` directly in Actions, controllers, jobs, commands, listeners, or Livewire components.
+- All non-FormRequest validation logic must be encapsulated in dedicated Data Validator classes (default location `app/DataValidators/{Domain}/`, but follow the project's existing convention). Never inline `Validator::make()` or throw `ValidationException` directly in Actions, controllers, jobs, commands, listeners, or Livewire components.
 - When `pekral/arch-app-services` is installed, Data Validators must use the `DataValidator` trait and call `$this->validate()` — see `@rules/laravel/architecture.mdc` for details.
 
 ## DTOs

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -38,6 +38,7 @@ Perform structured code review focused on:
 - Business logic correctness
 - Missing or incorrect behavior
 - Type safety and error handling
+- Data validation encapsulation — verify that all validation logic is in dedicated Data Validator classes or FormRequests, not inline in Actions, controllers, jobs, commands, listeners, or Livewire components (see `@rules/laravel/architecture.mdc` Data Validators section)
 
 ### Specialized Reviews (when relevant)
 

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -36,7 +36,7 @@ Example input:
 - Action class must be `final readonly`.
 - Action must expose exactly one public business method: `__invoke(...)` with an explicit return type.
 - Action must orchestrate only: validation, mapping, and delegation.
-- Do not place inline validation inside the Action. Use a dedicated Data Validator under `app/DataValidators/<Domain>/`.
+- Do not place inline validation inside the Action. Use a dedicated Data Validator (default location `app/DataValidators/<Domain>/`, but follow the project's existing convention).
 - Do not use direct Eloquent queries or `DB::` calls inside the Action.
 - Keep reads in repositories and writes in model managers/services according to project architecture.
 - Add or update PHPDoc where needed for PHPStan clarity.

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -30,6 +30,7 @@ Avoid generic best-practice noise.
 - SQL / command injection
 - XSS (stored, reflected, DOM)
 - unsafe deserialization
+- scattered or inline validation logic (validation not encapsulated in Data Validator classes or FormRequests increases risk of bypassed or inconsistent input checks)
 
 ### Authentication & Access Control
 - missing authorization (IDOR / BOLA)

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -30,7 +30,6 @@ Avoid generic best-practice noise.
 - SQL / command injection
 - XSS (stored, reflected, DOM)
 - unsafe deserialization
-- scattered or inline validation logic (validation not encapsulated in Data Validator classes or FormRequests increases risk of bypassed or inconsistent input checks)
 
 ### Authentication & Access Control
 - missing authorization (IDOR / BOLA)


### PR DESCRIPTION
## Summary
- Updated `rules/laravel/architecture.mdc` to enforce that all validation logic is encapsulated in dedicated Data Validator classes, with mandatory use of the `DataValidator` trait and `$this->validate()` from `pekral/arch-app-services` when the package is installed.
- Updated `rules/laravel/laravel.mdc` Validation section to reference the Data Validator pattern for non-FormRequest validation.
- Updated `skills/code-review/SKILL.md` to include data validation encapsulation as a core analysis check point.
- Added CR severity rules for validation encapsulation violations (critical) and missing `ValidationRules` interface (moderate).

Closes #326

## Test plan
- [ ] Verify `composer build` passes with all checks green
- [ ] Confirm code review skill flags inline `Validator::make()` outside Data Validators as critical
- [ ] Confirm architecture rule correctly references `DataValidator` trait and `ValidationRules` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)