### PR TITLE
docs(rules): mandate Pest syntax for new tests (#430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 - 🐛 **Fixed**: all mock rules now prefer partial mocks (`makePartial()`) over full mocks (#241)
 - ✨ **Added**: new Agent skill `skill-creator` for scaffolding new SKILL.md files that follow project conventions and pass `skill-check` validation (#432)
 - ✨ **Added**: new Laravel rule `laravel/queue-debouncing.mdc` covering safe queue debouncing, urgency separation, replaceable-work design, and review/testing requirements (#431)
+- 📝 **Changed**: testing rules now explicitly mandate Pest syntax (`it()` / `test()`) for all new test files; PHPUnit class-based tests are no longer allowed for new tests (#430)
 
 ## [0.6.2] - 2026-04-07
 

--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -10,6 +10,7 @@ globs: []
     - @rules/php/core-standards.mdc
     - @rules/laravel/architecture.mdc (for Laravel projects)
 
+- Write all new tests using Pest syntax (`it()` / `test()` functional blocks). Do not introduce PHPUnit-style class-based tests for new test files. When modifying existing PHPUnit tests, prefer rewriting them to Pest via `@skills/rewrite-tests-pest/SKILL.md` rather than extending the legacy class.
 - Never use `describe()`; use top-level `it()` / `test()` only.
 - Test classes should be `final`.
 - Prefer local variables; avoid shared mutable state.

--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -10,7 +10,8 @@ globs: []
     - @rules/php/core-standards.mdc
     - @rules/laravel/architecture.mdc (for Laravel projects)
 
-- Write all new tests using Pest syntax (`it()` / `test()` functional blocks). Do not introduce PHPUnit-style class-based tests for new test files. When modifying existing PHPUnit tests, prefer rewriting them to Pest via `@skills/rewrite-tests-pest/SKILL.md` rather than extending the legacy class.
+- Write all new tests using Pest syntax (`it()` / `test()` functional blocks). Do not introduce PHPUnit-style class-based tests for new test files.
+- When modifying existing PHPUnit tests, prefer rewriting them to Pest via `@skills/rewrite-tests-pest/SKILL.md` rather than extending the legacy class.
 - Never use `describe()`; use top-level `it()` / `test()` only.
 - Test classes should be `final`.
 - Prefer local variables; avoid shared mutable state.

--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -89,6 +89,7 @@ globs: ["*"]
 
 ## Testing
 - Add or update tests for every meaningful behavior change.
+- Write all new tests using Pest syntax (`it()` / `test()` functional blocks); do not introduce PHPUnit-style class-based tests for new test files.
 - Prefer deterministic tests.
 - Use the arrange-act-assert structure when it improves readability.
 - Use clear, human-readable test names.


### PR DESCRIPTION
## Summary
- Adds an explicit "use Pest syntax for new tests" rule to both `rules/code-testing/general.mdc` and `rules/php/core-standards.mdc` (Testing section).
- Existing rules already implied Pest via `it()` / `test()` mentions and `tests/Pest.php` references, but never stated it as a hard mandate. This PR closes that gap so skills like `create-test`, `create-missing-tests-in-pr`, and `test-driven-development` (which `Apply @rules/code-testing/general.mdc`) inherit the mandate.
- Points users to `@skills/rewrite-tests-pest/SKILL.md` when modifying legacy PHPUnit tests.
- Adds Unreleased CHANGELOG entry.

Closes #430

## Test plan
- [x] `composer build` — PASS (93 tests, 100% coverage)
- [x] No existing test was modified — rule changes are documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)