### PR TITLE
feat(skills): add refactoring proposals to code review skills

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -90,5 +90,10 @@ Before reviewing code, load and analyze the full linked issue:
     - Moderate
     - Minor
 
+- If reviewed code violates project rules or architecture but is **out of scope** for the current PR, add a **Refactoring Proposals** section with issue drafts:
+    - Title, scope, violated rule/principle, and suggested approach per proposal
+    - Only propose refactoring justified by defined rules — not stylistic preferences
+    - Omit this section if no opportunities are found
+
 - End with summary:
 **Summary: X Critical, Y Moderate, Z Minor**

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -88,6 +88,10 @@ Before reviewing code, load and analyze the full JIRA issue:
   - Critical
   - Moderate
   - Minor
+- If reviewed code violates project rules or architecture but is **out of scope** for the current PR, add a **Refactoring Proposals** section with issue drafts:
+  - Title, scope, violated rule/principle, and suggested approach per proposal
+  - Only propose refactoring justified by defined rules — not stylistic preferences
+  - Omit this section if no opportunities are found
 - End with:
   **Summary: X Critical, Y Moderate, Z Minor**
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -103,6 +103,18 @@ Before reviewing code, load and analyze the full issue context:
 
 1. ...
 
+## Refactoring Proposals
+
+If any reviewed code violates project rules (`@rules/php/core-standards.mdc`, `@rules/laravel/architecture.mdc`) or has clear structural issues that are **out of scope** for the current PR, propose a new issue for each refactoring opportunity:
+
+1. **Title:** short, actionable issue title  
+   **Scope:** affected file(s) or area  
+   **Reason:** which rule or principle is violated and why it matters  
+   **Suggested approach:** brief description of the expected refactoring
+
+Only propose refactoring that is justified by defined rules or architecture — not stylistic preferences.
+If no refactoring opportunities are found, omit this section.
+
 **Summary: X Critical, Y Moderate, Z Minor**
 ```
 ---


### PR DESCRIPTION
## Summary
- Přidána nová sekce **Refactoring Proposals** do všech tří code review skillů (`code-review`, `code-review-github`, `code-review-jira`)
- Pokud code review narazí na kód porušující definovaná pravidla (`core-standards.mdc`, `architecture.mdc`), který je mimo scope aktuálního PR, navrhne zadání pro nové issue s refaktoringem
- Každý návrh obsahuje: title, scope, porušené pravidlo a navrhovaný přístup
- Návrhy se generují pouze na základě definovaných pravidel, ne stylových preferencí

Closes #342

## Test plan
- [ ] Verify `code-review/SKILL.md` contains Refactoring Proposals section in output format
- [ ] Verify `code-review-github/SKILL.md` contains refactoring proposals instruction in output rules
- [ ] Verify `code-review-jira/SKILL.md` contains refactoring proposals instruction in GitHub output rules
- [ ] Run `composer build` — all checks pass at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)