### PR TITLE
fix(installer): read editor from composer.json when --editor is omitted

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -64,7 +64,10 @@ final class Installer
             }
         }
 
-        return InstallerPath::EDITOR_CURSOR;
+        $root = InstallerPath::resolveProjectRoot();
+        $editorFromConfig = InstallerPath::resolveEditorFromComposerJson($root);
+
+        return $editorFromConfig ?? InstallerPath::EDITOR_CURSOR;
     }
 
     private static function showHelp(): int

--- a/src/InstallerPath.php
+++ b/src/InstallerPath.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Pekral\CursorRules;
 
+use JsonException;
+
 final class InstallerPath
 {
 
@@ -171,6 +173,70 @@ final class InstallerPath
     public static function resolveAllSkillsTargetDirectories(string $root): array
     {
         return self::resolveSkillsTargetDirectories($root, self::EDITOR_ALL);
+    }
+
+    /**
+     * Reads the editor setting from composer.json extra.cursor-rules.editor.
+     */
+    public static function resolveEditorFromComposerJson(string $projectRoot): ?string
+    {
+        $data = self::readComposerJson($projectRoot);
+
+        if ($data === null) {
+            return null;
+        }
+
+        $extra = $data['extra'] ?? [];
+
+        if (!is_array($extra)) {
+            return null;
+        }
+
+        $config = $extra['cursor-rules'] ?? [];
+
+        if (!is_array($config)) {
+            return null;
+        }
+
+        $config = array_change_key_case($config, CASE_LOWER);
+        $editor = $config['editor'] ?? null;
+
+        if (!is_string($editor)) {
+            return null;
+        }
+
+        $editor = strtolower($editor);
+
+        return in_array($editor, self::getAllowedEditors(), true) ? $editor : null;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    private static function readComposerJson(string $projectRoot): ?array
+    {
+        $composerJsonPath = $projectRoot . '/composer.json';
+
+        if (!is_file($composerJsonPath)) {
+            return null;
+        }
+
+        $contents = file_get_contents($composerJsonPath);
+
+        // @codeCoverageIgnoreStart
+        if ($contents === false) {
+            return null;
+        }
+
+        // @codeCoverageIgnoreEnd
+
+        try {
+            $data = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        return is_array($data) ? $data : null;
     }
 
     private static function resolveHomeDirectory(): string|false

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1447,3 +1447,188 @@ test('CLAUDE.md source file exists in package', function (): void {
     expect(file_get_contents($claudeMd))->toContain('Surgical Changes');
     expect(file_get_contents($claudeMd))->toContain('Goal-Driven Execution');
 });
+
+test('resolveEditorFromComposerJson returns editor when configured', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => [
+            'cursor-rules' => [
+                'editor' => 'claude',
+            ],
+        ],
+    ]));
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBe('claude');
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson returns null when no editor configured', function (): void {
+    $root = installerCreateProjectRoot();
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBeNull();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson returns null for invalid editor value', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => [
+            'cursor-rules' => [
+                'editor' => 'invalid',
+            ],
+        ],
+    ]));
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBeNull();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson returns null when composer.json does not exist', function (): void {
+    $root = sys_get_temp_dir() . '/no-composer-' . bin2hex(random_bytes(4));
+    mkdir($root, 0777, true);
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBeNull();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson is case-insensitive for editor key', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => [
+            'cursor-rules' => [
+                'Editor' => 'Claude',
+            ],
+        ],
+    ]));
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBe('claude');
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install without --editor reads editor from composer.json', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => [
+            'cursor-rules' => [
+                'editor' => 'claude',
+            ],
+        ],
+    ]));
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install']);
+        ob_end_clean();
+
+        expect(is_file($root . '/.claude/rules/php/core-standards.mdc'))->toBeTrue();
+        expect(is_dir($root . '/.cursor/rules'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with --editor flag overrides composer.json editor', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => [
+            'cursor-rules' => [
+                'editor' => 'claude',
+            ],
+        ],
+    ]));
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=cursor']);
+        ob_end_clean();
+
+        expect(is_file($root . '/.cursor/rules/php/core-standards.mdc'))->toBeTrue();
+        expect(is_dir($root . '/.claude/rules'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson returns null when extra is not an array', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => 'not-an-array',
+    ]));
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBeNull();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson returns null when cursor-rules config is not an array', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', json_encode([
+        'extra' => [
+            'cursor-rules' => 'not-an-array',
+        ],
+    ]));
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBeNull();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});
+
+test('resolveEditorFromComposerJson returns null for invalid JSON', function (): void {
+    $root = installerCreateProjectRoot();
+    file_put_contents($root . '/composer.json', 'not valid json');
+
+    try {
+        $editor = InstallerPath::resolveEditorFromComposerJson($root);
+
+        expect($editor)->toBeNull();
+    } finally {
+        installerRemoveDirectory($root);
+    }
+});


### PR DESCRIPTION
## Summary
- `Installer::parseEditor()` now checks `composer.json` → `extra.cursor-rules.editor` before defaulting to `cursor`
- Extracted `InstallerPath::resolveEditorFromComposerJson()` and `InstallerPath::readComposerJson()` to read and validate the config
- Explicit `--editor` flag still takes precedence over `composer.json`

Closes #358

## Test plan
- [x] `resolveEditorFromComposerJson` returns correct editor when configured
- [x] Returns `null` for missing config, invalid editor, invalid JSON, non-array extra/config
- [x] Case-insensitive key and value handling
- [x] `install` without `--editor` respects `composer.json` editor setting
- [x] `install` with `--editor` overrides `composer.json`
- [x] 100% code coverage, `composer build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)