### PR TITLE
feat(skills): add skill-creator skill (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 🔧 **Changed**: move shared rule files from `rules/skills/` to `rules/`, update all skill references (#238)
 - 🐛 **Fixed**: `create-missing-tests-in-pr` and `test-like-human` skills now use shared `github-operations.mdc` / `jira-operations.mdc` rules instead of inline preferences (#237)
 - 🐛 **Fixed**: all mock rules now prefer partial mocks (`makePartial()`) over full mocks (#241)
+- ✨ **Added**: new Agent skill `skill-creator` for scaffolding new SKILL.md files that follow project conventions and pass `skill-check` validation (#432)
 
 ## [0.6.2] - 2026-04-07
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `create-issue` | Create a tracker issue from provided task text while preserving original meaning and structure. |
 | `create-issues-from-text` | Batch-create issues from provided text with automatic structure detection. |
 | `pr-summary` | Summarize current PR changes for development and product teams in a clear markdown report. |
+| `skill-creator` | Scaffold a new Agent skill that follows project conventions and passes `skill-check` validation. |
 
 ## Code Review, Security & Architecture
 
@@ -131,7 +132,6 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `refactor-entry-point-to-action` | Refactor controller/job/command/listener entry-point logic into Action classes. |
 | `smartest-project-addition` | Propose one high-impact, low-risk project improvement. |
 | `understand-propose-implement-verify` | Enforce a strict 4-step loop: understand, propose, implement, verify. |
-| `skill-creator` | Scaffold a new Agent skill that follows project conventions and passes `skill-check` validation. |
 
 ## Testing & Quality Automation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - unified PHP coding guidelines for PHP 8.4 projects
 - Pest-based testing with mandatory code analysis and 100% coverage
 - strong focus on clean code: typed properties, SRP, no redundant comments
-- **23 comprehensive Agent skills** for automated workflows (v0.8)
+- **24 comprehensive Agent skills** for automated workflows (v0.8)
 - fast onboarding inside development repositories
 
 ## Installation
@@ -101,7 +101,7 @@ vendor/bin/cursor-rules install --editor=cursor --symlink     # prefer symlinks 
 
 # 🎯 Skills Overview — **v0.8**
 
-> Current release includes 23 skills for issue resolution, code review, refactoring, testing, security, SQL performance, and delivery workflows.
+> Current release includes 24 skills for issue resolution, code review, refactoring, testing, security, SQL performance, and delivery workflows.
 
 Agent skills are installed into the chosen editor’s skill directory (see `--editor`). Use `--editor=all` to install for Cursor, Claude, and Codex at once. They can be invoked when relevant. Each skill follows project conventions, ensures code quality, and maintains 100% test coverage where applicable.
 
@@ -131,6 +131,7 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 | `refactor-entry-point-to-action` | Refactor controller/job/command/listener entry-point logic into Action classes. |
 | `smartest-project-addition` | Propose one high-impact, low-risk project improvement. |
 | `understand-propose-implement-verify` | Enforce a strict 4-step loop: understand, propose, implement, verify. |
+| `skill-creator` | Scaffold a new Agent skill that follows project conventions and passes `skill-check` validation. |
 
 ## Testing & Quality Automation
 

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: skill-creator
+description: "Use when creating a new Agent skill in this repository. Generates a SKILL.md that follows project conventions, passes skill-check validation, and updates the changelog and readme."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+
+# Skill Creator
+
+## Purpose
+Author a new Agent skill that fits this repository's conventions and ships ready for review.
+
+Focus on:
+- consistent frontmatter and section layout
+- behavior aligned with `skill-check.config.json` limits
+- clear Use when, Execution, and Done when sections
+- no duplication with existing skills
+
+---
+
+## Constraints
+- Apply `@rules/php/core-standards.mdc`
+- Apply `@rules/git/general.mdc`
+- Output must be in English
+- Do not modify other skills, rules, or production code
+- Do not duplicate an existing skill — extend or refactor instead
+- Never add behavior beyond what the requested skill needs
+
+---
+
+## Use when
+- A new Agent skill must be added to `skills/` for an AI agent workflow
+- An existing workflow that lives only in chat history should be promoted to a reusable skill
+- The user asks to "create a skill", "add a skill", or "scaffold a skill"
+
+---
+
+## Inputs the agent must collect
+Before generating any file, confirm with the user:
+- **Skill name** — kebab-case, ≤ 64 chars, unique under `skills/`
+- **Purpose** — one sentence describing what the skill does
+- **Trigger phrase** — the "Use when …" wording for the description
+- **Scope** — read-only review, code change, refactor, delivery, or other
+- **Required rules** — which `rules/**/*.md*` files the skill must apply
+- **Integrations** — issue tracker, GitHub, MySQL, Telescope, etc. (or none)
+- **Output expectations** — markdown report, code change, PR comment, etc.
+
+If the user already provided enough context, restate the assumptions and continue without re-asking.
+
+---
+
+## Execution
+
+### 1. Discover existing skills
+- List `skills/` and read any skill whose name overlaps semantically with the request.
+- If an existing skill already covers the workflow, stop and propose an update to that skill instead of creating a new one.
+
+### 2. Choose the slug and location
+- Slug must be kebab-case, ≤ 64 chars, and not collide with an existing folder under `skills/`.
+- Create `skills/<slug>/SKILL.md`. Add subfolders (`templates/`, `references/`) only when the skill genuinely needs them.
+
+### 3. Write the frontmatter
+Required keys:
+
+```yaml
+---
+name: <slug>
+description: "Use when <trigger phrase>. <one sentence on scope>."
+license: MIT
+metadata:
+  author: "Petr Král (pekral.cz)"
+---
+```
+
+Rules from `skill-check.config.json`:
+- `description`: 50–1024 chars; should start with "Use when"
+- `name`: ≤ 64 chars
+- Body: ≤ 500 lines and ≤ 5000 tokens
+
+### 4. Compose the body
+Use the following section order. Omit a section only when it does not apply.
+
+1. `# <Title Case Name>`
+2. `## Purpose` — one short paragraph plus a bullet list of focus areas
+3. `## Constraints` — applied rules and hard limits (one bullet per item)
+4. `## Use when` — concrete triggers
+5. `## Execution` — numbered steps the agent must follow
+6. `## Output` or `## Output Format` — structure of what the skill returns
+7. `## Principles` — short guiding rules (optional)
+8. `## Done when` — verifiable completion criteria
+
+### 5. Reference rules and other skills
+- Reference rule files as `@rules/<area>/<file>.mdc` or `.md` exactly as they exist on disk.
+- Reference other skills as `@skills/<slug>/SKILL.md`.
+- Never invent paths. Verify every reference points to a real file before saving.
+
+### 6. Keep behavior minimal
+- One skill, one workflow. Split into separate skills if the scope grows.
+- Do not paste rule content into the skill — link to it.
+- Do not add humanizer, marketing, or third-party links unless the user requests them.
+
+---
+
+## Quality Gates
+Run before declaring the skill done:
+- `composer skill-check-fix` — auto-fix `SKILL.md` formatting
+- `composer skill-check` — must report `PASS` with no warnings
+- `composer build` — full project build (must finish without errors)
+
+If `skill-check` flags warnings on the new file, fix the SKILL.md until the report is clean. Do not silence checks.
+
+---
+
+## Repository updates
+After the new SKILL.md passes validation:
+- Add a `CHANGELOG.md` entry under `[Unreleased]` describing the new skill and referencing the issue (e.g. `(#432)`).
+- Update `README.md`:
+  - bump the skill count in the "Skills Overview" header and the "Why This Package" bullet
+  - add the new skill to the appropriate table (Issue Resolution, Code Review, Testing, Platform & Data, etc.)
+
+Skip the README update only when the skill is intentionally internal and not part of the public catalog — state this explicitly in the PR description.
+
+---
+
+## Output
+
+- New file: `skills/<slug>/SKILL.md`
+- Updated `CHANGELOG.md` and `README.md`
+- Short summary covering:
+  - chosen slug and scope
+  - rules and skills referenced
+  - skill-check result
+  - follow-up tasks (e.g. tests for code that the skill orchestrates) if any
+
+---
+
+## Principles
+
+- Reuse existing skills before adding new ones
+- Keep each skill narrow and composable
+- Prefer explicit steps over vague guidance
+- Verify every `@rules/*` and `@skills/*` reference exists
+- Let `skill-check` be the source of truth for SKILL.md quality
+
+---
+
+## Done when
+- `skills/<slug>/SKILL.md` exists with valid frontmatter and required sections
+- `composer skill-check` passes with no warnings on the new file
+- `composer build` finishes without errors
+- `CHANGELOG.md` and `README.md` reflect the new skill (or the omission is justified)
+- The summary lists the slug, references, and validation result

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -37,7 +37,7 @@ Focus on:
 ---
 
 ## Inputs the agent must collect
-Before generating any file, confirm with the user:
+Before generating any file, gather:
 - **Skill name** — kebab-case, ≤ 64 chars, unique under `skills/`
 - **Purpose** — one sentence describing what the skill does
 - **Trigger phrase** — the "Use when …" wording for the description
@@ -46,7 +46,7 @@ Before generating any file, confirm with the user:
 - **Integrations** — issue tracker, GitHub, MySQL, Telescope, etc. (or none)
 - **Output expectations** — markdown report, code change, PR comment, etc.
 
-If the user already provided enough context, restate the assumptions and continue without re-asking.
+If running interactively, confirm the inputs with the user. If running autonomously (e.g. invoked by `resolve-issue` or a scheduled workflow), infer the inputs from the triggering issue / PR description and state the assumptions in the final summary.
 
 ---
 
@@ -79,16 +79,31 @@ Rules from `skill-check.config.json`:
 - Body: ≤ 500 lines and ≤ 5000 tokens
 
 ### 4. Compose the body
-Use the following section order. Omit a section only when it does not apply.
+The repo accepts two body layouts. Pick one and stay consistent within the file.
+
+**Layout A — Constraints-first (preferred for new skills):**
+
+1. `## Constraints` — applied rules and hard limits (one bullet per item)
+2. `## Use when` — concrete triggers
+3. `## Required approach` or `## Execution` — numbered steps the agent must follow
+4. `## Output` or `## Output Format` — structure of what the skill returns
+5. `## Done when` — verifiable completion criteria
+
+Examples in the repo: `refactor-entry-point-to-action`, `smartest-project-addition`, `test-driven-development`, `test-like-human`, `security-review`.
+
+**Layout B — Title + Purpose (legacy, still acceptable):**
 
 1. `# <Title Case Name>`
 2. `## Purpose` — one short paragraph plus a bullet list of focus areas
-3. `## Constraints` — applied rules and hard limits (one bullet per item)
-4. `## Use when` — concrete triggers
-5. `## Execution` — numbered steps the agent must follow
-6. `## Output` or `## Output Format` — structure of what the skill returns
-7. `## Principles` — short guiding rules (optional)
-8. `## Done when` — verifiable completion criteria
+3. `## Constraints`
+4. `## Execution`
+5. `## Output` or `## Output Format`
+6. `## Principles` — short guiding rules (optional)
+7. `## Done when`
+
+Examples in the repo: `code-review`, `class-refactoring`, `create-test`, `analyze-problem`.
+
+Omit a section only when it does not apply.
 
 ### 5. Reference rules and other skills
 - Reference rule files as `@rules/<area>/<file>.mdc` or `.md` exactly as they exist on disk.
@@ -104,11 +119,11 @@ Use the following section order. Omit a section only when it does not apply.
 
 ## Quality Gates
 Run before declaring the skill done:
-- `composer skill-check-fix` — auto-fix `SKILL.md` formatting
-- `composer skill-check` — must report `PASS` with no warnings
+- `composer skill-check` — must report `PASS` with no warnings on the new file
+- If `skill-check` flags an auto-fixable warning, run `npx skill-check check skills/<slug> --fix --no-security-scan` (path-scoped) instead of `composer skill-check-fix`, which rewrites every skill in the tree and can pollute the diff with unrelated formatting changes
 - `composer build` — full project build (must finish without errors)
 
-If `skill-check` flags warnings on the new file, fix the SKILL.md until the report is clean. Do not silence checks.
+Do not silence checks; fix the SKILL.md content until the report is clean.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds new `skill-creator` Agent skill that scaffolds SKILL.md files following project conventions and `skill-check.config.json` limits.
- Updates `CHANGELOG.md` (Unreleased) and bumps the skill catalog in `README.md` from 23 to 24, with the new entry under "Code Review, Security & Architecture".

Closes #432

## Test plan
- [x] `composer skill-check` — PASS (24 skills, 0 warnings)
- [x] `composer build` — PASS (93 tests, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)