### PR TITLE
fix(skills): switch to PR branch before code review

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -27,6 +27,7 @@ Run a full code review for GitHub pull requests and publish findings directly to
 ### 1. Load Context
 - Load PR, linked issue, and comments using CLI or MCP tools
 - If multiple PRs exist for one issue, review each independently
+- Before reviewing a PR, switch to the PR branch and pull latest changes
 
 ### 2. Pre-checks
 - If PR has merge conflicts → cancel review

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -31,6 +31,7 @@ Perform code review for JIRA issues by analyzing related pull requests and publi
 ### 1. Load Context
 - Load JIRA issue, comments, and attachments
 - Identify all open PRs linked to the issue
+- Before reviewing a PR, switch to the PR branch and pull latest changes
 
 ### 2. Pre-checks
 - If PR has conflicts → skip review for that PR

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -28,6 +28,7 @@ Perform structured code review focused on:
 
 ## Execution
 
+- Before starting, ensure you are on the branch that contains the changes to review. If not, switch to it.
 - Identify changes vs main branch.
 - Understand context (issue, PR description, comments).
 - Deduplicate previous findings.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -23,6 +23,7 @@ metadata:
 - Identify the task from the provided issue code or URL
 - Find all open pull requests for the task
   - If multiple PRs exist, process each independently
+- Before processing a PR, switch to the PR branch and pull latest changes
 
 ### For each PR:
 

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -63,12 +63,6 @@ If the source cannot be determined, ask the user.
 11. Add or update tests to cover the new or fixed behavior.
 12. Run project fixers and resolve issues for changed files.
 
-## Code quality and review
-- Run `@skills/code-review/SKILL.md`
-- Run `@skills/security-review/SKILL.md`
-- Fix all critical and moderate findings by `@skills/process-code-review/SKILL.md` before proceeding
-- Run `@skills/test-like-human/SKILL.md`
-
 ## Pull request
 - Create a branch and commit changes following `@rules/git/general.mdc`
 - Create a pull request with:
@@ -76,18 +70,43 @@ If the source cannot be determined, ask the user.
   - reference to the original issue
   - testing instructions
 
-### JIRA-specific follow-up
-- Link the created PR back to the JIRA issue
-- Add a JIRA comment (using JIRA formatting rules) that is understandable by non-technical testers and product managers, containing:
+## Code quality and review loop
+
+After the pull request is created, run the following review loop:
+
+1. Run `@skills/code-review/SKILL.md`
+2. If **Critical** or **Moderate** findings exist:
+   - Run `@skills/process-code-review/SKILL.md` to fix them
+   - Repeat from step 1
+3. Iterate until no **Critical** or **Moderate** findings remain
+
+After the review loop passes clean:
+
+4. Run `@skills/security-review/SKILL.md`
+5. Run `@skills/test-like-human/SKILL.md`
+
+## Final report
+
+Post the final report (code review result, security review result, and test-like-human result) back to the issue tracker where the assignment originated:
+
+- **GitHub:** post as a comment on the original issue
+- **JIRA:** post as a JIRA comment (using JIRA formatting rules) understandable by non-technical testers and product managers, containing:
   - **What changed:** a brief, plain-language summary of the fix or feature
   - **How to test:** step-by-step instructions a tester can follow to verify the change works correctly
   - **Risk areas and edge cases:** specific scenarios the tester should focus on to catch potential regressions or unexpected behavior
+- **Bugsnag:** post as a comment on the linked GitHub issue (if available)
+
+### JIRA-specific follow-up
+- Link the created PR back to the JIRA issue
 
 ## Done when
 - The issue is fully addressed
 - Behavior is correct and stable
 - Tests cover affected logic and pass
 - No sensitive data is exposed
-- Code review and security review findings are resolved
+- Code review loop passed with no Critical or Moderate findings
+- Security review completed
+- Test-like-human completed
+- Final report posted to the issue tracker
 - A clean pull request is created
 - For JIRA issues: PR is linked back and a summary comment is posted

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1103,7 +1103,8 @@ test('dry review rule is referenced by process-code-review skill', function (): 
 test('unified resolve-issue skill requires code review before PR creation', function (): void {
     $packageDir = dirname(__DIR__);
     $content = (string) file_get_contents($packageDir . '/skills/resolve-issue/SKILL.md');
-    expect($content)->toContain('Code review and security review findings are resolved');
+    expect($content)->toContain('Code review loop passed with no Critical or Moderate findings');
+    expect($content)->toContain('Security review completed');
     expect($content)->not->toContain('After checks pass, automatically push');
 });
 


### PR DESCRIPTION
## Summary
- Všechny code review skilly (`code-review`, `code-review-github`, `code-review-jira`, `process-code-review`) nyní před zahájením review přepnou na správnou branch s PR změnami
- Zajišťuje, že review běží proti aktuálnímu kódu, ne proti jiné větvi

Closes #334

## Test plan
- [ ] Spustit `code-review-github` na existující PR a ověřit, že se přepne na správnou branch
- [ ] Spustit `code-review-jira` na JIRA issue s PR a ověřit přepnutí branch
- [ ] Spustit `process-code-review` a ověřit, že pracuje na PR branch
- [ ] Ověřit, že `code-review` přepne na branch se změnami před analýzou