### PR TITLE
fix(skills): require full issue context analysis before code review

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -29,6 +29,18 @@ Run a full code review for GitHub pull requests and publish findings directly to
 - If multiple PRs exist for one issue, review each independently
 - Before reviewing a PR, switch to the PR branch and pull latest changes
 
+#### Issue Context Analysis
+Before reviewing code, load and analyze the full linked issue:
+
+1. Fetch the complete GitHub issue — description, all comments, and any referenced attachments or links.
+2. Extract from the issue:
+   - **Requirements and acceptance criteria** — what the code must do
+   - **Expected behavior** — how the feature or fix should work
+   - **Edge cases and constraints** — mentioned by the reporter or in comments
+   - **Test data** — any sample inputs, payloads, or scenarios provided in the issue
+3. Use this context to evaluate whether the implementation fully satisfies the issue — not just whether the code is technically correct.
+4. If the issue contains test data or test scenarios, verify they are covered by existing or new tests. Flag missing test coverage as a finding.
+
 ### 2. Pre-checks
 - If PR has merge conflicts → cancel review
 

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -33,6 +33,18 @@ Perform code review for JIRA issues by analyzing related pull requests and publi
 - Identify all open PRs linked to the issue
 - Before reviewing a PR, switch to the PR branch and pull latest changes
 
+#### Issue Context Analysis
+Before reviewing code, load and analyze the full JIRA issue:
+
+1. Fetch the complete JIRA issue — description, all comments, and all attachments (screenshots, files, embedded data).
+2. Extract from the issue:
+   - **Requirements and acceptance criteria** — what the code must do
+   - **Expected behavior** — how the feature or fix should work
+   - **Edge cases and constraints** — mentioned by the reporter or in comments
+   - **Test data** — any sample inputs, payloads, or scenarios provided in the issue
+3. Use this context to evaluate whether the implementation fully satisfies the issue — not just whether the code is technically correct.
+4. If the issue contains test data or test scenarios, verify they are covered by existing or new tests. Flag missing test coverage as a finding.
+
 ### 2. Pre-checks
 - If PR has conflicts → skip review for that PR
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -30,8 +30,20 @@ Perform structured code review focused on:
 
 - Before starting, ensure you are on the branch that contains the changes to review. If not, switch to it.
 - Identify changes vs main branch.
-- Understand context (issue, PR description, comments).
 - Deduplicate previous findings.
+
+### Issue Context Analysis
+
+Before reviewing code, load and analyze the full issue context:
+
+1. Load the complete issue or task (description, all comments, and attachments) from the linked tracker (GitHub, JIRA, Bugsnag).
+2. Extract from the issue:
+   - **Requirements and acceptance criteria** — what the code must do
+   - **Expected behavior** — how the feature or fix should work
+   - **Edge cases and constraints** — mentioned by the reporter or in comments
+   - **Test data** — any sample inputs, payloads, or scenarios provided in the issue
+3. Use this context to evaluate whether the implementation fully satisfies the issue — not just whether the code is technically correct.
+4. If the issue contains test data or test scenarios, verify they are covered by existing or new tests. Flag missing test coverage as a finding.
 
 ### Core Analysis
 - Regression risk (shared logic, dependencies)


### PR DESCRIPTION
## Summary
- Code review skills (`code-review`, `code-review-github`, `code-review-jira`) now require loading and analyzing the full issue context (description, all comments, attachments) before starting the review
- Reviews now evaluate whether the implementation satisfies the actual issue requirements, not just technical correctness
- If the issue contains test data or test scenarios, missing test coverage is flagged as a finding

Closes #336

## Test plan
- [x] All 76 existing tests pass
- [x] Skill-check validation passes (100/100 for all 23 skills)
- [ ] Verify code review skills load full issue context when invoked on a real PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)