### PR TITLE
feat(rules): custom validation rules creation enforcement

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -41,7 +41,7 @@ globs:
 - **Data Validator extraction (only when `vendor/pekral/arch-app-services` exists):** If an Action class contains inline validation logic (throwing `ValidationException` directly or calling `Validator::make()`), extract it into a dedicated Data Validator class. Default location is `app/DataValidators/{Domain}/`, but follow the project's existing convention if different.
 - **Livewire components (only in Livewire projects):** Livewire components are entry points — they must not contain business logic. Split every component into a PHP class (`app/Livewire/`) and a Blade view (`resources/views/livewire/`). Never use single-file (Volt) components. Delegate all business logic to Action classes.
 - **Validation rules as traits:** Extract reusable validation rules into traits in `App\Concerns`. Use these traits in FormRequest classes instead of duplicating rule arrays.
-- **Custom Rule classes reuse:** Before adding inline validation logic to a FormRequest, scan `app/Rules/` for existing custom Rule classes that already implement the required validation. Use existing custom rules instead of duplicating logic. During code review, flag any FormRequest that duplicates logic already covered by an existing custom Rule class.
+- **Custom Rule classes reuse:** Before adding validation logic, scan `app/Rules/` for existing custom Rule classes that already implement the required validation. If a matching Rule exists, use it. If no matching Rule exists and the validation logic is non-trivial or reusable, create a new custom Rule class in `app/Rules/` and use it. During code review, flag any FormRequest or Data Validator that duplicates logic already covered by an existing custom Rule class or that contains non-trivial inline validation that should be a custom Rule.
 - **Laravel AI SDK:** When implementing AI features in a Laravel project, always use the [Laravel AI SDK](https://laravel.com/docs/13.x/ai-sdk). Never call AI provider APIs directly when the Laravel AI SDK covers the use case.
 - **Custom Helpers:** Small utility functions that don't belong to any specific class (cache key generators, input validators, formatters) must be implemented as **global helper functions** in `app/helpers.php` (autoloaded via `composer.json` `files` key). Follow the [Laravel News helpers pattern](https://laravel-news.com/creating-helpers): plain functions, no wrapper classes, snake_case names. Do **not** create `final class` wrappers with a single static method for simple utility logic — use a helper function instead.
 
@@ -179,6 +179,7 @@ globs:
   - DTOs overriding `from()` only for key renaming instead of using mapping attributes
   - plain service classes used where an Action is the better fit
   - Data Validator class not implementing `ValidationRules` interface when rules could be reused
+  - non-trivial or reusable validation logic written inline instead of as a custom Rule class in `app/Rules/`
 
 ## Exceptions
 - No Action is required for:

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -26,8 +26,8 @@ globs:
 ## Validation
 - Use FormRequest classes for controller input validation.
 - Store reusable validation rules as traits in `App\\Concerns`.
-- Use custom Rule classes in `App\\Rules` for complex reusable validation.
-- Before adding inline validation logic, check whether a reusable rule already exists.
+- Use custom Rule classes in `App\\Rules` for complex or reusable validation.
+- Before adding validation logic, check `app/Rules/` for an existing custom Rule. If none exists and the logic is non-trivial or reusable, create a new custom Rule class and use it.
 - All non-FormRequest validation logic must be encapsulated in dedicated Data Validator classes (default location `app/DataValidators/{Domain}/`, but follow the project's existing convention). Never inline `Validator::make()` or throw `ValidationException` directly in Actions, controllers, jobs, commands, listeners, or Livewire components.
 - When `pekral/arch-app-services` is installed, Data Validators must use the `DataValidator` trait and call `$this->validate()` — see `@rules/laravel/architecture.mdc` for details.
 


### PR DESCRIPTION
## Summary
- Updated `rules/laravel/architecture.mdc` to enforce creating new custom Rule classes in `app/Rules/` when non-trivial or reusable validation logic is needed and no matching Rule exists yet.
- Updated `rules/laravel/laravel.mdc` Validation section with the same guidance.
- Added CR severity rule (moderate) for inline non-trivial validation that should be a custom Rule.

Closes #327

## Test plan
- [ ] Verify `composer build` passes
- [ ] Confirm code review flags inline non-trivial validation as moderate when a custom Rule should be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)