### PR TITLE
fix(skills): drop inline review comment workflow from CR skills

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -83,31 +83,11 @@ Before reviewing code, load and analyze the full linked issue:
 - **If no existing CR comment is found (first review):**
     - Post findings as a single PR comment using CLI tools
 
-#### Inline review comments (per finding)
-
-Mirror how a human reviewer leaves comments in the GitHub UI before clicking *Request changes*:
-
-1. Group findings (Critical, Moderate, Minor, and Refactoring (DRY / Tech Debt Reduction)) by `file:line`.
-2. For each finding that maps to a concrete line in the PR diff, attach a GitHub **review comment** anchored to that line via the GitHub review API:
-   ```bash
-   gh api -X POST "repos/{owner}/{repo}/pulls/{pr}/reviews" \
-     -F event=COMMENT \
-     -F body="<top-level review summary>" \
-     -F "comments[][path]=src/Foo/Bar.php" \
-     -F "comments[][line]=42" \
-     -F "comments[][side]=RIGHT" \
-     -F "comments[][body]=<finding body — severity, impact, fix, faulty example, expected behavior, test hint>"
-   ```
-   Submit a single review with all inline comments attached so they appear as one reviewer pass, not many ad-hoc comments.
-3. Use `event=COMMENT` for advisory passes. Use `event=REQUEST_CHANGES` only when at least one **Critical** finding is present and blocking merge is appropriate.
-4. The top-level summary comment (from the strategy above) must include severity counts and a link to each inline thread.
-5. If a finding cannot be anchored to a specific changed line (e.g. missing test coverage, architectural concern across the diff), keep it in the top-level summary comment instead of the inline review.
-
 #### Format
 - Critical → Moderate → Minor → Refactoring (DRY / Tech Debt Reduction)
-- Include file + line
+- Include file + line in the finding body
 - Include actionable fix
-- Inline review comments target specific lines; the summary comment aggregates them and lists items that have no single anchor line.
+- Post all findings inside the single PR comment — never as line-anchored review comments.
 
 - If no findings:
     - post: "No findings identified"

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -36,8 +36,6 @@
    Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
    Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
 
-> Each item that maps to a concrete diff line should also be posted as an inline review comment anchored to `file:line`, so the PR thread mirrors how a human reviewer leaves comments before clicking *Request changes*.
-
 > **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -80,8 +80,7 @@ Before reviewing code, load and analyze the full JIRA issue:
   - Critical → Moderate → Minor → Refactoring (DRY / Tech Debt Reduction)
   - file + line
   - actionable fix
-- For each finding that maps to a concrete line in the PR diff, attach an inline review comment via the GitHub review API (`gh api -X POST repos/{owner}/{repo}/pulls/{pr}/reviews` with a `comments[]` array of `{path, line, side, body}` entries). Submit one review with all inline comments so the PR shows a single reviewer pass instead of scattered ad-hoc comments. Use `event=COMMENT` for advisory passes; reserve `event=REQUEST_CHANGES` for blocking Critical findings.
-- The top-level PR comment still aggregates severity counts and lists items that cannot be anchored to a specific line (missing test coverage, cross-diff architectural concerns).
+- Post all technical findings inside the single PR comment — never as line-anchored review comments. Include the `file:line` reference in the body of each finding instead.
 - This is the only place where technical details appear
 
 #### JIRA (non-technical summary only)

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -36,8 +36,6 @@
    Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
    Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
 
-> Each item that maps to a concrete diff line should also be posted as an inline review comment anchored to `file:line`, mirroring how a human reviewer leaves comments before clicking *Request changes*.
-
 > **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1194,19 +1194,22 @@ test('code review templates include refactoring tech debt section', function ():
     }
 });
 
-test('github code review skills describe inline review comment workflow', function (): void {
+test('github code review skills do not describe inline review comment workflow', function (): void {
     $packageDir = dirname(__DIR__);
     $githubFacingSkills = [
         $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/code-review-github/templates/pr-comment-output.md',
         $packageDir . '/skills/code-review-jira/SKILL.md',
+        $packageDir . '/skills/code-review-jira/templates/github-output.md',
     ];
 
     foreach ($githubFacingSkills as $skillFile) {
         $content = (string) file_get_contents($skillFile);
-        expect($content)->toContain('/pulls/{pr}/reviews');
-        expect($content)->toContain('comments[]');
-        expect($content)->toContain('event=COMMENT');
-        expect($content)->toContain('event=REQUEST_CHANGES');
+        expect($content)->not->toContain('/pulls/{pr}/reviews');
+        expect($content)->not->toContain('comments[]');
+        expect($content)->not->toContain('event=COMMENT');
+        expect($content)->not->toContain('event=REQUEST_CHANGES');
+        expect($content)->not->toContain('inline review comment');
     }
 });
 


### PR DESCRIPTION
## Summary
- Remove the GitHub review API inline-comment instructions from `code-review-github` and `code-review-jira` skills and their PR-comment templates so reviews are posted as a single PR comment, never anchored to file:line.
- Invert the existing regression test into a guard that asserts the inline-review workflow stays absent from both skills and templates.

Closes https://github.com/pekral/cursor-rules/issues/426

## Test plan
- [x] `composer skill-check` (23 skills, 0 errors, score 100/100)
- [x] `composer phpcs-check`
- [x] `composer pint-check`
- [x] `composer rector-check`
- [x] `composer analyse` (PHPStan)
- [x] `vendor/bin/pest tests/ --no-coverage` (93 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)