### PR TITLE
fix(rules): define Data Builders as multi-method classes, not Action pattern

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -4,6 +4,7 @@ alwaysApply: false
 globs:
   - vendor/pekral/arch-app-services/**
   - app/Actions/**
+  - app/DataBuilders/**
   - app/DataValidators/**
   - app/ModelManagers/**
   - app/Repositories/**
@@ -109,6 +110,16 @@ globs:
 - DTO classes should be `final readonly` with promoted constructor properties where practical.
 - Place DTOs under `app/Dto/{Domain}` and use a `Data` suffix.
 
+## Data Builders
+- Data Builders are dedicated classes for mapping, hydrating, and normalizing input into DTOs.
+- Data Builders are **not** Action pattern classes — they do not use `__invoke()` and may expose multiple public methods.
+- Each public method should accept input (array, request data, model, external API response, etc.) and return a typed DTO.
+- Data Builders must never query the database or perform side effects.
+- Store Data Builders under `app/DataBuilders/{Domain}/` and use the `DataBuilder` suffix.
+- Data Builders should be `final readonly` with constructor injection where practical.
+- Use Data Builders when DTO construction involves non-trivial mapping, hydration, or normalization that does not belong in the DTO itself.
+- Actions may call Data Builders for complex DTO transformations instead of performing inline mapping.
+
 ## Data Validators
 - All data validation logic must be encapsulated in dedicated Data Validator classes — never inline in Actions, controllers, jobs, commands, listeners, or Livewire components.
 - Actions must not throw `ValidationException` directly.
@@ -185,6 +196,7 @@ globs:
   - calling Actions via `->__invoke()` instead of `$action(...)`
   - DTOs overriding `from()` only for key renaming instead of using mapping attributes
   - plain service classes used where an Action is the better fit
+  - Data Builder class using Action pattern (`__invoke()`) instead of named public methods
   - Data Validator class not implementing `ValidationRules` interface when rules could be reused
   - non-trivial or reusable validation logic written inline instead of as a custom Rule class in `app/Rules/`
 

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -21,7 +21,7 @@ globs:
 - Services: focused stateless domain/application services.
 - Repositories: read-only data access.
 - ModelManagers: write-only persistence.
-- Data Builders: transform DTOs only, never query the database.
+- Data Builders: multi-method classes that map, hydrate, or normalize input into DTOs. Not Action pattern — no `__invoke()`. Never query the database.
 
 ## Validation
 - Use FormRequest classes for controller input validation.


### PR DESCRIPTION
## Summary
- Added dedicated **Data Builders** section to `architecture.mdc` defining them as multi-method classes (not Action pattern) that map, hydrate, and normalize input into DTOs
- Data Builders must not use `__invoke()`, must not query the database, and should be stored under `app/DataBuilders/{Domain}/`
- Updated `laravel.mdc` layer responsibilities to clarify Data Builder role
- Added `app/DataBuilders/**` to architecture rule globs
- Added Moderate CR severity rule for Data Builders misusing Action pattern

## Changes
- `rules/laravel/architecture.mdc` — new Data Builders section, glob, and CR severity rule
- `rules/laravel/laravel.mdc` — updated Data Builders description in Layer Responsibilities

Closes #352

## Test plan
- [x] `composer build` passes (fixers, checkers, tests, 100% coverage)
- [ ] Verify rules install correctly via `bin/cursor-rules install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)