### PR TITLE
fix(skill): always run all specialized skills in code-review

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -53,13 +53,13 @@ Before reviewing code, load and analyze the full issue context:
 - Type safety and error handling
 - Data validation encapsulation — verify that all validation logic is in dedicated Data Validator classes or FormRequests (using validation rules from reusable traits in `app/Concerns/`), not inline in Actions, controllers, jobs, commands, listeners, or Livewire components (see `@rules/laravel/architecture.mdc` Data Validators section)
 
-### Specialized Reviews (when relevant)
+### Specialized Reviews
 
 - Always run:
     - @skills/security-review/SKILL.md
+    - @skills/mysql-problem-solver/SKILL.md
 
 - Run conditionally:
-    - SQL changes → @skills/mysql-problem-solver/SKILL.md
     - Shared state / concurrency → @skills/race-condition-review/SKILL.md
     - I/O or external calls → I/O review
 
@@ -131,5 +131,4 @@ If no refactoring opportunities are found, omit this section.
 
 ## After Completion
 
-- If no **Critical** or **Moderate** findings remain:
-    - run @skills/test-like-human/SKILL.md
+- Always run @skills/test-like-human/SKILL.md


### PR DESCRIPTION
## Summary
- Moved `mysql-problem-solver` from conditional ("SQL changes only") to "Always run" in code-review skill
- Made `test-like-human` always run after code review completion (removed condition "only if no Critical/Moderate findings")
- `security-review` was already in "Always run" — no change needed

Closes #361

## Test plan
- [ ] Run `/code-review` on a PR without SQL changes and verify `mysql-problem-solver` is invoked
- [ ] Run `/code-review` on a PR with Critical findings and verify `test-like-human` still runs
- [ ] Verify `security-review` continues to run as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)