### PR TITLE
docs(rules,skills): mandate 100% coverage with discovery + report (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 - ✨ **Added**: new Agent skill `skill-creator` for scaffolding new SKILL.md files that follow project conventions and pass `skill-check` validation (#432)
 - ✨ **Added**: new Laravel rule `laravel/queue-debouncing.mdc` covering safe queue debouncing, urgency separation, replaceable-work design, and review/testing requirements (#431)
 - 📝 **Changed**: testing rules now explicitly mandate Pest syntax (`it()` / `test()`) for all new test files; PHPUnit class-based tests are no longer allowed for new tests (#430)
+- 📝 **Changed**: rules and CR skills now require 100% test coverage for every changed code path, mandate discovering the project's coverage command (Phing → Composer) before running it, and require a `## Coverage` section in every published CR comment — never push a CR report without the coverage result (#429)
 
 ## [0.6.2] - 2026-04-07
 

--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -56,8 +56,9 @@ globs: []
 
 ## Coverage
 - Every test change must be verified to be functional — run affected tests after each modification.
-- Ensure 100% code coverage for all changed or added code paths.
-- If coverage tooling exists in the project, use it to verify coverage after test changes.
+- Require 100% code coverage for every changed or added code path — applies equally to code modifications and code review.
+- Before running coverage, discover the project's coverage command (prefer Phing target from `build.xml`/`phing.xml`; fall back to a Composer script in `composer.json` such as `test:coverage` or `coverage`). Do not assume a default command.
+- Always report the coverage result (tool used, command, % covered for changed lines). If no coverage tooling can be discovered, state that explicitly and treat it as a blocking finding — never silently skip the check or push a report without it.
 
 ## Code Style and Quality Gates
 - Discover available fixers and checkers: prefer Phing targets (`build.xml`/`phing.xml`) over Composer scripts (`composer.json`).

--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -90,6 +90,7 @@ globs: ["*"]
 ## Testing
 - Add or update tests for every meaningful behavior change.
 - Write all new tests using Pest syntax (`it()` / `test()` functional blocks); do not introduce PHPUnit-style class-based tests for new test files.
+- Require 100% test coverage for every changed or added code path. Before running coverage, discover the project's coverage command (prefer Phing target from `build.xml`/`phing.xml`; fall back to a Composer script in `composer.json` such as `test:coverage` or `coverage`). Always report the result; never push or finalize a change without it.
 - Prefer deterministic tests.
 - Use the arrange-act-assert structure when it improves readability.
 - Use clear, human-readable test names.

--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -90,7 +90,9 @@ globs: ["*"]
 ## Testing
 - Add or update tests for every meaningful behavior change.
 - Write all new tests using Pest syntax (`it()` / `test()` functional blocks); do not introduce PHPUnit-style class-based tests for new test files.
-- Require 100% test coverage for every changed or added code path. Before running coverage, discover the project's coverage command (prefer Phing target from `build.xml`/`phing.xml`; fall back to a Composer script in `composer.json` such as `test:coverage` or `coverage`). Always report the result; never push or finalize a change without it.
+- Require 100% test coverage for every changed or added code path.
+- Before running coverage, discover the project's coverage command (prefer Phing target from `build.xml`/`phing.xml`; fall back to a Composer script in `composer.json` such as `test:coverage` or `coverage`).
+- Always report the coverage result; never push or finalize a change without it.
 - Prefer deterministic tests.
 - Use the arrange-act-assert structure when it improves readability.
 - Use clear, human-readable test names.

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -108,6 +108,7 @@ Before reviewing code, load and analyze the full linked issue:
 - These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test directly from the PR comment.
 - Minor findings may omit these fields when no behavior change is implied.
 - If reviewed code violates project rules or architecture but is **out of scope** for the current PR, add a **Refactoring Proposals** section with issue drafts (justified by defined rules only)
+- The posted PR comment must always include a `## Coverage` section before the summary line. The section reports the tool used, command run, and coverage result for changed lines (or "tooling unavailable" with reason). Never post a CR comment without it.
 - End with summary line
 
 ## Output Format

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -52,4 +52,12 @@
 Only propose refactoring justified by defined rules — not stylistic preferences.
 Omit this section if no opportunities are found.
 
+## Coverage
+
+> Mandatory. Never post a CR comment without this section.
+
+- **Tool:** name of the discovered coverage tool (Phing target, Composer script, etc.) or "not available" with reason.
+- **Command:** exact command that was executed.
+- **Result:** % covered for changed lines (or list any uncovered added/changed lines, which must also appear as Critical findings).
+
 **Summary: X Critical, Y Moderate, Z Minor, R Refactoring (DRY / Tech Debt Reduction)**

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -106,6 +106,7 @@ Before reviewing code, load and analyze the full JIRA issue:
     - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
 - These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test directly from the PR comment.
 - Minor findings may omit these fields when no behavior change is implied.
+- The posted PR comment must always include a `## Coverage` section before the summary line. The section reports the tool used, command run, and coverage result for changed lines (or "tooling unavailable" with reason). Never post a CR comment without it.
 - Use the template defined in `templates/github-output.md`
 
 ### JIRA (non-technical summary — only here)

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -52,4 +52,12 @@
 Only propose refactoring justified by defined rules — not stylistic preferences.
 Omit this section if no opportunities are found.
 
+## Coverage
+
+> Mandatory. Never post a CR comment without this section.
+
+- **Tool:** name of the discovered coverage tool (Phing target, Composer script, etc.) or "not available" with reason.
+- **Command:** exact command that was executed.
+- **Result:** % covered for changed lines (or list any uncovered added/changed lines, which must also appear as Critical findings).
+
 **Summary: X Critical, Y Moderate, Z Minor, R Refactoring (DRY / Tech Debt Reduction)**

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -122,9 +122,11 @@ Run this section over the PR diff only — never over untouched code.
 ### Validation
 - Verify acceptance criteria
 - **Coverage gate (mandatory):** every line, branch, and condition added or modified in the current PR diff must be covered by tests.
-  - Run the project coverage tool (e.g. `composer test:coverage` / `phpunit --coverage-*`) scoped to changed files.
+  - Before running coverage, discover the project's coverage command (prefer Phing target from `build.xml`/`phing.xml`; fall back to a Composer script in `composer.json` such as `test:coverage` or `coverage`). Do not assume a default command.
+  - Run the discovered command scoped to changed files.
   - Map the coverage report to the diff and list any uncovered added/changed lines as **Critical** findings.
   - If coverage tooling is unavailable or cannot be executed, raise that as a **Critical** finding instead of skipping the check.
+  - Always include a `## Coverage` section in the published review reporting the tool used, the command run, and the result for changed lines (or "tooling unavailable" with reason). Never finalize a review without it.
 - Identify missing test scenarios beyond raw coverage (edge cases, error paths, regressions).
 
 ---

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -54,4 +54,12 @@ If any reviewed code violates project rules (`@rules/php/core-standards.mdc`, `@
 Only propose refactoring that is justified by defined rules or architecture — not stylistic preferences.
 If no refactoring opportunities are found, omit this section.
 
+## Coverage
+
+> Mandatory. Never finalize a review without this section.
+
+- **Tool:** name of the discovered coverage tool (Phing target, Composer script, etc.) or "not available" with reason.
+- **Command:** exact command that was executed.
+- **Result:** % covered for changed lines (or list any uncovered added/changed lines, which must also appear as Critical findings).
+
 **Summary: X Critical, Y Moderate, Z Minor, R Refactoring (DRY / Tech Debt Reduction)**


### PR DESCRIPTION
## Summary
- Adds explicit 100% coverage mandate to `rules/php/core-standards.mdc` (alwaysApply:true) so it propagates to every file edit.
- Tightens `rules/code-testing/general.mdc` Coverage section with mandatory tool discovery (Phing → Composer) and mandatory result reporting; missing coverage tooling is now a blocking finding, not a silent skip.
- Updates `code-review`, `code-review-github`, `code-review-jira` SKILL.md and their templates so every published CR review includes a `## Coverage` section (tool, command, result) before the Summary. CR comments without coverage are explicitly forbidden.

Closes #429

## Files touched
- `CHANGELOG.md`
- `rules/php/core-standards.mdc`
- `rules/code-testing/general.mdc`
- `skills/code-review/SKILL.md` + `templates/review-output.md`
- `skills/code-review-github/SKILL.md` + `templates/pr-comment-output.md`
- `skills/code-review-jira/SKILL.md` + `templates/github-output.md`

## Test plan
- [x] `composer build` — PASS (93 tests, 100% coverage)
- [x] No production code touched; all edits are documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)