### PR TITLE
fix(skill): specify acli with MCP fallback for JIRA issue loading

### DIFF
--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -29,7 +29,7 @@ Perform code review for JIRA issues by analyzing related pull requests and publi
 ## Execution
 
 ### 1. Load Context
-- Load JIRA issue, comments, and attachments
+- Load JIRA issue, comments, and attachments using `acli`. If `acli` is unavailable, fall back to JIRA MCP server.
 - Identify all open PRs linked to the issue
 - Before reviewing a PR, switch to the PR branch and pull latest changes
 

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -45,7 +45,7 @@ If the source cannot be determined, ask the user.
    - **GitHub:** the issue repository must match the current Git remote origin.
    - **JIRA:** the issue project key must match the configured JIRA project for this repository.
    - If the issue does not belong to the current project, refuse to process it and inform the user.
-2. Fetch and analyze the issue from the detected source.
+2. Fetch and analyze the issue from the detected source. For JIRA issues, use `acli` as the primary tool. If `acli` is unavailable, fall back to JIRA MCP server.
 3. Define exact requirements and expected behavior.
 4. Classify the task (bug or feature).
 


### PR DESCRIPTION
## Summary
- `code-review-jira` — explicitně specifikuje `acli` jako primární nástroj pro načtení JIRA issue s fallbackem na JIRA MCP server
- `resolve-issue` — přidává stejnou instrukci do kroku 2 (Fetch and analyze)

Obě změny jsou konzistentní s pravidly v `rules/jira/general.mdc`.

## Test plan
- [ ] Spustit `/code-review-jira` s dostupným `acli` — ověřit, že se použije `acli`
- [ ] Spustit `/resolve-issue` s JIRA issue — ověřit, že se použije `acli`
- [ ] Ověřit fallback na MCP server, pokud `acli` není k dispozici

🤖 Generated with [Claude Code](https://claude.com/claude-code)