### PR TITLE
feat(skill): require faulty example + expected behavior in CR findings

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -87,6 +87,12 @@ Before reviewing code, load and analyze the full linked issue:
 - No praise
 - No “what was checked”
 - Use exactly three severity levels: Critical, Moderate, Minor
+- Each **Critical** and **Moderate** finding must include:
+    - **Faulty Example** — minimal code snippet or input payload reproducing the issue (redact secrets/PII)
+    - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)
+    - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
+- These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test directly from the PR comment.
+- Minor findings may omit these fields when no behavior change is implied.
 - If reviewed code violates project rules or architecture but is **out of scope** for the current PR, add a **Refactoring Proposals** section with issue drafts (justified by defined rules only)
 - End with summary line
 

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -10,9 +10,15 @@
 
 ## Critical
 
-1. [file:line] Description  
-   Impact: ...  
+1. [file:line] Description
+   Impact: ...
    Fix: ...
+   Faulty Example:
+   ```php
+   // minimal code or input that reproduces the issue
+   ```
+   Expected Behavior: what the correct outcome (return value, exception, side effect) must be.
+   Test Hint: one-sentence outline of the test that would fail today and pass after the fix.
 
 ## Moderate
 
@@ -22,11 +28,17 @@
 
 1. ...
 
+> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
+> - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
+> - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
+> - Test Hint must point at the layer the test belongs in (unit, integration, feature) and the entry point to call.
+> - Minor findings may omit these fields when no behavior change is implied (e.g. naming, dead code).
+
 ## Refactoring Proposals
 
-1. **Title:** short, actionable issue title  
-   **Scope:** affected file(s) or area  
-   **Reason:** which rule or principle is violated and why it matters  
+1. **Title:** short, actionable issue title
+   **Scope:** affected file(s) or area
+   **Reason:** which rule or principle is violated and why it matters
    **Suggested approach:** brief description of the expected refactoring
 
 Only propose refactoring justified by defined rules — not stylistic preferences.

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -87,6 +87,12 @@ Before reviewing code, load and analyze the full JIRA issue:
 - Include: file paths, line numbers, code references, severity levels, concrete fixes
 - Findings only — no praise, no explanations of what was checked
 - Use severity levels: Critical, Moderate, Minor
+- Each **Critical** and **Moderate** finding must include:
+    - **Faulty Example** — minimal code snippet or input payload reproducing the issue (redact secrets/PII)
+    - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)
+    - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
+- These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test directly from the PR comment.
+- Minor findings may omit these fields when no behavior change is implied.
 - Use the template defined in `templates/github-output.md`
 
 ### JIRA (non-technical summary — only here)

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -10,9 +10,15 @@
 
 ## Critical
 
-1. [file:line] Description  
-   Impact: ...  
+1. [file:line] Description
+   Impact: ...
    Fix: ...
+   Faulty Example:
+   ```php
+   // minimal code or input that reproduces the issue
+   ```
+   Expected Behavior: what the correct outcome (return value, exception, side effect) must be.
+   Test Hint: one-sentence outline of the test that would fail today and pass after the fix.
 
 ## Moderate
 
@@ -22,11 +28,17 @@
 
 1. ...
 
+> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
+> - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
+> - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
+> - Test Hint must point at the layer the test belongs in (unit, integration, feature) and the entry point to call.
+> - Minor findings may omit these fields when no behavior change is implied (e.g. naming, dead code).
+
 ## Refactoring Proposals
 
-1. **Title:** short, actionable issue title  
-   **Scope:** affected file(s) or area  
-   **Reason:** which rule or principle is violated and why it matters  
+1. **Title:** short, actionable issue title
+   **Scope:** affected file(s) or area
+   **Reason:** which rule or principle is violated and why it matters
    **Suggested approach:** brief description of the expected refactoring
 
 Only propose refactoring justified by defined rules — not stylistic preferences.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -106,6 +106,12 @@ Before reviewing code, load and analyze the full issue context:
     - location
     - risk/impact
     - concrete fix
+- Each **Critical** and **Moderate** finding must additionally include:
+    - **Faulty Example** — minimal code snippet or input payload that reproduces the issue (redact secrets/PII)
+    - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)
+    - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
+- These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test without re-deriving context.
+- Minor findings may omit these fields when no behavior change is implied (naming, dead code, etc.).
 
 ---
 

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -10,9 +10,15 @@
 
 ## Critical
 
-1. [file:line] Description  
-   Impact: ...  
+1. [file:line] Description
+   Impact: ...
    Fix: ...
+   Faulty Example:
+   ```php
+   // minimal code or input that reproduces the issue
+   ```
+   Expected Behavior: what the correct outcome (return value, exception, side effect) must be.
+   Test Hint: one-sentence outline of the test that would fail today and pass after the fix.
 
 ## Moderate
 
@@ -22,13 +28,19 @@
 
 1. ...
 
+> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding.** They feed `process-code-review` so each fix can be backed by a reproducer test.
+> - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
+> - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
+> - Test Hint must point at the layer the test belongs in (unit, integration, feature) and the entry point to call.
+> - Minor findings may omit these fields when no behavior change is implied (e.g. naming, dead code).
+
 ## Refactoring Proposals
 
 If any reviewed code violates project rules (`@rules/php/core-standards.mdc`, `@rules/laravel/architecture.mdc`) or has clear structural issues that are **out of scope** for the current PR, propose a new issue for each refactoring opportunity:
 
-1. **Title:** short, actionable issue title  
-   **Scope:** affected file(s) or area  
-   **Reason:** which rule or principle is violated and why it matters  
+1. **Title:** short, actionable issue title
+   **Scope:** affected file(s) or area
+   **Reason:** which rule or principle is violated and why it matters
    **Suggested approach:** brief description of the expected refactoring
 
 Only propose refactoring that is justified by defined rules or architecture — not stylistic preferences.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -32,6 +32,22 @@ metadata:
 - Build a checklist from all review findings
 - Map each finding to a concrete code or test change
 
+#### Reproducer extraction (per finding)
+
+For every Critical and Moderate finding, extract the reproducer fields published by the CR skills (`@skills/code-review/SKILL.md`, `@skills/code-review-github/SKILL.md`, `@skills/code-review-jira/SKILL.md`, `@skills/security-review/SKILL.md`):
+
+- **Faulty Example** — the minimal snippet or input that reproduces the bug
+- **Expected Behavior** — the assertion target the test must verify
+- **Test Hint** — the layer (unit, integration, feature) and entry point
+
+Use these to write a failing test **before** applying the fix:
+
+1. Drop the Faulty Example into a new test case at the layer named in the Test Hint.
+2. Assert the Expected Behavior — the test must fail on the current code.
+3. Apply the fix from the finding; rerun the test until it passes.
+
+If a finding lacks one of these fields, request a CR rerun rather than guessing — the CR skills are responsible for providing them.
+
 ---
 
 ### Pre-fix phase

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -92,6 +92,13 @@ Avoid generic best-practice noise.
 - exploit scenario
 - recommended fix
 
+### Reproducer fields (mandatory for Critical and High)
+- **Faulty Example** — minimal code snippet or attacker payload that reproduces the vulnerability (redact secrets, tokens, and PII)
+- **Expected Behavior** — single assertable security guarantee (rejection, authorization denial, escaped output, no side effect)
+- **Test Hint** — one sentence pointing at the test layer (unit, feature, HTTP) and entry point
+
+These fields exist so `@skills/process-code-review/SKILL.md` can turn each finding into a regression test without re-deriving the attack vector. Medium and Low findings may omit them when no behavior change is implied.
+
 ### Output format
 
 Use the template defined in `templates/audit-report.md`.

--- a/skills/security-review/templates/audit-report.md
+++ b/skills/security-review/templates/audit-report.md
@@ -1,7 +1,16 @@
 ## Security Audit Report - <Project Name>
 
 ### Critical
-- ...
+1. [file:line] Description
+   Category (OWASP): ...
+   Exploit Scenario: ...
+   Recommended Fix: ...
+   Faulty Example:
+   ```php
+   // minimal code or attacker-supplied payload that reproduces the vulnerability
+   ```
+   Expected Behavior: what the application must do instead (rejected input, thrown exception, denied authorization, sanitized output).
+   Test Hint: one-sentence outline of the security test (request shape, assertion target, layer).
 
 ### High
 - ...
@@ -11,6 +20,12 @@
 
 ### Low
 - ...
+
+> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and High finding** so `process-code-review` can turn each finding into a regression test.
+> - Faulty Example must be a minimal, runnable snippet or attacker payload — redact real secrets, tokens, and PII with placeholders.
+> - Expected Behavior must be a single assertable security guarantee (rejection, authorization denial, escaped output, no side effect).
+> - Test Hint must point at the layer the test belongs in (unit, feature, HTTP) and the entry point to call.
+> - Medium and Low findings may omit these fields when no behavior change is implied.
 
 ### Action Items
 1. [ ] ...


### PR DESCRIPTION
## Shrnutí
- Šablony CR výstupů (`code-review`, `code-review-github`, `code-review-jira`, `security-review`) nyní u každého **Critical** a **Moderate** (resp. **High**) findingu vyžadují trojici **Faulty Example** / **Expected Behavior** / **Test Hint**.
- `process-code-review` má novou sekci *Reproducer extraction*, která tyto pole čte z PR komentáře a převádí je na padající test ještě před aplikací fixu.
- Bezpečnostní pojistka: faulty example musí být minimální a nesmí obsahovat reálná tajemství / PII (placeholdery povinně).

## Důvod
Issue [#414](https://github.com/pekral/cursor-rules/issues/414): _„Uprav skilly CR tak, aby report obsahoval i chybné příklady či data k bodu, který je reportován a bylo možné pomocí skill process-code-review napsat jednoduše a efektivně testy, které nasimulují tuto chybu."_

## Doporučení k testování
- [ ] Spustit `composer build` lokálně — všechny existující testy projdou a coverage 100 %.
- [ ] Otevřít kterýkoli z aktualizovaných template souborů (`skills/code-review/templates/review-output.md`, `skills/code-review-github/templates/pr-comment-output.md`, `skills/code-review-jira/templates/github-output.md`, `skills/security-review/templates/audit-report.md`) a ověřit, že u Critical/Moderate findingu jsou pole **Faulty Example**, **Expected Behavior**, **Test Hint**.
- [ ] V `skills/process-code-review/SKILL.md` ověřit přítomnost sekce *Reproducer extraction (per finding)*.
- [ ] Pustit `process-code-review` na ukázkový PR s CR komentářem obsahujícím nový formát a ověřit, že skill napíše failing test podle Faulty Example.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)