### PR TITLE
feat(rules): add named arguments guidelines and review checklist

### DIFF
--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -63,6 +63,15 @@ globs: ["*"]
 - Never suppress errors with `@`.
 - When fixing an unused variable (e.g. PHPCS `UnusedVariable`): delete the variable if it is not required. If the variable is required (e.g. assigned from a function call with side effects), suppress the warning with `assert($variable !== null)` or similar `assert()` instead of removing the assignment.
 
+## Named Arguments
+- Many parameters is a code smell. It often means the method does too much or should accept a DTO/value object.
+- Named arguments help most with booleans, null, array values, and unclear strings. For example, `true`, `null`, `[]` without context say nothing.
+- They improve call-site readability without unnecessary variables. Instead of `$status = 'active'` just for a hint, use `status: 'active'`.
+- They should not replace good design. When a method has 8 parameters, named arguments do not fix the problem. They just make it bearable.
+- In public APIs, parameter names become part of the contract. Renaming a parameter in a public method can break consumers using named arguments.
+- Keep arguments in the original method signature order even when using named arguments.
+- See `rules/php/examples/named-arguments.md` for usage examples.
+
 ## Design Principles
 - Follow SOLID pragmatically, not dogmatically.
 - Keep I/O at the edges where practical.

--- a/rules/php/examples/named-arguments.md
+++ b/rules/php/examples/named-arguments.md
@@ -1,0 +1,119 @@
+# Named Arguments Examples
+
+### Good: named arguments clarify unclear scalar values
+
+```php
+Http::retry(times: 3, sleepMilliseconds: 100);
+```
+
+```php
+Str::limit(
+    value: $description,
+    limit: 160,
+    end: '...',
+);
+```
+
+```php
+Cache::put(
+    key: $cacheKey,
+    value: $result,
+    ttl: now()->addMinutes(10),
+);
+```
+
+### Good: named arguments make boolean flags readable
+
+```php
+$report->export(
+    format: 'csv',
+    includeHeader: true,
+    compress: false,
+);
+```
+
+### Good: named arguments make nullable values explicit
+
+```php
+$userService->updateProfile(
+    user: $user,
+    displayName: $displayName,
+    avatarPath: null,
+);
+```
+
+### Good: named arguments help with repeated scalar types
+
+```php
+$invoice->applyDiscount(
+    amount: 500,
+    currency: 'CZK',
+    reason: 'loyalty_discount',
+);
+```
+
+### Avoid: obvious single-argument calls
+
+```php
+$userRepository->find(id: $id);
+```
+
+Prefer:
+
+```php
+$userRepository->find($id);
+```
+
+### Avoid: named arguments do not fix bad method design
+
+```php
+$action(
+    userId: $user->id,
+    productId: $product->id,
+    quantity: 2,
+    sendEmail: true,
+    priority: 'high',
+    source: 'admin',
+);
+```
+
+Prefer DTO/value object:
+
+```php
+$action(new CreateOrderData(
+    userId: $user->id,
+    productId: $product->id,
+    quantity: 2,
+    sendEmail: true,
+    priority: 'high',
+    source: 'admin',
+));
+```
+
+### Avoid: do not reorder arguments just because PHP allows it
+
+```php
+Str::limit(
+    end: '...',
+    value: $description,
+    limit: 160,
+);
+```
+
+Prefer keeping the original signature order:
+
+```php
+Str::limit(
+    value: $description,
+    limit: 160,
+    end: '...',
+);
+```
+
+### Avoid: public API parameter names become part of the contract
+
+```php
+// Risky for public package APIs:
+// Renaming $sleepMilliseconds later would break users calling it by name.
+Http::retry(times: 3, sleepMilliseconds: 100);
+```

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -64,6 +64,13 @@ Before reviewing code, load and analyze the full issue context:
 - Type safety and error handling
 - Data validation encapsulation — verify that all validation logic is in dedicated Data Validator classes or FormRequests (using validation rules from reusable traits in `app/Concerns/`), not inline in Actions, controllers, jobs, commands, listeners, or Livewire components (see `@rules/laravel/architecture.mdc` Data Validators section)
 
+### Named Arguments Review
+- Would positional arguments be ambiguous?
+- Are there boolean, null, array, or repeated scalar values?
+- Would a DTO or value object be a better design?
+- Is this a public API where parameter names must remain stable?
+- Are arguments still listed in the original method signature order?
+
 ### Specialized Reviews
 
 - Always run:

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -916,8 +916,8 @@ test('install fails when copy fails due to unwritable destination', function ():
 
     $root = installerCreateProjectRoot();
     $targetDir = $root . '/.cursor/rules/php';
-    installerEnsureDirectory($targetDir);
-    chmod($targetDir, 0444);
+    installerEnsureDirectory($targetDir . '/examples');
+    chmod($targetDir, 0555);
     $cwd = getcwd();
     $originalCwd = $cwd !== false ? $cwd : '';
 


### PR DESCRIPTION
## Summary
- Add a new "Named Arguments" section to `rules/php/core-standards.mdc` describing when named arguments help (booleans, null, arrays, unclear scalars), when they should not replace better design (DTOs/value objects), and the public-API contract implication.
- Add `rules/php/examples/named-arguments.md` with concrete good/bad usage examples.
- Add a "Named Arguments Review" checklist to the `code-review` skill so reviewers verify ambiguity, design alternatives, public-API stability, and original parameter order.

## Test plan
- [ ] Verify rendered Markdown of `rules/php/core-standards.mdc` and the new examples file.
- [ ] Confirm `skills/code-review/SKILL.md` checklist appears in the right section and references the rules consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)