### PR TITLE
Refactor skill structure: code-review

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -88,35 +88,7 @@ Before reviewing code, load and analyze the full issue context:
 
 ## Output Format
 
-```markdown
-## Critical
-
-1. [file:line] Description  
-   Impact: ...  
-   Fix: ...
-
-## Moderate
-
-1. ...
-
-## Minor
-
-1. ...
-
-## Refactoring Proposals
-
-If any reviewed code violates project rules (`@rules/php/core-standards.mdc`, `@rules/laravel/architecture.mdc`) or has clear structural issues that are **out of scope** for the current PR, propose a new issue for each refactoring opportunity:
-
-1. **Title:** short, actionable issue title  
-   **Scope:** affected file(s) or area  
-   **Reason:** which rule or principle is violated and why it matters  
-   **Suggested approach:** brief description of the expected refactoring
-
-Only propose refactoring that is justified by defined rules or architecture — not stylistic preferences.
-If no refactoring opportunities are found, omit this section.
-
-**Summary: X Critical, Y Moderate, Z Minor**
-```
+Use the template defined in `templates/review-output.md`.
 ---
 
 ## Principles

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -1,0 +1,27 @@
+## Critical
+
+1. [file:line] Description  
+   Impact: ...  
+   Fix: ...
+
+## Moderate
+
+1. ...
+
+## Minor
+
+1. ...
+
+## Refactoring Proposals
+
+If any reviewed code violates project rules (`@rules/php/core-standards.mdc`, `@rules/laravel/architecture.mdc`) or has clear structural issues that are **out of scope** for the current PR, propose a new issue for each refactoring opportunity:
+
+1. **Title:** short, actionable issue title  
+   **Scope:** affected file(s) or area  
+   **Reason:** which rule or principle is violated and why it matters  
+   **Suggested approach:** brief description of the expected refactoring
+
+Only propose refactoring that is justified by defined rules or architecture — not stylistic preferences.
+If no refactoring opportunities are found, omit this section.
+
+**Summary: X Critical, Y Moderate, Z Minor**


### PR DESCRIPTION
## Summary
- Extracted output format template from `SKILL.md` (lines 91-119) into `templates/review-output.md`
- Updated `SKILL.md` to reference the template file instead of inlining it
- Follows the same Skill File Structure standard as previously refactored skills (`analyze-problem`, `laravel-telescope`, `resolve-issue`)

Closes #369

## Test plan
- [x] `composer build` passes clean (skill-check 100/100, all 86 tests pass, 100% coverage)
- [x] Template content matches original output format exactly
- [x] SKILL.md references template correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)