### PR TITLE
fix(skills): enforce 100% coverage and explicit fixer/checker quality gates before PR

### DIFF
--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -56,9 +56,11 @@ globs: []
 - Ensure 100% code coverage for all changed or added code paths.
 - If coverage tooling exists in the project, use it to verify coverage after test changes.
 
-## Code Style
-- Run project fixers (e.g. `php-cs-fixer`, `pint`) in dry-run mode on changed test files to verify code style compliance.
-- Fix any code style violations before finalizing test changes.
+## Code Style and Quality Gates
+- Discover available fixers and checkers: prefer Phing targets (`build.xml`/`phing.xml`) over Composer scripts (`composer.json`).
+- Run available fixers on changed test files and fix any violations.
+- Run available checkers/analyzers on changed test files and resolve all reported errors.
+- Complete all quality gates before finalizing test changes.
 
 ## Test Review
 - After completing test changes, run a quick code review focused on test quality against these rules.

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -93,6 +93,12 @@ Focus on:
 
 ---
 
+## Pre-push quality gates
+
+- Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`)
+- Run available fixers on all changed files and fix any violations
+- Run available checkers/analyzers on all changed files and resolve all reported errors
+
 ## After Completion
 
 - Run @skills/code-review/SKILL.md

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -52,7 +52,7 @@ metadata:
     current changes.
 -   If coverage tooling exists, verify that current changes are covered
     with 100% coverage.
--   If fixers or test-related wrappers exist in the project, use them.
+-   If fixers or test-related wrappers exist in the project, use them (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`).
 -   Do not run the whole test suite unless it is required for the
     changed files workflow.
 -   If the review recommendation is already satisfied by existing tests,
@@ -70,7 +70,9 @@ Provide a brief markdown summary including:
 
 **After completing the tasks**
 
--   Run project fixers in dry-run mode on all changed test files and fix any violations.
+-   Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`).
+-   Run available fixers on all changed test files and fix any violations.
+-   Run available checkers/analyzers on all changed test files and resolve all reported errors.
 -   Run a quick code review of all added or updated tests against `@rules/code-testing/general.mdc` and fix any findings.
 -   Summarize what testing recommendations from the code review were
     verified.

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -46,9 +46,10 @@ Create or update tests to cover current changes according to project conventions
 - Ensure 100% code coverage for all changed or added code paths
 - If coverage tooling exists, run it and verify the result
 
-### 6. Code Style
-- Run project fixers in dry-run mode on changed test files
-- Fix any code style violations
+### 6. Code Style and Quality Gates
+- Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`)
+- Run available fixers on changed test files and fix any violations
+- Run available checkers/analyzers on changed test files and resolve all reported errors
 
 ### 7. Test Review
 - Run a quick code review of the created/updated tests against `@rules/code-testing/general.mdc`

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -71,6 +71,12 @@ metadata:
 
 ---
 
+### Pre-push quality gates
+
+- Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`)
+- Run available fixers on all changed files and fix any violations
+- Run available checkers/analyzers on all changed files and resolve all reported errors
+
 ### Finalization
 
 - Run @skills/test-like-human/SKILL.md if changes are testable

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -50,7 +50,7 @@ Example input:
 6. Preserve repository/service/manager boundaries and multitenancy/account scope.
 7. Update the entry point to delegate via `$action(...)` and keep its public contract unchanged.
 8. Add or update tests for the refactored flow and important failure paths.
-9. Run required checks/fixers for changed PHP files and resolve issues.
+9. Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`). Run fixers first, then checkers/analyzers on all changed files. Resolve all reported issues.
 10. Run `@skills/code-review/SKILL.md` for the current changes.
 11. Run `@skills/process-code-review/SKILL.md` and fix critical or medium findings before finishing.
 
@@ -68,5 +68,5 @@ Example input:
 - Validation is delegated to a dedicated Data Validator when applicable.
 - Behavior, signatures, and response format remain unchanged.
 - Tests cover the refactored flow and important edge/failure paths.
-- Required checks pass for changed files.
+- Fixers and checkers ran clean on all changed files.
 - Internal architecture-focused review was completed and important findings were fixed.

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -61,7 +61,21 @@ If the source cannot be determined, ask the user.
 9. Ensure no sensitive data is exposed in error/validation messages.
 10. Run tests for affected areas and confirm correctness.
 11. Add or update tests to cover the new or fixed behavior.
-12. Run project fixers and resolve issues for changed files.
+12. Verify 100% code coverage for all changed or added code paths — if coverage tooling exists, run it and confirm the result before proceeding.
+
+## Pre-push quality gates
+
+Before committing and pushing changes, run project fixers and checkers on changed files. Discover available tooling using this priority:
+
+1. **Phing** — check for `build.xml` or `phing.xml` in the project root. If present, list available targets (`phing -l`) and use relevant fixer/checker targets.
+2. **Composer scripts** — if Phing is not available, inspect `composer.json` `scripts` section for fixer and checker commands (e.g. `fix`, `check`, `build`, `pint-fix`, `phpcs-fix`, `rector-fix`, `pint-check`, `phpcs-check`, `rector-check`, `test:coverage`).
+
+Run in this order:
+1. **Fixers** — run all available fixers on changed files (e.g. code style, rector, normalize). Fix any issues they report.
+2. **Checkers** — run all available checkers/analyzers on changed files (e.g. code style check, static analysis, audit). Resolve all reported errors before proceeding.
+3. **Coverage** — if a coverage command exists, run it and confirm 100% coverage for changed code paths.
+
+If both fixers and checkers fail or are not found, stop and inform the user.
 
 ## Pull request
 - Create a branch and commit changes following `@rules/git/general.mdc`
@@ -102,7 +116,8 @@ Post the final report (code review result, security review result, and test-like
 ## Done when
 - The issue is fully addressed
 - Behavior is correct and stable
-- Tests cover affected logic and pass
+- Tests cover affected logic with 100% coverage and pass
+- Pre-push fixers and checkers ran clean on all changed files
 - No sensitive data is exposed
 - Code review loop passed with no Critical or Moderate findings
 - Security review completed

--- a/skills/rewrite-tests-pest/SKILL.md
+++ b/skills/rewrite-tests-pest/SKILL.md
@@ -38,15 +38,17 @@ metadata:
 ## Post-rewrite validation
 1. Run all rewritten tests and confirm they pass.
 2. Verify 100% code coverage for all rewritten test paths — if coverage tooling exists, run it.
-3. Run project fixers in dry-run mode on changed test files and fix any violations.
-4. Run a quick code review of rewritten tests against `@rules/code-testing/general.mdc` and fix any findings.
+3. Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`).
+4. Run available fixers on changed test files and fix any violations.
+5. Run available checkers/analyzers on changed test files and resolve all reported errors.
+6. Run a quick code review of rewritten tests against `@rules/code-testing/general.mdc` and fix any findings.
 
 ## Done when
 - Target tests are rewritten to Pest syntax
 - Rewritten tests preserve original intent and behavior
 - Tests are deterministic and pass reliably
 - 100% code coverage is verified for rewritten code paths
-- Code style is verified via fixer dry-run
+- Code style and quality checks pass (fixers and checkers ran clean)
 - Test review passed with no findings
 - Duplication is reduced where it meaningfully improves readability
 - Shared lightweight helpers are extracted appropriately

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -69,8 +69,10 @@ Never fix a bug without first writing or updating a test that reproduces it.
 
 ## Post-cycle validation
 1. Verify 100% code coverage for all changed or added code paths — if coverage tooling exists, run it.
-2. Run project fixers in dry-run mode on changed test files and fix any violations.
-3. Run a quick code review of all tests written during the TDD cycle against `@rules/code-testing/general.mdc` and fix any findings.
+2. Discover available fixers and checkers (prefer Phing targets from `build.xml`/`phing.xml`; fall back to Composer scripts in `composer.json`).
+3. Run available fixers on changed files and fix any violations.
+4. Run available checkers/analyzers on changed files and resolve all reported errors.
+5. Run a quick code review of all tests written during the TDD cycle against `@rules/code-testing/general.mdc` and fix any findings.
 
 ## Done when
 - Every implemented behavior is backed by a test
@@ -79,6 +81,6 @@ Never fix a bug without first writing or updating a test that reproduces it.
 - Changed behavior, edge cases, and failure paths are covered
 - Relevant tests pass
 - 100% code coverage is verified for all changes
-- Code style is verified via fixer dry-run
+- Code style and quality checks pass (fixers and checkers ran clean)
 - Test review passed with no findings
 - Refactoring did not introduce new behavior


### PR DESCRIPTION
## Summary
- All resolve-issue related skills and rules now enforce 100% test coverage verification before creating a PR
- Replaced vague "run project fixers" instructions with explicit discovery and execution steps: prefer Phing targets (`build.xml`/`phing.xml`), fall back to Composer scripts
- Added separate checker/analyzer step after fixers to catch remaining quality issues
- Updated `Done when` criteria to reflect new requirements

## Affected files
- `skills/resolve-issue/SKILL.md` — added "Pre-push quality gates" section with Phing/Composer priority
- `skills/create-test/SKILL.md` — updated Code Style section to include checkers
- `skills/test-driven-development/SKILL.md` — updated post-cycle validation
- `skills/create-missing-tests-in-pr/SKILL.md` — added Phing preference and checker step
- `skills/rewrite-tests-pest/SKILL.md` — updated post-rewrite validation
- `skills/refactor-entry-point-to-action/SKILL.md` — explicit fixer/checker discovery
- `skills/class-refactoring/SKILL.md` — added pre-push quality gates section
- `skills/process-code-review/SKILL.md` — added pre-push quality gates before finalization
- `rules/code-testing/general.mdc` — updated Code Style section to include checkers and Phing preference

## Test plan
- [x] `composer build` passes clean (76 tests, 100% coverage, no errors)
- [x] skill-check validation: 23 skills, 100/100 score, PASS

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)