### PR TITLE
feat(skills): unify JIRA context loading via load-issue.sh

### DIFF
--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -29,8 +29,10 @@ Perform code review for JIRA issues by analyzing related pull requests and publi
 ## Execution
 
 ### 1. Load Context
-- Load JIRA issue, comments, and attachments using `acli`. If `acli` is unavailable, fall back to JIRA MCP server.
-- Identify all open PRs linked to the issue
+- Load JIRA context by running `./scripts/load-issue.sh <KEY|URL>` — the single deterministic entry point. Never call `acli` directly. Read issue header, description, comments, attachments, subtasks, issue links, custom fields, `devSummary`, and `pullRequests` off the resulting JSON document.
+- The script accepts a bare key (`ECOMAIL-1234`), a `/browse/<KEY>` URL, or any URL containing `?selectedIssue=<KEY>`.
+- If the script is unavailable (missing tool, exit code 2/3) fall back to the JIRA MCP server. Always prefer the MCP fallback for data the script cannot cover: changelog (`expand=changelog`), available next transitions, and friendly custom-field names (`expand=names`).
+- Identify all open PRs linked to the issue from the script's `pullRequests` array
 - Before reviewing a PR, switch to the PR branch and pull latest changes
 
 #### Issue Context Analysis

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -29,7 +29,7 @@ Perform code review for JIRA issues by analyzing related pull requests and publi
 ## Execution
 
 ### 1. Load Context
-- Load JIRA context by running `./scripts/load-issue.sh <KEY|URL>` — the single deterministic entry point. Never call `acli` directly. Read issue header, description, comments, attachments, subtasks, issue links, custom fields, `devSummary`, and `pullRequests` off the resulting JSON document.
+- Load JIRA context by running `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` — the single deterministic entry point. Never call `acli` directly. Read issue header, description, comments, attachments, subtasks, issue links, custom fields, `devSummary`, and `pullRequests` off the resulting JSON document.
 - The script accepts a bare key (`ECOMAIL-1234`), a `/browse/<KEY>` URL, or any URL containing `?selectedIssue=<KEY>`.
 - If the script is unavailable (missing tool, exit code 2/3) fall back to the JIRA MCP server. Always prefer the MCP fallback for data the script cannot cover: changelog (`expand=changelog`), available next transitions, and friendly custom-field names (`expand=names`).
 - Identify all open PRs linked to the issue from the script's `pullRequests` array

--- a/skills/code-review-jira/scripts/load-issue.sh
+++ b/skills/code-review-jira/scripts/load-issue.sh
@@ -23,7 +23,7 @@
 #     "timeTracking": { "originalEstimate", "remainingEstimate", "timeSpent", "ratio" },
 #     "descriptionAdf":  <raw ADF or null>,
 #     "descriptionText": "<flattened plain text>",
-#     "descriptionMediaRefs": [ { "adfId", "altText", "filename", "attachmentId", "contentUrl", "mimeType" } ],
+#     "descriptionMediaRefs": [ { "adfId", "altText" } ],
 #     "issueLinks":  [ { "id", "type", "direction", "verb", "linkedKey", "linkedSummary", "linkedStatus", "linkedType" } ],
 #     "subtasks":    [ { "key", "summary", "status", "type" } ],
 #     "comments":    [ { "author", "body", "created", "visibility" } ],
@@ -35,9 +35,15 @@
 #
 # Notes:
 #   - `customFields` runs every customfield_* value through a universal Java/Groovy
-#     toString unwrap: any value that wraps `json={…}` is parsed back into JSON.
-#     Primitives, arrays, and already-structured objects pass through unchanged.
-#     No site-specific field IDs are hardcoded.
+#     toString unwrap: any string that starts with `{` and contains `json={…}` is
+#     parsed back into JSON. The leading-`{` anchor keeps the unwrap from firing
+#     on free-text fields that happen to mention `json={…}` in prose. Primitives,
+#     arrays, and already-structured objects pass through unchanged. No
+#     site-specific field IDs are hardcoded.
+#   - `descriptionMediaRefs[]` carries only `adfId` + `altText`. Correlating ADF
+#     media nodes back to entries in `attachments[]` requires an additional
+#     Atlassian Cloud Media API call, which is out of scope for this script;
+#     consumers should join on `attachments[]` themselves when needed.
 #   - `devSummary` is a convenience projection derived from
 #     customFields[$JIRA_DEV_SUMMARY_FIELD] (default `customfield_10000`,
 #     overridable via the JIRA_DEV_SUMMARY_FIELD env var). The shape stays
@@ -174,7 +180,7 @@ def tryParseTrimEnd:
   | .parsed;
 
 def unwrapJavaToString:
-  if type == "string" and test("json=\\{") then
+  if type == "string" and test("^\\{.*json=\\{") then
     (capture("json=(?<j>\\{.*\\})") | .j) as $candidate
     | (($candidate | fromjson?) // ($candidate | tryParseTrimEnd) // .)
   else .
@@ -217,7 +223,6 @@ def adfMedia:
 | ($f.description // null) as $desc
 | (if $desc == null then "" else ($desc | adfText) end) as $descText
 | (if $desc == null then [] else ($desc | adfMedia) end) as $descMedia
-| ($att | map({id: (.id // null), filename: (.filename // null), contentUrl: (.content // null), mimeType: (.mimeType // null)})) as $attIdx
 | {
     key: $key,
     url: (if $host != "" then "https://" + $host + "/browse/" + $key else null end),
@@ -248,9 +253,7 @@ def adfMedia:
     },
     descriptionAdf: $desc,
     descriptionText: ($descText | gsub("\n\n+"; "\n\n") | sub("\n+$"; "")),
-    descriptionMediaRefs: ($descMedia | map(. + {
-      filename: null, attachmentId: null, contentUrl: null, mimeType: null
-    })),
+    descriptionMediaRefs: $descMedia,
     issueLinks: ($links | map(
       if .outwardIssue then
         { id: .id, type: (.type.name // null), direction: "outward",

--- a/skills/code-review-jira/scripts/load-issue.sh
+++ b/skills/code-review-jira/scripts/load-issue.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# load-issue.sh — single deterministic entry point for loading JIRA issue context.
+#
+# Usage:
+#   load-issue.sh <KEY|URL>
+#
+# Accepts:
+#   - a bare issue key, e.g. ECOMAIL-1234
+#   - a /browse/<KEY> URL, e.g. https://ecomail.atlassian.net/browse/ECOMAIL-1234
+#   - any JIRA URL containing ?selectedIssue=<KEY> (atlOrigin and other query
+#     params are tolerated and ignored)
+#
+# Emits one JSON document on stdout with the following stable shape:
+#
+#   {
+#     "key", "url", "summary", "status", "issueType", "priority",
+#     "assignee", "reporter", "creator", "created", "updated",
+#     "resolution", "resolutionDate", "dueDate", "environment",
+#     "labels", "components", "fixVersions",
+#     "parent":  { "key", "summary", "status" } | null,
+#     "project": { "key", "name", "typeKey" }   | null,
+#     "watchCount": <int>,
+#     "timeTracking": { "originalEstimate", "remainingEstimate", "timeSpent", "ratio" },
+#     "descriptionAdf":  <raw ADF or null>,
+#     "descriptionText": "<flattened plain text>",
+#     "descriptionMediaRefs": [ { "adfId", "altText", "filename", "attachmentId", "contentUrl", "mimeType" } ],
+#     "issueLinks":  [ { "id", "type", "direction", "verb", "linkedKey", "linkedSummary", "linkedStatus", "linkedType" } ],
+#     "subtasks":    [ { "key", "summary", "status", "type" } ],
+#     "comments":    [ { "author", "body", "created", "visibility" } ],
+#     "attachments": [ { "id", "name", "size", "mimeType", "contentUrl", "author", "created" } ],
+#     "customFields":  { "customfield_XXXXX": <parsed value>, … },
+#     "devSummary":    { "pullRequestCount", "branchCount", "commitCount", "state", "isStale", "byInstance" } | null,
+#     "pullRequests":  [ { "number", "title", "url", "state", "headRefName", "baseRefName", "isDraft", "mergedAt", "author" } ]
+#   }
+#
+# Notes:
+#   - `customFields` runs every customfield_* value through a universal Java/Groovy
+#     toString unwrap: any value that wraps `json={…}` is parsed back into JSON.
+#     Primitives, arrays, and already-structured objects pass through unchanged.
+#     No site-specific field IDs are hardcoded.
+#   - `devSummary` is a convenience projection derived from
+#     customFields[$JIRA_DEV_SUMMARY_FIELD] (default `customfield_10000`,
+#     overridable via the JIRA_DEV_SUMMARY_FIELD env var). The shape stays
+#     identical across JIRA sites because it's computed, not field-id-bound.
+#   - The Atlassian CLI `--paginate` flag emits a JSON stream (one document per
+#     page) instead of a single document. We slurp with `jq -s` to merge pages.
+#   - `pullRequests` are resolved via `gh search prs <KEY>` and may include PRs
+#     across any GitHub repo the current `gh` auth can see.
+#
+# Known limitations (intentionally out of scope, fall back to JIRA MCP):
+#   - issue changelog (`expand=changelog`)
+#   - available next transitions
+#   - friendly custom-field names (`expand=names`)
+#
+# Exit codes:
+#   1  usage error (missing or unparseable argument)
+#   2  missing required tool (acli, jq)
+#   3  JIRA fetch failed
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: load-issue.sh <KEY|URL>
+
+  KEY    bare JIRA work-item key (e.g. ECOMAIL-1234)
+  URL    /browse/<KEY> URL or any URL with ?selectedIssue=<KEY>
+
+Env:
+  JIRA_SITE                  override the JIRA host (e.g. ecomail.atlassian.net)
+  JIRA_DEV_SUMMARY_FIELD     customfield id feeding devSummary (default: customfield_10000)
+EOF
+}
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  usage
+  exit 1
+fi
+
+INPUT="$1"
+
+for bin in acli jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "load-issue.sh: required tool not found: $bin" >&2
+    exit 2
+  fi
+done
+
+extract_key_from_url() {
+  local url="$1"
+  local key
+  key="$(printf '%s' "$url" | grep -oE '[?&]selectedIssue=[A-Z][A-Z0-9_]+-[0-9]+' | head -n1 | sed -E 's/^[?&]selectedIssue=//')"
+  if [[ -n "$key" ]]; then
+    printf '%s' "$key"
+    return 0
+  fi
+  key="$(printf '%s' "$url" | grep -oE '/browse/[A-Z][A-Z0-9_]+-[0-9]+' | head -n1 | sed -E 's#^/browse/##')"
+  if [[ -n "$key" ]]; then
+    printf '%s' "$key"
+    return 0
+  fi
+  return 1
+}
+
+extract_host_from_url() {
+  local url="$1"
+  printf '%s' "$url" | sed -nE 's#^https?://([^/]+)/.*#\1#p'
+}
+
+KEY=""
+HOST_FROM_URL=""
+
+if [[ "$INPUT" =~ ^[A-Z][A-Z0-9_]+-[0-9]+$ ]]; then
+  KEY="$INPUT"
+elif [[ "$INPUT" =~ ^https?:// ]]; then
+  if ! KEY="$(extract_key_from_url "$INPUT")"; then
+    echo "load-issue.sh: could not extract a JIRA key from URL: $INPUT" >&2
+    exit 1
+  fi
+  HOST_FROM_URL="$(extract_host_from_url "$INPUT")"
+else
+  echo "load-issue.sh: argument must be a bare key or a URL: $INPUT" >&2
+  exit 1
+fi
+
+resolve_host() {
+  if [[ -n "$HOST_FROM_URL" ]]; then
+    printf '%s' "$HOST_FROM_URL"
+    return 0
+  fi
+  if [[ -n "${JIRA_SITE:-}" ]]; then
+    printf '%s' "$JIRA_SITE"
+    return 0
+  fi
+  local config="${HOME}/.config/acli/jira_config.yaml"
+  if [[ -f "$config" ]]; then
+    awk '/^current_profile:/ { cp=$2 } /^[[:space:]]*-[[:space:]]*site:/ { site=$3 } /^[[:space:]]*cloud_id:/ { if ($2 ":" account_id == cp) { print site; exit } cid=$2 } /^[[:space:]]*account_id:/ { account_id=$2; if (cid ":" account_id == cp) { print site; exit } }' "$config" | head -n1
+  fi
+}
+
+HOST="$(resolve_host || true)"
+DEV_FIELD="${JIRA_DEV_SUMMARY_FIELD:-customfield_10000}"
+
+VIEW_JSON="$(acli jira workitem view "$KEY" --fields '*all' --json 2>/dev/null || true)"
+if [[ -z "$VIEW_JSON" ]] || ! printf '%s' "$VIEW_JSON" | jq -e . >/dev/null 2>&1; then
+  echo "load-issue.sh: failed to fetch JIRA issue $KEY" >&2
+  exit 3
+fi
+
+COMMENTS_JSON="$(acli jira workitem comment list --key "$KEY" --json --paginate 2>/dev/null | jq -s '{ comments: ([ .[].comments // [] ] | add // []) }' 2>/dev/null || printf '{"comments": []}')"
+
+PRS_JSON='[]'
+if command -v gh >/dev/null 2>&1; then
+  PRS_JSON="$(gh search prs "$KEY" \
+      --json number,title,url,state,headRefName,baseRefName,isDraft,mergedAt,author \
+      --limit 50 2>/dev/null || printf '[]')"
+  if ! printf '%s' "$PRS_JSON" | jq -e . >/dev/null 2>&1; then
+    PRS_JSON='[]'
+  fi
+fi
+
+jq -n \
+  --arg key "$KEY" \
+  --arg host "$HOST" \
+  --arg devField "$DEV_FIELD" \
+  --argjson view "$VIEW_JSON" \
+  --argjson commentsResp "$COMMENTS_JSON" \
+  --argjson prs "$PRS_JSON" '
+def tryParseTrimEnd:
+  . as $s
+  | { s: $s, parsed: null }
+  | until(.parsed != null or (.s | length) == 0;
+      .s |= .[0:length-1]
+      | .parsed = (.s | fromjson?))
+  | .parsed;
+
+def unwrapJavaToString:
+  if type == "string" and test("json=\\{") then
+    (capture("json=(?<j>\\{.*\\})") | .j) as $candidate
+    | (($candidate | fromjson?) // ($candidate | tryParseTrimEnd) // .)
+  else .
+  end;
+
+def adfText:
+  if type != "object" then ""
+  elif .type == "text" then (.text // "")
+  elif .type == "hardBreak" then "\n"
+  elif (.type // "") | IN("paragraph","heading","bulletList","orderedList","listItem","blockquote","codeBlock")
+  then
+    ((.content // []) | map(adfText) | join("")) + "\n"
+  else
+    ((.content // []) | map(adfText) | join(""))
+  end;
+
+def adfMedia:
+  if type != "object" then []
+  elif .type == "media" then
+    [ { adfId: (.attrs.id // null),
+        altText: (.attrs.alt // null) } ]
+  else
+    ((.content // []) | map(adfMedia) | add // [])
+  end;
+
+($view.fields // {}) as $f
+| ($f.attachment // []) as $att
+| ($f.subtasks // []) as $sub
+| ($f.issuelinks // []) as $links
+| (($f.comment.comments // []) | map({key: .id, value: {created: .created, visibility: (.visibility.value // null)}}) | from_entries) as $viewCommentIdx
+| ($f | to_entries
+       | map(select(.key | startswith("customfield_")))
+       | map({ key: .key, value: (.value | unwrapJavaToString) })
+       | from_entries) as $cf
+| ($cf[$devField] // null) as $devRaw
+| (if ($devRaw | type) == "object" and ($devRaw.cachedValue.summary // null) != null
+    then $devRaw.cachedValue.summary
+    else null
+   end) as $devCached
+| ($f.description // null) as $desc
+| (if $desc == null then "" else ($desc | adfText) end) as $descText
+| (if $desc == null then [] else ($desc | adfMedia) end) as $descMedia
+| ($att | map({id: (.id // null), filename: (.filename // null), contentUrl: (.content // null), mimeType: (.mimeType // null)})) as $attIdx
+| {
+    key: $key,
+    url: (if $host != "" then "https://" + $host + "/browse/" + $key else null end),
+    summary: ($f.summary // null),
+    status: ($f.status.name // null),
+    issueType: ($f.issuetype.name // null),
+    priority: ($f.priority.name // null),
+    assignee: ($f.assignee.displayName // null),
+    reporter: ($f.reporter.displayName // null),
+    creator: ($f.creator.displayName // null),
+    created: ($f.created // null),
+    updated: ($f.updated // null),
+    resolution: ($f.resolution.name // null),
+    resolutionDate: ($f.resolutiondate // null),
+    dueDate: ($f.duedate // null),
+    environment: ($f.environment // null),
+    labels: ($f.labels // []),
+    components: ($f.components // [] | map(.name)),
+    fixVersions: ($f.fixVersions // [] | map(.name)),
+    parent: (if $f.parent then { key: $f.parent.key, summary: ($f.parent.fields.summary // null), status: ($f.parent.fields.status.name // null) } else null end),
+    project: (if $f.project then { key: $f.project.key, name: $f.project.name, typeKey: ($f.project.projectTypeKey // null) } else null end),
+    watchCount: ($f.watches.watchCount // 0),
+    timeTracking: {
+      originalEstimate: ($f.timetracking.originalEstimate // null),
+      remainingEstimate: ($f.timetracking.remainingEstimate // null),
+      timeSpent: ($f.timetracking.timeSpent // null),
+      ratio: ($f.workratio // null)
+    },
+    descriptionAdf: $desc,
+    descriptionText: ($descText | gsub("\n\n+"; "\n\n") | sub("\n+$"; "")),
+    descriptionMediaRefs: ($descMedia | map(. + {
+      filename: null, attachmentId: null, contentUrl: null, mimeType: null
+    })),
+    issueLinks: ($links | map(
+      if .outwardIssue then
+        { id: .id, type: (.type.name // null), direction: "outward",
+          verb: (.type.outward // null),
+          linkedKey: .outwardIssue.key,
+          linkedSummary: (.outwardIssue.fields.summary // null),
+          linkedStatus: (.outwardIssue.fields.status.name // null),
+          linkedType: (.outwardIssue.fields.issuetype.name // null) }
+      else
+        { id: .id, type: (.type.name // null), direction: "inward",
+          verb: (.type.inward // null),
+          linkedKey: (.inwardIssue.key // null),
+          linkedSummary: (.inwardIssue.fields.summary // null),
+          linkedStatus: (.inwardIssue.fields.status.name // null),
+          linkedType: (.inwardIssue.fields.issuetype.name // null) }
+      end)),
+    subtasks: ($sub | map({
+      key: .key,
+      summary: (.fields.summary // null),
+      status: (.fields.status.name // null),
+      type: (.fields.issuetype.name // null)
+    })),
+    comments: ($commentsResp.comments // [] | map(. as $c | {
+      author: (if ($c.author | type) == "object" then ($c.author.displayName // null) else $c.author end),
+      body: (if ($c.body | type) == "object" then ($c.body | adfText) else $c.body end),
+      created: ($c.created // $viewCommentIdx[$c.id].created // null),
+      visibility: (if ($c.visibility | type) == "object" then $c.visibility.value else ($c.visibility // $viewCommentIdx[$c.id].visibility) end)
+    })),
+    attachments: ($att | map({
+      id: (.id // null),
+      name: (.filename // null),
+      size: (.size // null),
+      mimeType: (.mimeType // null),
+      contentUrl: (.content // null),
+      author: (if (.author | type) == "object" then (.author.displayName // null) else .author end),
+      created: (.created // null)
+    })),
+    customFields: $cf,
+    devSummary: (if $devCached == null then null else {
+      pullRequestCount: ($devCached.pullrequest.overall.count // 0),
+      branchCount: ($devCached.branch.overall.count // 0),
+      commitCount: ($devCached.repository.overall.count // 0),
+      state: ($devCached.pullrequest.overall.state // null),
+      isStale: (($devCached.pullrequest.overall.stateCount // 0) == 0),
+      byInstance: ($devCached.pullrequest.byInstanceType // null)
+    } end),
+    pullRequests: ($prs | map({
+      number: .number,
+      title: .title,
+      url: .url,
+      state: .state,
+      headRefName: .headRefName,
+      baseRefName: .baseRefName,
+      isDraft: .isDraft,
+      mergedAt: .mergedAt,
+      author: (.author.login // null)
+    }))
+  }
+'

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -48,7 +48,7 @@ If a previous code review exists for the same PR:
 
 Before reviewing code, load and analyze the full issue context:
 
-1. Load the complete issue or task (description, all comments, and attachments) from the linked tracker (GitHub, JIRA, Bugsnag).
+1. Load the complete issue or task (description, all comments, and attachments) from the linked tracker (GitHub, JIRA, Bugsnag). For JIRA issues, call `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` and read all fields off the resulting JSON document — never call `acli` directly. Fall back to the JIRA MCP server only when the script is unavailable or for data outside its scope (changelog, available transitions, friendly custom-field names).
 2. Extract from the issue:
    - **Requirements and acceptance criteria** — what the code must do
    - **Expected behavior** — how the feature or fix should work

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -40,6 +40,8 @@ For every Critical and Moderate finding, extract the reproducer fields published
 - **Expected Behavior** — the assertion target the test must verify
 - **Test Hint** — the layer (unit, integration, feature) and entry point
 
+For JIRA-originated reviews, read the reproducer fields off `comments[]` and `descriptionText` returned by `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` instead of re-fetching the issue. Never call `acli` directly.
+
 Use these to write a failing test **before** applying the fix:
 
 1. Drop the Faulty Example into a new test case at the layer named in the Test Hint.

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -38,13 +38,13 @@ See `references/source-detection.md` for the detection table and rules.
    - **GitHub:** the issue repository must match the current Git remote origin.
    - **JIRA:** the issue project key must match the configured JIRA project for this repository.
    - If the issue does not belong to the current project, refuse to process it and inform the user.
-2. Fetch and analyze the issue from the detected source. For JIRA issues, use `acli` as the primary tool. If `acli` is unavailable, fall back to JIRA MCP server.
+2. Fetch and analyze the issue from the detected source. For JIRA issues, load context by running `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` and read all fields off the resulting JSON document. Never call `acli` directly. If the script is unavailable (missing tool, exit code 2/3), fall back to the JIRA MCP server.
 3. Define exact requirements and expected behavior.
 4. Classify the task (bug or feature).
 
 ### Comment analysis
 
-5. Before analyzing the problem, fetch and read **all comments and replies** from the issue tracker (GitHub, JIRA, or Bugsnag):
+5. Before analyzing the problem, fetch and read **all comments and replies** from the issue tracker (GitHub, JIRA, or Bugsnag). For JIRA issues, read `comments[]` directly off the JSON loaded in step 2 — do not issue a second listing call:
    - Group comments by conversation thread (e.g., review threads, reply chains).
    - For each thread, determine:
      - **Current requirements** — requests or conditions that are still valid and unfulfilled.


### PR DESCRIPTION
## Summary

- Add `skills/code-review-jira/scripts/load-issue.sh` — single deterministic entry point that loads a JIRA issue and emits one JSON document with the contract documented in #438.
- Route the four JIRA-touching skills (`code-review-jira`, `resolve-issue`, `process-code-review`, `code-review`) through the script. Direct `acli` calls are replaced; JIRA MCP stays as fallback for the things the script can't cover (changelog, available transitions, friendly custom-field names).

Closes #438.

## What the script does

- Accepts a bare key (`ECOMAIL-1234`), a `/browse/<KEY>` URL, or any URL containing `?selectedIssue=<KEY>` (atlOrigin and friends are tolerated).
- Calls `acli jira workitem view --fields '*all'` + `comment list --paginate` (slurped with `jq -s` to fix the JSON-stream-not-document quirk) + `gh search prs <KEY>`.
- Universal Java/Groovy-toString unwrap for any `customfield_*` whose value wraps `json={…}` — no site-specific IDs hardcoded.
- `devSummary` is a convenience projection from `customFields[$JIRA_DEV_SUMMARY_FIELD]` (default `customfield_10000`, env-overridable).
- Exit codes: `1` usage, `2` missing tool, `3` JIRA fetch failed.

## Skills updated

- `skills/code-review-jira/SKILL.md` — section *1. Load Context* points at the script.
- `skills/resolve-issue/SKILL.md` — steps 2 and 5 read off the script's JSON instead of issuing extra `acli` calls.
- `skills/process-code-review/SKILL.md` — the reproducer-fields paragraph now reads off `comments[]` / `descriptionText`.
- `skills/code-review/SKILL.md` — Issue Context Analysis step 1 calls the script for the JIRA branch.

## Test plan

- [x] `composer build` clean: skill-check + Pint + PHPCS + Rector + PHPStan + Pest at 100% coverage, 0 errors.
- [x] Bare key: `load-issue.sh ECOMAIL-2869`
- [x] `/browse/<KEY>` URL: `load-issue.sh https://ecomail.atlassian.net/browse/ECOMAIL-2869`
- [x] `?selectedIssue=` URL: `load-issue.sh 'https://ecomail.atlassian.net/jira/software/projects/ECOMAIL/boards/10?selectedIssue=ECOMAIL-2869&atlOrigin=eyJpIjoiMTIzIn0'`
- [x] All three forms produce one valid JSON document and resolve the same `key`/`url`.
- [x] Error paths: no arg → exit 1 + usage; bad arg → exit 1; unknown key → exit 3.
- [x] Populated Dev panel issue (`ECOMAIL-6290`) — `devSummary` and unwrapped `customfield_10000` parsed correctly through the trim-to-valid-JSON fallback.
- [x] `JIRA_SITE` and `JIRA_DEV_SUMMARY_FIELD` env overrides honored.

Testing reference: JIRA issue [ECOMAIL-2869](https://ecomail.atlassian.net/browse/ECOMAIL-2869) used end-to-end (subtasks-via-link, attachment embedded in description, paginated comments, populated/empty Dev panel cases via ECOMAIL-6290).

🤖 Generated with [Claude Code](https://claude.com/claude-code)