### PR TITLE
fix(rules): enforce Repository encapsulation for all DB read operations

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -78,14 +78,17 @@ globs:
 - Keep services stateless.
 - Do not mix unrelated multi-domain orchestration into one service.
 - If logic does not primarily serve a single model, prefer an Action instead.
+- Services must not execute direct Eloquent queries or `DB::` calls — delegate reads to Repositories and writes to ModelManagers.
 
 ## Repositories and ModelManagers
+- All database read operations (Eloquent queries, `DB::` calls, query builder) must be encapsulated in Repository classes — never inline in Actions, Services, Facades, controllers, jobs, commands, listeners, or Livewire components.
 - Repositories are read-only:
   - querying
   - filtering
   - pagination
   - retrieval
 - Repositories must not perform writes or side effects.
+- All database write operations must be encapsulated in ModelManager classes — never inline persistence in Actions, Services, Facades, controllers, jobs, commands, listeners, or Livewire components.
 - ModelManagers are write-only:
   - create
   - update
@@ -175,6 +178,7 @@ globs:
   - validation logic not encapsulated in a dedicated Data Validator class (e.g. inline validation in controllers, jobs, commands, listeners, or Livewire components outside of FormRequest)
   - inline imperative validation in Actions, Services, Facades, Jobs, Commands, or Listeners — guard clauses that check input and throw exceptions (e.g. `if (!in_array(...)) throw new InvalidArgumentException(...)`) must be extracted into a Data Validator
   - Data Validator class calling `Validator::make()` directly when `pekral/arch-app-services` is installed (must use `DataValidator` trait and `$this->validate()`)
+  - inline database queries (Eloquent or `DB::`) in Actions, Services, Facades, controllers, jobs, commands, listeners, or Livewire components — reads must go through Repositories, writes through ModelManagers
   - services tied to one model that do not extend `BaseModelService`
   - non-CRUD methods inside resource controllers
 - Mark as moderate:

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -53,6 +53,8 @@ globs:
 - Call invokable classes using `$action($payload)`, never `$action->__invoke($payload)`.
 
 ## Database and Eloquent
+- All database read operations must be encapsulated in Repository classes — never inline Eloquent queries or `DB::` calls for data retrieval in Actions, Services, Facades, controllers, jobs, commands, listeners, or Livewire components. Delegate reads to a Repository.
+- All database write operations must be encapsulated in ModelManager classes (when using `pekral/arch-app-services`) — never perform inline persistence in Actions, Services, controllers, jobs, commands, listeners, or Livewire components.
 - Prefer Eloquent over Query Builder or raw SQL unless there is a measured reason not to.
 - Keep business logic out of models.
 - Define relationships, scopes, casts, and accessors in models.


### PR DESCRIPTION
## Summary
- All database read operations (Eloquent queries, `DB::` calls) must now be encapsulated in Repository classes — inline queries in Actions, Services, Facades, controllers, jobs, commands, listeners, or Livewire components are forbidden
- All database write operations must go through ModelManager classes
- Added explicit rule for Services: must not execute direct Eloquent queries or `DB::` calls — delegate to Repositories/ModelManagers
- Added Critical CR severity rule for inline DB queries outside Repositories/ModelManagers

## Changes
- `rules/laravel/architecture.mdc` — added Repository/ModelManager encapsulation rules, Services DB delegation rule, CR severity rule
- `rules/laravel/laravel.mdc` — added DB read/write encapsulation rules to Database and Eloquent section

Closes #347

## Test plan
- [x] `composer build` passes (fixers, checkers, tests, 100% coverage)
- [ ] Verify rules install correctly via `bin/cursor-rules install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)