### PR TITLE
feat(rules): add shared refactoring definition (legacy → modern architecture)

### DIFF
--- a/rules/laravel/architecture.mdc
+++ b/rules/laravel/architecture.mdc
@@ -198,6 +198,7 @@ globs:
 - Always enforce the Action pattern in code review for new or materially changed backend flows.
 - New jobs, controller actions, console commands, listeners, and Livewire methods must delegate orchestration to Actions.
 - If a new or changed flow bypasses the Action pattern, request changes.
+- Apply the shared refactoring definition from `@rules/refactoring/general.mdc` whenever the PR includes refactoring: behavior must be preserved, migration must be incremental, and entry points / responsibilities / DRY / concurrency must follow the recommended process.
 
 ### CR Severity Rules
 - Mark as critical:

--- a/rules/refactoring/general.mdc
+++ b/rules/refactoring/general.mdc
@@ -1,0 +1,66 @@
+---
+description: Shared definition of refactoring (legacy → modern architecture). Applies to refactoring skills and code review whenever refactoring is in scope.
+alwaysApply: false
+globs: []
+---
+
+## What Refactoring Is
+- Refactoring is a **behavior-preserving change of code structure**.
+- The application keeps doing the same thing; only how it does it changes.
+- Goals: readability, structure, and readiness for further development.
+- Refactoring is **technical debt reduction**, not a feature.
+
+## Symptoms of Legacy Code
+- Large methods (e.g. controllers doing everything).
+- Mixed validation, business logic, and persistence in one place.
+- Code duplication.
+- Poor testability.
+- Hidden bugs and race conditions.
+
+## What Refactoring Brings
+- Faster delivery of new features.
+- Fewer bugs and regressions.
+- Better readability.
+- Easier onboarding.
+- The ability to scale both the application and the team.
+
+## Core Rule
+- **Never** do a big-bang rewrite.
+- **Always** migrate incrementally, one piece at a time.
+
+## Recommended Process
+1. **Stabilize** — add at least smoke tests, fix critical bugs first.
+2. **Identify entry points** — start at controllers, jobs, commands, listeners, Livewire components.
+3. **Introduce the Action pattern** — keep entry points thin; delegate orchestration to Actions.
+4. **Split responsibilities** — Action (orchestration), Service (business logic), Repository (read), ModelManager (write).
+5. **Modernize code**:
+    - raw arrays → DTOs (e.g. Spatie Laravel Data)
+    - static helpers → dependency injection
+    - fat models → service layer
+    - inline validation → Data Validators / FormRequests
+6. **Remove duplication** — apply DRY pragmatically, not dogmatically.
+7. **Address concurrency** — DB transactions, `lockForUpdate`, atomic operations instead of read-modify-write on shared state.
+
+## When to Refactor
+- Changes are slow and painful.
+- The code is unreadable.
+- The team is afraid to touch it.
+- The same bugs keep coming back.
+
+## When Not to Refactor
+- Just to make the code "look nice".
+- Without a business reason.
+
+## Reality Check
+- Refactoring does not deliver immediate business value.
+- Without it, however:
+    - delivery slows down,
+    - technical debt grows,
+    - error rate increases.
+- Refactoring is an investment in future delivery speed and system stability.
+
+## Code Review Application
+- Treat this definition as authoritative when reviewing or proposing refactoring.
+- Flag big-bang rewrites and mixed-responsibility entry points as findings.
+- Prefer incremental migration over wholesale rewrites in suggested fixes.
+- For Laravel projects, combine this rule with `@rules/laravel/architecture.mdc` (Action pattern, Repositories, ModelManagers, Data Validators, DTOs).

--- a/skills/class-refactoring/SKILL.md
+++ b/skills/class-refactoring/SKILL.md
@@ -21,6 +21,7 @@ Focus on:
 ---
 
 ## Constraints
+- Apply @rules/refactoring/general.mdc — shared definition of refactoring, recommended incremental process, and "no big-bang rewrite" rule.
 - Apply @rules/php/core-standards.mdc
 - If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Apply @rules/code-testing/general.mdc
@@ -32,6 +33,7 @@ Focus on:
 ## Execution
 
 - Analyze the class and identify the highest-impact refactoring.
+- Follow the incremental process from `@rules/refactoring/general.mdc` (stabilize → identify entry points → introduce Action pattern → split responsibilities → modernize → DRY → concurrency). Never propose a big-bang rewrite.
 - Fix any obvious pre-existing bugs before refactoring (separate commit).
 - Apply focused refactoring:
   - simplify structure

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -18,6 +18,7 @@ Perform structured code review focused on:
 ## Constraints
 - Apply @rules/php/core-standards.mdc
 - Apply @rules/code-review/general.mdc
+- Apply @rules/refactoring/general.mdc — use the shared refactoring definition when assessing refactoring changes or when proposing refactoring; reject big-bang rewrites and prefer incremental migration.
 - If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Output findings only (no praise)
 - Never modify code
@@ -62,6 +63,7 @@ Before reviewing code, load and analyze the full issue context:
 - Business logic correctness
 - Missing or incorrect behavior
 - Type safety and error handling
+- Refactoring quality — when changes are refactoring in nature, validate them against `@rules/refactoring/general.mdc`: behavior must be preserved, migration must be incremental (no big-bang rewrites), and entry points / responsibilities / DRY / concurrency must follow the recommended process. In Laravel projects, combine with `@rules/laravel/architecture.mdc`.
 - Data validation encapsulation — verify that all validation logic is in dedicated Data Validator classes or FormRequests (using validation rules from reusable traits in `app/Concerns/`), not inline in Actions, controllers, jobs, commands, listeners, or Livewire components (see `@rules/laravel/architecture.mdc` Data Validators section)
 - Repository scope — verify Repositories expose only basic, reusable queries (`find`, `findBy{Attribute}`, `all`, simple `where` lookups, pagination of a base scope). Feature-specific or use-case–specific query methods in Repositories are a finding; specialization belongs in a Service (single-model) or Action (cross-model / cross-feature) composing basic Repository methods (see `@rules/laravel/architecture.mdc` Repositories and ModelManagers section)
 - Data Modification (DRY) — enumerate every place in the changes that modifies data before it is saved or passed downstream (DTO mapping, payload shaping, key renaming, default fallbacks, format normalization, business-driven derivation). Cross-check against existing entry points; if the same shaping appears in more than one Action / Service / controller / job / listener / Livewire component / command, flag it and require consolidation into the canonical layer (Data Builder, DTO named constructor, Data Validator, ModelManager, Repository — see `@rules/laravel/architecture.mdc` Data Modification (DRY) section). Output the list of modification places explicitly in the review so the duplication picture is visible.

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -7,6 +7,7 @@ metadata:
 ---
 
 ## Constraints
+- Apply `@rules/refactoring/general.mdc` — incremental migration only, never a big-bang rewrite.
 - Apply `@rules/php/core-standards.mdc`.
 - If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Preserve behavior, signatures, response contracts, and tenant/account scope.


### PR DESCRIPTION
## Shrnutí

Issue #416 požadoval, aby AI agent chápal pojem **refaktoring** podle dané definice (legacy → moderní architektura) a aby tuto definici bral v potaz minimálně při Code Review v Laravel projektech.

Změny zavádí jednu kanonickou definici sdílenou napříč skilly i pravidly:

- **`rules/refactoring/general.mdc`** (nové) — definice refaktoringu (behavior-preserving change), symptomy legacy kódu, přínosy, hlavní pravidlo (žádný big-bang rewrite, jen postupná migrace), doporučený postup (stabilizace → entry pointy → Action pattern → rozdělení odpovědností → modernizace → DRY → concurrency), kdy / kdy ne refaktorovat, reality check, a sekce pro CR.
- **`skills/class-refactoring/SKILL.md`** — odkazuje na nové pravidlo a explicitně vyžaduje inkrementální postup.
- **`skills/code-review/SKILL.md`** — aplikuje nové pravidlo při CR; přidává `Refactoring quality` mezi Core Analysis položky.
- **`skills/refactor-entry-point-to-action/SKILL.md`** — přebírá pravidlo do constraints.
- **`rules/laravel/architecture.mdc`** — `Code Review Enforcement` sekce nyní explicitně vyžaduje aplikaci sdílené definice při CR refaktoringu v Laravel projektu.

## Doporučení k testování

- [ ] Otevřít [`rules/refactoring/general.mdc`](https://github.com/pekral/cursor-rules/blob/feat/refactoring-philosophy/rules/refactoring/general.mdc) a zkontrolovat, že obsah odpovídá definici z [issue #416](https://github.com/pekral/cursor-rules/issues/416).
- [ ] Ověřit reference v [`skills/class-refactoring/SKILL.md`](https://github.com/pekral/cursor-rules/blob/feat/refactoring-philosophy/skills/class-refactoring/SKILL.md), [`skills/code-review/SKILL.md`](https://github.com/pekral/cursor-rules/blob/feat/refactoring-philosophy/skills/code-review/SKILL.md), [`skills/refactor-entry-point-to-action/SKILL.md`](https://github.com/pekral/cursor-rules/blob/feat/refactoring-philosophy/skills/refactor-entry-point-to-action/SKILL.md).
- [ ] V Laravel projektu spustit code-review skill nad ukázkovým "big-bang rewrite" diffem a ověřit, že je flagován dle nového pravidla.
- [ ] `composer build` musí projít zelenou (PHPStan, skill-check, normalize, phpcs, pint, rector, tests, coverage 100%).

### Tests

Existují → ano, struktural test `query scopes rule is present in class refactoring skill` dál prochází; nové testy pro tento change nejsou potřeba (jde o textové změny v rules/skills, beze změny PHP kódu).

Closes #416