### PR TITLE
fix(skills): load all Laravel rules in code-related skills

### DIFF
--- a/skills/analyze-problem/SKILL.md
+++ b/skills/analyze-problem/SKILL.md
@@ -22,6 +22,7 @@ Focus on:
 
 ## Constraints
 - Apply @rules/php/core-standards.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Never modify code
 - Output Markdown only
 - Use one language only

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -22,7 +22,7 @@ Focus on:
 
 ## Constraints
 - Apply @rules/php/core-standards.mdc
-- Apply @rules/laravel/architecture.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Apply @rules/code-testing/general.mdc
 - Never change behavior
 - Keep public API stable unless explicitly required

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -16,6 +16,7 @@ Run a full code review for GitHub pull requests and publish findings directly to
 
 ## Constraints
 - Apply @rules/git/general.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - All output posted to GitHub must be in English
 - Never modify code
 - Output findings only (no praise)

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -19,6 +19,7 @@ Perform code review for JIRA issues by analyzing related pull requests and publi
 ## Constraints
 - Apply @rules/jira/general.mdc
 - Apply @rules/git/general.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Never modify code
 - GitHub output must be in English
 - JIRA output must be understandable for non-developers

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -18,7 +18,7 @@ Perform structured code review focused on:
 ## Constraints
 - Apply @rules/php/core-standards.mdc
 - Apply @rules/code-review/general.mdc
-- Apply @rules/laravel/architecture.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Output findings only (no praise)
 - Never modify code
 - All output must be in English

--- a/skills/composer-update/SKILL.md
+++ b/skills/composer-update/SKILL.md
@@ -16,6 +16,7 @@ Analyze dependency updates after `composer update`, detect conflicts, and summar
 
 ## Constraints
 - Apply @rules/php/core-standards.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Output Markdown only
 
 ---

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -14,6 +14,7 @@ metadata:
 -   Apply @rules/php/core-standards.mdc
 -   Apply @rules/git/general.mdc
 -   Apply @rules/code-testing/general.mdc
+-   If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 -   If you are not on the main git branch in the project, switch to it.
 -   This task is based on the existing pull request review.
 -   First read your existing code review for the current pull request

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -15,6 +15,7 @@ Create or update tests to cover current changes according to project conventions
 
 ## Constraints
 - Apply @rules/code-testing/general.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Do not modify production code unless strictly required
 
 ---

--- a/skills/laravel-telescope/SKILL.md
+++ b/skills/laravel-telescope/SKILL.md
@@ -6,6 +6,11 @@ metadata:
   author: "Petr Král (pekral.cz)"
 ---
 
+## Constraints
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
+
+---
+
 ## Purpose
 
 Use this skill when you need to investigate a specific Laravel Telescope request, read its runtime data, find the same request directly in the Telescope database tables, and propose actionable optimizations.

--- a/skills/mysql-problem-solver/SKILL.md
+++ b/skills/mysql-problem-solver/SKILL.md
@@ -20,6 +20,7 @@ Focus on:
 
 ## Constraints
 - Apply @rules/sql.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Be practical and direct
 - Prefer investigation over assumptions
 - Do not invent schema, indexes, or runtime behavior

--- a/skills/pr-summary/SKILL.md
+++ b/skills/pr-summary/SKILL.md
@@ -9,6 +9,7 @@ metadata:
 **Constraint:**
 - Apply @rules/php/core-standards.mdc
 - Apply @rules/git/general.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Write the summary in singular first person (one developer made the changes).
 - The output must be formatted in markdown.
 - Focus on the "why" and business impact, not on implementation details.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -10,6 +10,7 @@ metadata:
 - Apply @rules/php/core-standards.mdc
 - Apply @rules/git/general.mdc
 - Apply @rules/jira/general.mdc
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Never combine multiple languages in your answer
 - All CR output must be written in English
 - Never push direct changes to the main branch

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`.
-- Read and follow `@rules/laravel/architecture.mdc` before making changes.
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Preserve behavior, signatures, response contracts, and tenant/account scope.
 - Do not report review output to any third-party service.
 - After changes, run an internal architecture-first review and fix important findings immediately.

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -9,6 +9,7 @@ metadata:
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
 - Apply `@rules/git/general.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Follow project architecture and testing rules
 - Do not expose sensitive/internal details in user-facing messages
 - Preserve existing behavior unless explicitly required otherwise

--- a/skills/rewrite-tests-pest/SKILL.md
+++ b/skills/rewrite-tests-pest/SKILL.md
@@ -9,6 +9,7 @@ metadata:
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
 - Apply `@rules/code-testing/general.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Do not generate `covers()`
 
 ## Use when

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -9,6 +9,7 @@ metadata:
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
 - Apply `@rules/code-review/general.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Output must be in English
 - Focus on realistic, exploitable issues
 - Never reveal secrets

--- a/skills/smartest-project-addition/SKILL.md
+++ b/skills/smartest-project-addition/SKILL.md
@@ -8,6 +8,7 @@ metadata:
 
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Recommend exactly one addition
 - Do not include alternative proposals in the final answer
 - Do not implement code unless explicitly requested

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -9,6 +9,7 @@ metadata:
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
 - Apply `@rules/code-testing/general.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Follow test conventions from `@skills/create-test/SKILL.md`
 
 ## Core principle

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -10,6 +10,7 @@ metadata:
 - Apply `@rules/php/core-standards.mdc`
 - Apply `@rules/git/general.mdc`
 - Apply `@rules/jira/general.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Output must be human-readable (no technical logs or internal details)
 - Focus on user-visible behavior, not implementation
 

--- a/skills/understand-propose-implement-verify/SKILL.md
+++ b/skills/understand-propose-implement-verify/SKILL.md
@@ -8,6 +8,7 @@ metadata:
 
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
+- If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Always follow this order: understand → propose → implement → verify
 - Prefer existing project skills over custom solutions; do not duplicate logic already covered by a skill
 


### PR DESCRIPTION
## Summary
- All 20 code-related skills now conditionally load all four Laravel rule files (`laravel.mdc`, `architecture.mdc`, `filament.mdc`, `livewire.mdc`) when the current project uses Laravel
- Previously only 3 skills referenced `architecture.mdc` — now every skill that generates, reviews, or tests PHP code has full Laravel architectural context
- Non-code skills (create-issue, create-issues-from-text, merge-github-pr) were intentionally excluded as they don't interact with project code

Closes #348

## Test plan
- [x] `composer build` passes (skill-check 100%, all tests pass, 100% coverage)
- [ ] Verify skills correctly detect Laravel projects and apply rules
- [ ] Confirm non-Laravel projects are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)