### PR TITLE
feat(skill): per-item justification + 100% PR coverage gate

### DIFF
--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -83,8 +83,11 @@ Before reviewing code, load and analyze the full issue context:
 
 ### Validation
 - Verify acceptance criteria
-- Check test coverage for changed files (must be 100%)
-- Identify missing test scenarios
+- **Coverage gate (mandatory):** every line, branch, and condition added or modified in the current PR diff must be covered by tests.
+  - Run the project coverage tool (e.g. `composer test:coverage` / `phpunit --coverage-*`) scoped to changed files.
+  - Map the coverage report to the diff and list any uncovered added/changed lines as **Critical** findings.
+  - If coverage tooling is unavailable or cannot be executed, raise that as a **Critical** finding instead of skipping the check.
+- Identify missing test scenarios beyond raw coverage (edge cases, error paths, regressions).
 
 ---
 

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -99,6 +99,22 @@ metadata:
   - Add a new top-level PR comment with resolved-point status
 - Mark resolved items (checkbox or inline) in all cases
 
+#### Per-item justification (required)
+
+Every resolved review point in the PR comment **must** include a brief justification using this format:
+
+```
+- [x] {short finding title}
+  - **Why:** {what was wrong / what the reviewer asked for}
+  - **Reason:** {root cause or rule that was violated}
+  - **Solution:** {what was changed and why this is the best fit}
+```
+
+Rules:
+- Keep each line **one sentence max**.
+- Skip the section only if a point was rejected or deferred — in that case state the rejection reason instead.
+- Do not pad with filler, restate the obvious, or paraphrase the diff.
+
 ---
 
 ### Completion


### PR DESCRIPTION
## Summary

Closes #404.

- **process-code-review** — every resolved review point posted on the PR must now include a `Why / Reason / Solution` triplet (one sentence each). This makes it explicit *why* the change was applied and *why it's the best fit*, which is what the issue asked for.
- **code-review** — strengthened the validation step into a hard "Coverage gate": every line, branch, and condition added or modified in the current PR diff must be covered by tests. Uncovered diff lines are a Critical finding. Missing coverage tooling is also Critical (so the check can never be silently skipped).

## Test plan

- [x] `composer build` (skill-check + tests + coverage) passes locally
- [ ] Reviewer confirms the new "Per-item justification" block in `skills/process-code-review/SKILL.md` reads naturally
- [ ] Reviewer confirms the new "Coverage gate" wording in `skills/code-review/SKILL.md` is enforceable

🤖 Generated with [Claude Code](https://claude.com/claude-code)