### PR TITLE
feat(rules): repositories — basic queries only, specialization in services/actions

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -89,6 +89,8 @@ globs:
   - pagination
   - retrieval
 - Repositories must not perform writes or side effects.
+- **Basic queries only:** Repositories may expose only generic, reusable queries (e.g. `find`, `findBy{Attribute}`, `all`, simple `where` lookups, pagination of a base scope). Use case–specific or feature-specific queries (combinations, multi-condition business filters, joins driven by a single feature) must not live in Repositories.
+- **Specialization belongs to Services and Actions:** When a feature needs a specialized result, compose it from basic Repository methods inside a Service (when scoped to one model) or an Action (when orchestrating across models or features). Services and Actions still must not write Eloquent or `DB::` queries themselves — they call Repository methods and shape the result.
 - All database write operations must be encapsulated in ModelManager classes — never inline persistence in Actions, Services, Facades, controllers, jobs, commands, listeners, or Livewire components.
 - ModelManagers are write-only:
   - create
@@ -199,6 +201,7 @@ globs:
   - services tied to one model that do not extend `BaseModelService`
   - non-CRUD methods inside resource controllers
 - Mark as moderate:
+  - feature-specific or use-case–specific query methods inside Repositories — Repositories must expose only basic, reusable queries; specialization belongs in Services or Actions composing those basic methods
   - calling Actions via `->__invoke()` instead of `$action(...)`
   - DTOs overriding `from()` only for key renaming instead of using mapping attributes
   - plain service classes used where an Action is the better fit

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -61,6 +61,7 @@ Focus on:
 - Do not place business logic in controllers or Livewire components.
 - Use existing query scopes instead of duplicating conditions.
 - Prefer DTOs over raw arrays when the project uses them.
+- Keep Repositories limited to basic, reusable queries. When refactoring uncovers a feature-specific query method on a Repository, move it to a Service (single-model) or an Action (cross-model / cross-feature) that composes basic Repository methods (see `@rules/laravel/architecture.mdc` Repositories and ModelManagers section).
 
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -63,6 +63,7 @@ Before reviewing code, load and analyze the full issue context:
 - Missing or incorrect behavior
 - Type safety and error handling
 - Data validation encapsulation — verify that all validation logic is in dedicated Data Validator classes or FormRequests (using validation rules from reusable traits in `app/Concerns/`), not inline in Actions, controllers, jobs, commands, listeners, or Livewire components (see `@rules/laravel/architecture.mdc` Data Validators section)
+- Repository scope — verify Repositories expose only basic, reusable queries (`find`, `findBy{Attribute}`, `all`, simple `where` lookups, pagination of a base scope). Feature-specific or use-case–specific query methods in Repositories are a finding; specialization belongs in a Service (single-model) or Action (cross-model / cross-feature) composing basic Repository methods (see `@rules/laravel/architecture.mdc` Repositories and ModelManagers section)
 
 ### Named Arguments Review
 - Would positional arguments be ambiguous?


### PR DESCRIPTION
## Souhrn

Closes #408.

Konvence „repository jen základní queries, specializace v service či actions“ promítnuta do třech míst:

- **`rules/laravel/architecture.mdc`** — sekce *Repositories and ModelManagers* dostala dva explicitní body: (1) repository smí vystavovat pouze generické, znovupoužitelné dotazy (`find`, `findBy{Attribute}`, `all`, jednoduché `where`, paginace base scope), (2) feature-specific / use-case dotazy se skládají v Service (single-model) nebo Action (cross-model / cross-feature) z těch základních metod. Do *CR Severity Rules* přidán Moderate finding pro feature-specific query metody na Repository.
- **`skills/code-review/SKILL.md`** — Core Analysis dostal explicitní bullet *Repository scope*, aby se reviewer u každého PR díval na rozsah Repository tříd.
- **`skills/class-refactoring/SKILL.md`** — Laravel Context dostal pravidlo, že refactoring má feature-specific Repository metody přesouvat do Service / Action.

Skilly pro generování (resolve-issue, class-refactoring, refactor-entry-point-to-action) přebírají pravidlo přes referenci na `@rules/laravel/architecture.mdc`.

## Test plán

- [x] `composer build` prošel lokálně (skill-check, normalize, phpcs, pint, rector, phpstan, security-audit, testy se 100 % coverage)
- [ ] Reviewer ověří, že Moderate finding v *CR Severity Rules* je správně formulovaný (nemá vyšší severitu, není v kontradikci s ostatními pravidly)
- [ ] Reviewer ověří, že nové bullety v code-review a class-refactoring nezduplikují existující obsah

🤖 Generated with [Claude Code](https://claude.com/claude-code)