### PR TITLE
fix(skills): always run test-like-human after code review

### DIFF
--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -115,5 +115,4 @@ Before reviewing code, load and analyze the full JIRA issue:
 
 ## After Completion
 
-- If no **Critical** or **Moderate** findings:
-  - run @skills/test-like-human/SKILL.md
+- Always run @skills/test-like-human/SKILL.md, regardless of code review findings.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -151,4 +151,4 @@ Use the template defined in `templates/review-output.md`.
 
 ## After Completion
 
-- Always run @skills/test-like-human/SKILL.md
+- Always run @skills/test-like-human/SKILL.md, regardless of code review findings.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1120,6 +1120,20 @@ test('query scopes rule is present in class refactoring skill', function (): voi
     expect($content)->toContain('query scopes');
 });
 
+test('test-like-human always runs after code review skills regardless of findings', function (): void {
+    $packageDir = dirname(__DIR__);
+    $skillFiles = [
+        $packageDir . '/skills/code-review/SKILL.md',
+        $packageDir . '/skills/code-review-jira/SKILL.md',
+    ];
+
+    foreach ($skillFiles as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain('Always run @skills/test-like-human/SKILL.md');
+        expect($content)->not->toContain("If no **Critical** or **Moderate** findings:\n  - run @skills/test-like-human/SKILL.md");
+    }
+});
+
 test('install with prune on non-existent target directory does nothing', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/skills/some-skill/SKILL.md', 'content');

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1129,8 +1129,8 @@ test('test-like-human always runs after code review skills regardless of finding
 
     foreach ($skillFiles as $skillFile) {
         $content = (string) file_get_contents($skillFile);
-        expect($content)->toContain('Always run @skills/test-like-human/SKILL.md');
-        expect($content)->not->toContain("If no **Critical** or **Moderate** findings:\n  - run @skills/test-like-human/SKILL.md");
+        expect($content)->not->toContain('If no **Critical** or **Moderate**');
+        expect($content)->toMatch('/##\s*After Completion[^#]*Always run @skills\/test-like-human\/SKILL\.md, regardless of code review findings\./s');
     }
 });
 


### PR DESCRIPTION
## Shrnutí
- `@skills/test-like-human/SKILL.md` se nyní spouští **vždy** po `code-review` i `code-review-jira` skillu, bez ohledu na to, jestli CR našel Critical/Moderate nálezy.
- Sjednoceno znění "After Completion" v obou skill souborech, aby bylo explicitní, že podmíněné spouštění (původní *"If no Critical or Moderate findings"*) odpadá.
- Přidán regression test v `tests/InstallerTest.php`, který hlídá, že obě skill files obsahují `Always run` direktivu a neobsahují původní podmíněnou variantu.

## Doporučení k testování
- [ ] Otevři `skills/code-review/SKILL.md` — sekce *After Completion* obsahuje řádek `- Always run @skills/test-like-human/SKILL.md, regardless of code review findings.`
- [ ] Otevři `skills/code-review-jira/SKILL.md` — sekce *After Completion* obsahuje stejnou direktivu (žádná podmínka *"If no Critical or Moderate"*)
- [ ] Spusť `composer build` — všechny checkery (skill-check, composer-normalize, phpcs, pint, rector, phpstan, security audit) zelené, 87 testů projde, coverage 100 %
- [ ] Otevři `tests/InstallerTest.php`, najdi test `test-like-human always runs after code review skills regardless of findings` a ověř, že selže, pokud někdo přepíše direktivu zpět na podmíněnou variantu

Closes #422

Issue: https://github.com/pekral/cursor-rules/issues/422