### PR TITLE
feat(skill): add previous CR status summary to code review output

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -63,7 +63,8 @@ Before reviewing code, load and analyze the full linked issue:
 
 #### Posting strategy
 - **If an existing CR comment is found (follow-up review):**
-    - Post a **summary-only** top-level PR comment (e.g. status update, summary line)
+    - Analyze all previous CR findings and classify each as: **Resolved**, **Deferred**, or **Still open**
+    - Include a **Previous CR Status** section at the top of the new review comment (before any new findings)
     - Post **detailed findings** as a new PR comment that references the original CR comment (quote its first line or link to it)
     - GitHub does not support native replies to issue comments — use quoting (e.g. "> Replying to code review from {date}") to create a visual thread
 

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -1,3 +1,13 @@
+## Previous CR Status
+
+> Include this section only in follow-up reviews when a previous CR exists for the same PR. Omit entirely for first reviews.
+
+| # | Finding | Status |
+|---|---------|--------|
+| 1 | Previous finding description | ✅ Resolved / ⏳ Deferred / ❌ Still open |
+
+---
+
 ## Critical
 
 1. [file:line] Description  

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -61,6 +61,8 @@ Before reviewing code, load and analyze the full JIRA issue:
 ### 4. Publish Results
 
 #### GitHub (technical findings only)
+- If a previous CR exists for the same PR, analyze all previous findings and classify each as: **Resolved**, **Deferred**, or **Still open**
+- Include a **Previous CR Status** section at the top of the GitHub comment (before new findings)
 - Post all technical findings as PR comment
 - Format:
   - Critical → Moderate → Minor

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -1,3 +1,13 @@
+## Previous CR Status
+
+> Include this section only in follow-up reviews when a previous CR exists for the same PR. Omit entirely for first reviews.
+
+| # | Finding | Status |
+|---|---------|--------|
+| 1 | Previous finding description | ✅ Resolved / ⏳ Deferred / ❌ Still open |
+
+---
+
 ## Critical
 
 1. [file:line] Description  

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -32,6 +32,17 @@ Perform structured code review focused on:
 - Identify changes vs main branch.
 - Deduplicate previous findings.
 
+### Previous CR Analysis
+
+If a previous code review exists for the same PR:
+
+1. Load all previous CR findings from PR comments.
+2. Classify each previous finding into one of these statuses:
+   - **Resolved** — the finding was fixed in subsequent commits.
+   - **Deferred** — the finding was acknowledged but intentionally left for a future task.
+   - **Still open** — the finding was not addressed and remains valid.
+3. Include this classification as a **Previous CR Status** section in the output (before new findings).
+
 ### Issue Context Analysis
 
 Before reviewing code, load and analyze the full issue context:

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -1,3 +1,13 @@
+## Previous CR Status
+
+> Include this section only in follow-up reviews when a previous CR exists for the same PR. Omit entirely for first reviews.
+
+| # | Finding | Status |
+|---|---------|--------|
+| 1 | Previous finding description | ✅ Resolved / ⏳ Deferred / ❌ Still open |
+
+---
+
 ## Critical
 
 1. [file:line] Description  


### PR DESCRIPTION
## Summary
- Follow-up code reviews now include a **Previous CR Status** section that classifies each prior finding as Resolved, Deferred, or Still open
- Added `Previous CR Analysis` step to `code-review/SKILL.md` execution flow
- Updated posting strategy in `code-review-github` and `code-review-jira` to include previous CR summary in follow-up reviews
- Added Previous CR Status table template to all three output templates (`review-output.md`, `pr-comment-output.md`, `github-output.md`)

Closes #397

## Test plan
- [ ] Verify `composer build` passes clean
- [ ] Run a code review on a PR that already has a prior CR comment — confirm the new review includes a Previous CR Status section
- [ ] Run a first-time code review on a PR without prior CR — confirm the Previous CR Status section is omitted
- [ ] Verify the status table correctly classifies findings as Resolved/Deferred/Still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)