### PR TITLE
feat(rules): forbid speculative (YAGNI) parameters in PHP

### DIFF
--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -79,6 +79,7 @@ globs: ["*"]
 - Extract repeated logic into reusable abstractions only when repetition is real and meaningful.
 - Keep related code together and maintain a logical folder structure.
 - Leave touched code cleaner than you found it.
+- Do not add speculative (YAGNI) parameters. Add a parameter to a method, function, action, or constructor only when at least one current caller actually needs it. Optional knobs, "in case" defaults, and parameters introduced solely for hypothetical future callers must be removed; add them later when a real use case appears.
 
 ## Documentation
 - Prefer self-documenting code over explanatory comments.


### PR DESCRIPTION
## Souhrn

Closes #407.

`rules/php/core-standards.mdc` (sekce *Design Principles*) má nový bullet, který zakazuje přidávat metodám, funkcím, akcím nebo konstruktorům **spekulativní (YAGNI) parametry** — tj. parametry, které žádný současný caller nepotřebuje. Optional knoby a "in case" defaulty se přidávají až ve chvíli, kdy je reálně potřebuje skutečné call site.

Pravidlo se propíše do všech skill workflow přes `@rules/php/core-standards.mdc` referenci (resolve-issue, class-refactoring, code-review, refactor-entry-point-to-action…).

## Test plán

- [x] `composer build` (skill-check + tests + 100% coverage) prošel lokálně
- [ ] Reviewer ověří, že nový bullet je v souladu s ostatními body v *Design Principles*
- [ ] Reviewer ověří, že pravidlo není duplicitní s `Named Arguments` sekcí (ta řeší pojmenování argumentů, ne jejich přidávání)

🤖 Generated with [Claude Code](https://claude.com/claude-code)