### PR TITLE
Add existing solution lookup and real test data rules

### DIFF
--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -22,9 +22,10 @@ globs: []
 - Avoid mocking data that can be created via factories.
 
 ## Mocking
+- Prefer storing real data in the database over mocking ModelManager or Repository classes.
 - Mock only:
-    - external services
-    - exception scenarios
+    - external services that cannot run in test environment
+    - exception scenarios that are hard to reach otherwise
 - Prefer partial mocks over full mocks.
 - Remove unnecessary or redundant mocks.
 

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -82,6 +82,7 @@ globs:
 - Prefer `Http::fake()` over mocking HTTP integrations manually.
 - Never allow real external HTTP calls in tests.
 - Use factories for Eloquent persistence in tests.
+- Prefer storing real data in the database and using it in tests over mocking ModelManager or Repository classes. Only mock external services that cannot run in test environment.
 - Add or update tests for every meaningful behavior change.
 - Use `Artisan::call(CommandClass::class)` for console command execution in tests.
 
@@ -101,6 +102,13 @@ globs:
 ## Dependency Injection
 - Always pass service dependencies via constructor, never as method parameters. This applies to Actions, Services, and all other classes.
 - Exception: Livewire components do not support constructor injection — use the `boot()` lifecycle hook instead.
+
+## New Feature Implementation
+- Before implementing a new feature, check if an existing solution already covers the use case:
+  1. Check Spatie packages first (https://github.com/orgs/spatie/repositories)
+  2. Search for other well-maintained community packages
+  3. Only build a custom solution if no suitable package exists
+- When using an existing package, prefer the simplest and most efficient integration
 
 ## General Laravel Practices
 - Prefer Laravel conventions and built-in features first.


### PR DESCRIPTION
## Summary
- Added "New Feature Implementation" section to Laravel rules requiring Spatie package check → community package search → custom solution (Closes #389)
- Updated Laravel testing rules and `code-testing/general.mdc` to prefer real database data over mocking ModelManager/Repository classes (Closes #364)

## Changes
### `rules/laravel/laravel.mdc`
- New section: check Spatie packages first, then community packages, before building custom solutions
- Testing: added rule to prefer real DB data over mocking persistence layers

### `rules/code-testing/general.mdc`
- Mocking section: added preference for real DB data, refined mock-only scope to external services that cannot run in test environment

## Test plan
- [x] `composer build` passes clean (skill-check 100/100, 86 tests, 100% coverage)
- [x] Rules are consistent across `laravel.mdc` and `code-testing/general.mdc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)