### PR TITLE
feat(skills): require third-party API contract verification in code review

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -53,6 +53,7 @@ Before reviewing code, load and analyze the full linked issue:
 - Run conditionally:
     - Database changes → @skills/mysql-problem-solver/SKILL.md
     - Shared state → @skills/race-condition-review/SKILL.md
+    - Third-party API or service changes → ensure the **Third-Party API & Service Analysis** step from `@skills/code-review/SKILL.md` is executed for the diff
 
 ### 4. Post Results
 

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -57,6 +57,7 @@ Before reviewing code, load and analyze the full JIRA issue:
 - Run conditionally:
   - DB changes → @skills/mysql-problem-solver/SKILL.md
   - Shared state → @skills/race-condition-review/SKILL.md
+  - Third-party API or service changes → ensure the **Third-Party API & Service Analysis** step from `@skills/code-review/SKILL.md` is executed for the diff
 
 ### 4. Publish Results
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -57,12 +57,28 @@ Before reviewing code, load and analyze the full issue context:
 3. Use this context to evaluate whether the implementation fully satisfies the issue — not just whether the code is technically correct.
 4. If the issue contains test data or test scenarios, verify they are covered by existing or new tests. Flag missing test coverage as a finding.
 
+### Third-Party API & Service Analysis
+
+Run this section only when the diff integrates with, modifies, or depends on a third-party API or external service (HTTP clients, vendor SDK calls, webhooks, OAuth flows, payload schemas, queue/event consumers backed by external systems).
+
+1. Identify every affected API or service from the diff and list the concrete endpoints, SDK methods, webhook events, or message contracts that changed.
+2. Locate the official public reference for each one — vendor documentation, OpenAPI/Swagger spec, SDK reference, or webhook contract. Prefer URLs cited in the issue or PR; otherwise look up the vendor's current published documentation for the version in use.
+3. Compare the implementation against the public contract:
+   - endpoints, HTTP methods, and required vs optional parameters
+   - request and response schemas, status codes, and error envelopes
+   - authentication, scopes, rate limits, idempotency keys, and retry semantics
+   - pagination, filtering, sorting, webhook signatures, and timeouts
+4. Cross-check the implementation against the issue assignment — verify the chosen endpoints, parameters, and behaviors satisfy what the issue actually asked for. Flag any divergence (missing endpoint, wrong verb, ignored field, fabricated parameter) as a finding.
+5. Confirm coverage of every API use case that is in scope for the issue — documented filters, status branches, error states, and edge inputs the issue explicitly or implicitly requires. Missing in-scope use cases are findings; out-of-scope use cases belong in **Refactoring Proposals**.
+6. If the public reference cannot be located, accessed, or matched to the version in use, raise this as a finding instead of silently assuming the contract.
+
 ### Core Analysis
 - Regression risk (shared logic, dependencies)
 - Architecture and design quality
 - Business logic correctness
 - Missing or incorrect behavior
 - Type safety and error handling
+- Third-party API/service contract — when changes touch external APIs or services, verify the implementation matches the public API documentation, satisfies the issue assignment, and covers all relevant in-scope API use cases (see **Third-Party API & Service Analysis** section)
 - Refactoring quality — when changes are refactoring in nature, validate them against `@rules/refactoring/general.mdc`: behavior must be preserved, migration must be incremental (no big-bang rewrites), and entry points / responsibilities / DRY / concurrency must follow the recommended process. In Laravel projects, combine with `@rules/laravel/architecture.mdc`.
 - Data validation encapsulation — verify that all validation logic is in dedicated Data Validator classes or FormRequests (using validation rules from reusable traits in `app/Concerns/`), not inline in Actions, controllers, jobs, commands, listeners, or Livewire components (see `@rules/laravel/architecture.mdc` Data Validators section)
 - Repository scope — verify Repositories expose only basic, reusable queries (`find`, `findBy{Attribute}`, `all`, simple `where` lookups, pagination of a base scope). Feature-specific or use-case–specific query methods in Repositories are a finding; specialization belongs in a Service (single-model) or Action (cross-model / cross-feature) composing basic Repository methods (see `@rules/laravel/architecture.mdc` Repositories and ModelManagers section)

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -69,8 +69,8 @@ Run this section only when the diff integrates with, modifies, or depends on a t
    - authentication, scopes, rate limits, idempotency keys, and retry semantics
    - pagination, filtering, sorting, webhook signatures, and timeouts
 4. Cross-check the implementation against the issue assignment — verify the chosen endpoints, parameters, and behaviors satisfy what the issue actually asked for. Flag any divergence (missing endpoint, wrong verb, ignored field, fabricated parameter) as a finding.
-5. Confirm coverage of every API use case that is in scope for the issue — documented filters, status branches, error states, and edge inputs the issue explicitly or implicitly requires. Missing in-scope use cases are findings; out-of-scope use cases belong in **Refactoring Proposals**.
-6. If the public reference cannot be located, accessed, or matched to the version in use, raise this as a finding instead of silently assuming the contract.
+5. Confirm coverage of every API use case that is in scope for the issue — documented filters, status branches, error states, and edge inputs the issue explicitly or implicitly requires. Missing in-scope use cases are findings. Do not propose adopting API features that current scope does not require (YAGNI per `@rules/php/core-standards.mdc`); only when the diff exposes an out-of-scope structural shortcoming in how the project consumes the API (e.g. missing webhook signature verification across other consumers) raise it under **Refactoring Proposals**.
+6. If the public reference cannot be located, accessed, or matched to the version in use, raise this as a **Moderate** finding instead of silently assuming the contract.
 
 ### Core Analysis
 - Regression risk (shared logic, dependencies)

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -51,7 +51,7 @@ Avoid generic best-practice noise.
 - dangerous protocols (`file://`, `gopher://`, etc.)
 - missing validation after redirects
 - missing rate limiting or abuse protection
-- third-party API contract — when the diff integrates with a third-party API or service, verify the implementation against the public API documentation: authentication and scope handling, signature/webhook verification, idempotency and retry semantics, error envelopes, and rate-limit handling. Flag any divergence from the issue assignment or missing in-scope use cases that the API exposes.
+- third-party API contract — when the diff integrates with a third-party API or service, verify the security-critical aspects of the implementation against the public API documentation: authentication and scope handling, signature/webhook verification, idempotency and retry semantics, error envelopes, and rate-limit handling. Functional alignment with the issue assignment is owned by `@skills/code-review/SKILL.md` — do not duplicate it here.
 
 ### File Handling
 - unsafe uploads (extension, MIME, signature)

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -51,6 +51,7 @@ Avoid generic best-practice noise.
 - dangerous protocols (`file://`, `gopher://`, etc.)
 - missing validation after redirects
 - missing rate limiting or abuse protection
+- third-party API contract — when the diff integrates with a third-party API or service, verify the implementation against the public API documentation: authentication and scope handling, signature/webhook verification, idempotency and retry semantics, error envelopes, and rate-limit handling. Flag any divergence from the issue assignment or missing in-scope use cases that the API exposes.
 
 ### File Handling
 - unsafe uploads (extension, MIME, signature)


### PR DESCRIPTION
## Summary
- Add **Third-Party API & Service Analysis** subsection to `skills/code-review/SKILL.md` and a matching bullet in **Core Analysis**, instructing reviewers to compare diffs that touch third-party APIs/services against the public API contract, the issue assignment, and the full set of in-scope use cases the API exposes.
- Extend **External Interaction (APIs & SSRF)** in `skills/security-review/SKILL.md` with the same contract-verification expectation focused on security-relevant aspects (authentication/scopes, signature verification, idempotency, error envelopes, rate-limit handling).
- Resolves https://github.com/pekral/cursor-rules/issues/418

## Test plan
- [x] `composer skill-check` passes (23/23 skills, 100/100 quality score)
- [x] `composer build` passes (fix + check, 100% test coverage)
- [ ] Reviewer reads the new Third-Party API & Service Analysis section and confirms it is actionable for a real PR touching a third-party API

🤖 Generated with [Claude Code](https://claude.com/claude-code)