### PR TITLE
feat(rules): require deduplicationId() on SQS-deduplicated Laravel jobs (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 - ✨ **Added**: new Laravel rule `laravel/queue-debouncing.mdc` covering safe queue debouncing, urgency separation, replaceable-work design, and review/testing requirements (#431)
 - 📝 **Changed**: testing rules now explicitly mandate Pest syntax (`it()` / `test()`) for all new test files; PHPUnit class-based tests are no longer allowed for new tests (#430)
 - 📝 **Changed**: rules and CR skills now require 100% test coverage for every changed code path, mandate discovering the project's coverage command (Phing → Composer) before running it, and require a `## Coverage` section in every published CR comment — never push a CR report without the coverage result (#429)
+- 📝 **Changed**: Laravel queue rules require a `deduplicationId(): string` method directly on the job class when using SQS FIFO / an SQS deduplicator package — the job is the source of truth for its own deduplication identity (#428)
 
 ## [0.6.2] - 2026-04-07
 

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -92,6 +92,7 @@ globs:
 - Avoid heavy logic in job constructors.
 - Define retries, timeout, and backoff explicitly or via config.
 - When reviewing jobs, verify whether queue behavior is configured in the job class or centrally in config.
+- When using an SQS FIFO queue or an SQS deduplicator package, the job class itself must expose a `deduplicationId(): string` method that returns the deduplication key. Do not configure the deduplication key outside the job (in dispatchers, middleware, service providers, or config callbacks) — the job is the source of truth for its own deduplication identity. Compose the key from stable, business-meaningful inputs (e.g. payload identifiers) so retries of the same logical event resolve to the same key.
 
 ## Middleware
 - Use middleware only for cross-cutting concerns.

--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -92,7 +92,9 @@ globs:
 - Avoid heavy logic in job constructors.
 - Define retries, timeout, and backoff explicitly or via config.
 - When reviewing jobs, verify whether queue behavior is configured in the job class or centrally in config.
-- When using an SQS FIFO queue or an SQS deduplicator package, the job class itself must expose a `deduplicationId(): string` method that returns the deduplication key. Do not configure the deduplication key outside the job (in dispatchers, middleware, service providers, or config callbacks) — the job is the source of truth for its own deduplication identity. Compose the key from stable, business-meaningful inputs (e.g. payload identifiers) so retries of the same logical event resolve to the same key.
+- When using an SQS FIFO queue or an SQS deduplicator package, the job class itself must expose a `deduplicationId(): string` method that returns the deduplication key.
+- Do not configure the deduplication key outside the job (in dispatchers, middleware, service providers, or config callbacks) — the job is the source of truth for its own deduplication identity.
+- Compose the deduplication key from stable, business-meaningful inputs (e.g. payload identifiers) so retries of the same logical event resolve to the same key.
 
 ## Middleware
 - Use middleware only for cross-cutting concerns.


### PR DESCRIPTION
## Summary
- Adds a Queue and Jobs rule to `rules/laravel/laravel.mdc` mandating that Laravel jobs using an SQS FIFO queue or an SQS deduplicator package expose a `deduplicationId(): string` method directly on the job class.
- The job is now declared the source of truth for its own deduplication identity — the rule explicitly forbids configuring the key in dispatchers, middleware, service providers, or config callbacks, and recommends composing the key from stable, business-meaningful inputs.
- Adds Unreleased CHANGELOG entry.

Closes #428

## Test plan
- [x] `composer build` — PASS (93 tests, 100% coverage)
- [x] No production code changed; documentation-only diff.

## Coverage
- **Tool:** Composer script `test:coverage` (Phing not available; no `build.xml`/`phing.xml` in repo)
- **Command:** `composer test:coverage` → `vendor/bin/pest --coverage tests --min=100`
- **Result:** 100.0% across all source classes (no new PHP lines added; existing coverage preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)