### PR TITLE
feat(skills): wire class-refactoring into code review skills

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -49,11 +49,22 @@ Before reviewing code, load and analyze the full linked issue:
 - Always run:
     - @skills/code-review/SKILL.md
     - @skills/security-review/SKILL.md
+    - @skills/class-refactoring/SKILL.md — read-only refactoring lens scoped to the PR diff. Surface DRY duplication and tech-debt-reducing changes that apply to lines actually touched by the PR. Do not propose changes outside the diff.
 
 - Run conditionally:
     - Database changes → @skills/mysql-problem-solver/SKILL.md
     - Shared state → @skills/race-condition-review/SKILL.md
     - Third-party API or service changes → ensure the **Third-Party API & Service Analysis** step from `@skills/code-review/SKILL.md` is executed for the diff
+
+#### Refactoring & Tech Debt (DRY) Analysis (PR diff only)
+
+1. Restrict the analysis to lines added or modified in the PR — never review untouched code.
+2. For each changed block, apply `@skills/class-refactoring/SKILL.md` and look for:
+   - duplicated logic that already exists elsewhere (DRY)
+   - data shaping repeated across Actions/Services/controllers/jobs/listeners/Livewire/commands
+   - oversized methods, deep nesting, mixed responsibilities introduced or amplified by the change
+3. Each finding must include the file path, the affected line range, and a concrete refactoring that *reduces* tech debt.
+4. In-scope refactorings go into the **Refactoring (DRY / Tech Debt Reduction)** section of the PR comment template. Out-of-scope structural problems still belong in **Refactoring Proposals**.
 
 ### 4. Post Results
 
@@ -72,10 +83,31 @@ Before reviewing code, load and analyze the full linked issue:
 - **If no existing CR comment is found (first review):**
     - Post findings as a single PR comment using CLI tools
 
+#### Inline review comments (per finding)
+
+Mirror how a human reviewer leaves comments in the GitHub UI before clicking *Request changes*:
+
+1. Group findings (Critical, Moderate, Minor, and Refactoring (DRY / Tech Debt Reduction)) by `file:line`.
+2. For each finding that maps to a concrete line in the PR diff, attach a GitHub **review comment** anchored to that line via the GitHub review API:
+   ```bash
+   gh api -X POST "repos/{owner}/{repo}/pulls/{pr}/reviews" \
+     -F event=COMMENT \
+     -F body="<top-level review summary>" \
+     -F "comments[][path]=src/Foo/Bar.php" \
+     -F "comments[][line]=42" \
+     -F "comments[][side]=RIGHT" \
+     -F "comments[][body]=<finding body — severity, impact, fix, faulty example, expected behavior, test hint>"
+   ```
+   Submit a single review with all inline comments attached so they appear as one reviewer pass, not many ad-hoc comments.
+3. Use `event=COMMENT` for advisory passes. Use `event=REQUEST_CHANGES` only when at least one **Critical** finding is present and blocking merge is appropriate.
+4. The top-level summary comment (from the strategy above) must include severity counts and a link to each inline thread.
+5. If a finding cannot be anchored to a specific changed line (e.g. missing test coverage, architectural concern across the diff), keep it in the top-level summary comment instead of the inline review.
+
 #### Format
-- Critical → Moderate → Minor
+- Critical → Moderate → Minor → Refactoring (DRY / Tech Debt Reduction)
 - Include file + line
 - Include actionable fix
+- Inline review comments target specific lines; the summary comment aggregates them and lists items that have no single anchor line.
 
 - If no findings:
     - post: "No findings identified"
@@ -88,6 +120,7 @@ Before reviewing code, load and analyze the full linked issue:
 - No praise
 - No “what was checked”
 - Use exactly three severity levels: Critical, Moderate, Minor
+- Add a **Refactoring (DRY / Tech Debt Reduction)** section after the Minor findings whenever the diff contains in-scope tech-debt-reducing changes (DRY duplication, oversized methods, mixed responsibilities). Each item must include `file:line` and a concrete refactoring step.
 - Each **Critical** and **Moderate** finding must include:
     - **Faulty Example** — minimal code snippet or input payload reproducing the issue (redact secrets/PII)
     - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -28,6 +28,16 @@
 
 1. ...
 
+## Refactoring (DRY / Tech Debt Reduction)
+
+> Include only items that apply to lines actually touched by this PR (added or modified). Never review untouched code here. Each item must reduce technical debt — no stylistic preferences.
+
+1. [file:line] DRY duplication or structural problem in the changed code
+   Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
+   Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
+
+> Each item that maps to a concrete diff line should also be posted as an inline review comment anchored to `file:line`, so the PR thread mirrors how a human reviewer leaves comments before clicking *Request changes*.
+
 > **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
@@ -44,4 +54,4 @@
 Only propose refactoring justified by defined rules — not stylistic preferences.
 Omit this section if no opportunities are found.
 
-**Summary: X Critical, Y Moderate, Z Minor**
+**Summary: X Critical, Y Moderate, Z Minor, R Refactoring (DRY / Tech Debt Reduction)**

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -53,11 +53,22 @@ Before reviewing code, load and analyze the full JIRA issue:
 - For each PR:
   - run @skills/code-review/SKILL.md
   - run @skills/security-review/SKILL.md
+  - run @skills/class-refactoring/SKILL.md — read-only refactoring lens scoped to the PR diff. Surface DRY duplication and tech-debt-reducing changes only on lines actually touched by the PR.
 
 - Run conditionally:
   - DB changes → @skills/mysql-problem-solver/SKILL.md
   - Shared state → @skills/race-condition-review/SKILL.md
   - Third-party API or service changes → ensure the **Third-Party API & Service Analysis** step from `@skills/code-review/SKILL.md` is executed for the diff
+
+#### Refactoring & Tech Debt (DRY) Analysis (PR diff only)
+
+1. Restrict the analysis to lines added or modified in the PR — never review untouched code.
+2. For each changed block, apply `@skills/class-refactoring/SKILL.md` and look for:
+   - duplicated logic that already exists elsewhere (DRY)
+   - data shaping repeated across Actions/Services/controllers/jobs/listeners/Livewire/commands
+   - oversized methods, deep nesting, mixed responsibilities introduced or amplified by the change
+3. Each finding must include the file path, the affected line range, and a concrete refactoring that *reduces* tech debt.
+4. In-scope refactorings go into the **Refactoring (DRY / Tech Debt Reduction)** section of the GitHub PR comment template. Out-of-scope structural problems still belong in **Refactoring Proposals**.
 
 ### 4. Publish Results
 
@@ -66,9 +77,11 @@ Before reviewing code, load and analyze the full JIRA issue:
 - Include a **Previous CR Status** section at the top of the GitHub comment (before new findings)
 - Post all technical findings as PR comment
 - Format:
-  - Critical → Moderate → Minor
+  - Critical → Moderate → Minor → Refactoring (DRY / Tech Debt Reduction)
   - file + line
   - actionable fix
+- For each finding that maps to a concrete line in the PR diff, attach an inline review comment via the GitHub review API (`gh api -X POST repos/{owner}/{repo}/pulls/{pr}/reviews` with a `comments[]` array of `{path, line, side, body}` entries). Submit one review with all inline comments so the PR shows a single reviewer pass instead of scattered ad-hoc comments. Use `event=COMMENT` for advisory passes; reserve `event=REQUEST_CHANGES` for blocking Critical findings.
+- The top-level PR comment still aggregates severity counts and lists items that cannot be anchored to a specific line (missing test coverage, cross-diff architectural concerns).
 - This is the only place where technical details appear
 
 #### JIRA (non-technical summary only)

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -28,6 +28,16 @@
 
 1. ...
 
+## Refactoring (DRY / Tech Debt Reduction)
+
+> Include only items that apply to lines actually touched by this PR (added or modified). Never review untouched code here. Each item must reduce technical debt — no stylistic preferences.
+
+1. [file:line] DRY duplication or structural problem in the changed code
+   Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
+   Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
+
+> Each item that maps to a concrete diff line should also be posted as an inline review comment anchored to `file:line`, mirroring how a human reviewer leaves comments before clicking *Request changes*.
+
 > **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
@@ -44,4 +54,4 @@
 Only propose refactoring justified by defined rules — not stylistic preferences.
 Omit this section if no opportunities are found.
 
-**Summary: X Critical, Y Moderate, Z Minor**
+**Summary: X Critical, Y Moderate, Z Minor, R Refactoring (DRY / Tech Debt Reduction)**

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -97,10 +97,27 @@ Run this section only when the diff integrates with, modifies, or depends on a t
 - Always run:
     - @skills/security-review/SKILL.md
     - @skills/mysql-problem-solver/SKILL.md
+    - @skills/class-refactoring/SKILL.md — read-only refactoring lens scoped to the PR diff. Use it to surface concrete tech-debt-reducing changes (DRY duplication, single-responsibility breaches, oversized methods) that apply to lines actually touched by the PR. Do not propose changes that fall outside the diff.
 
 - Run conditionally:
     - Shared state / concurrency → @skills/race-condition-review/SKILL.md
     - I/O or external calls → I/O review
+
+### Refactoring & Tech Debt (DRY) Analysis
+
+Run this section over the PR diff only — never over untouched code.
+
+1. List every block of changed lines (added or modified) per file.
+2. For each block, evaluate against `@skills/class-refactoring/SKILL.md`:
+   - duplicated logic that already exists elsewhere in the codebase (DRY)
+   - data-shaping repeated across Actions/Services/controllers/jobs/listeners/Livewire/commands
+   - oversized methods, deep nesting, mixed responsibilities introduced or amplified by the change
+   - per-row DB operations in loops (link to the **Core Analysis** rule above)
+3. Output the result in the **Refactoring (DRY / Tech Debt Reduction)** section of the review template:
+   - file:line of the offending change
+   - the duplicated/structural problem in one sentence
+   - a concrete refactoring that *reduces* tech debt (consolidate into Data Builder / DTO / Service / Action / Repository per `@rules/laravel/architecture.mdc`)
+4. Refactoring proposals here are improvements that fit inside the PR scope. Out-of-scope structural problems still belong in **Refactoring Proposals** (separate issue draft).
 
 ### Validation
 - Verify acceptance criteria

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -28,6 +28,14 @@
 
 1. ...
 
+## Refactoring (DRY / Tech Debt Reduction)
+
+> Include only items that apply to lines actually touched by this PR (added or modified). Never review untouched code here. Each item must reduce technical debt — no stylistic preferences.
+
+1. [file:line] DRY duplication or structural problem in the changed code
+   Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
+   Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
+
 > **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding.** They feed `process-code-review` so each fix can be backed by a reproducer test.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
@@ -46,4 +54,4 @@ If any reviewed code violates project rules (`@rules/php/core-standards.mdc`, `@
 Only propose refactoring that is justified by defined rules or architecture — not stylistic preferences.
 If no refactoring opportunities are found, omit this section.
 
-**Summary: X Critical, Y Moderate, Z Minor**
+**Summary: X Critical, Y Moderate, Z Minor, R Refactoring (DRY / Tech Debt Reduction)**

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1175,7 +1175,7 @@ test('code review skills constrain refactoring lens to PR diff', function (): vo
     foreach ($reviewSkills as $skillFile) {
         $content = (string) file_get_contents($skillFile);
         expect($content)->toContain('Refactoring & Tech Debt (DRY)');
-        expect($content)->toContain('PR diff');
+        expect($content)->toContain('untouched code');
     }
 });
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1149,6 +1149,67 @@ test('test-like-human guard rejects gating regressions', function (): void {
     expect((bool) preg_match($guardRegex, $regressionDirectiveOutsideSection))->toBeFalse();
 });
 
+test('every code review skill references class-refactoring skill', function (): void {
+    $packageDir = dirname(__DIR__);
+    $needle = '@skills/class-refactoring/SKILL.md';
+    $reviewSkills = [
+        $packageDir . '/skills/code-review/SKILL.md',
+        $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/code-review-jira/SKILL.md',
+    ];
+
+    foreach ($reviewSkills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain($needle);
+    }
+});
+
+test('code review skills constrain refactoring lens to PR diff', function (): void {
+    $packageDir = dirname(__DIR__);
+    $reviewSkills = [
+        $packageDir . '/skills/code-review/SKILL.md',
+        $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/code-review-jira/SKILL.md',
+    ];
+
+    foreach ($reviewSkills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain('Refactoring & Tech Debt (DRY)');
+        expect($content)->toContain('PR diff');
+    }
+});
+
+test('code review templates include refactoring tech debt section', function (): void {
+    $packageDir = dirname(__DIR__);
+    $templates = [
+        $packageDir . '/skills/code-review/templates/review-output.md',
+        $packageDir . '/skills/code-review-github/templates/pr-comment-output.md',
+        $packageDir . '/skills/code-review-jira/templates/github-output.md',
+    ];
+
+    foreach ($templates as $template) {
+        $content = (string) file_get_contents($template);
+        expect($content)->toContain('## Refactoring (DRY / Tech Debt Reduction)');
+        expect($content)->toContain('R Refactoring (DRY / Tech Debt Reduction)');
+    }
+});
+
+test('github code review skills describe inline review comment workflow', function (): void {
+    $packageDir = dirname(__DIR__);
+    $githubFacingSkills = [
+        $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/code-review-jira/SKILL.md',
+    ];
+
+    foreach ($githubFacingSkills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain('/pulls/{pr}/reviews');
+        expect($content)->toContain('comments[]');
+        expect($content)->toContain('event=COMMENT');
+        expect($content)->toContain('event=REQUEST_CHANGES');
+    }
+});
+
 test('install with prune on non-existent target directory does nothing', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/skills/some-skill/SKILL.md', 'content');


### PR DESCRIPTION
## Summary
- All code review skills (`code-review`, `code-review-github`, `code-review-jira`) now also run `class-refactoring` as a read-only refactoring lens scoped to the PR diff. They surface DRY duplication and tech-debt-reducing improvements directly in the review output via a new **Refactoring (DRY / Tech Debt Reduction)** section.
- GitHub-facing review skills describe how to post **inline review comments** anchored to `file:line` via the GitHub review API (`POST /repos/{owner}/{repo}/pulls/{pr}/reviews` with a `comments[]` payload), so the AI reviewer mirrors how a human reviewer attaches comments to specific lines before clicking *Request changes*.
- Templates and the summary line gained the new section so the visible review output reflects the new lens.
- Regression tests in `tests/InstallerTest.php` lock in: every code review skill references `class-refactoring`, the refactoring lens stays scoped to the PR diff, all three templates carry the new section, and GitHub-facing review skills document the inline comment workflow.

Closes https://github.com/pekral/cursor-rules/issues/424

## Test plan
- [x] `composer fix`
- [x] `composer build` (skill-check, composer-normalize-check, phpcs, pint, rector, phpstan, security audit, pest with 100% coverage) — 93 passing