### PR TITLE
feat(skills): add Suggested Fix code snippet to code-review reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 
 ## [Unreleased]
 
+- 📝 **Changed**: code review and security-review skills (`code-review`, `code-review-github`, `code-review-jira`, `security-review`) and their output templates now require a **Suggested Fix** code snippet alongside Faulty Example / Expected Behavior / Test Hint for every Critical and Moderate finding (Critical/High for security). The snippet must comply with `@rules/php/core-standards.mdc` and, on Laravel projects, `@rules/laravel/architecture.mdc`. `process-code-review` reads the snippet and applies it directly when resolving the finding
 - 📝 **Changed**: code review skills (`code-review`, `code-review-github`, `code-review-jira`) and the shared `code-review/general.mdc` rule now require reviewers to flag newly added or modified logic that duplicates behavior already present elsewhere in the codebase — reuse the existing implementation to keep logic unified across the application (#440)
 - 🐛 **Fixed**: CR skills now systematically review all open PRs per issue instead of only one (#227)
 - 🐛 **Fixed**: JIRA skills now consistently prefer `acli` console tool via shared `jira-operations.mdc` rule (#228)

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -105,7 +105,8 @@ Before reviewing code, load and analyze the full linked issue:
     - **Faulty Example** — minimal code snippet or input payload reproducing the issue (redact secrets/PII)
     - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)
     - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
-- These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test directly from the PR comment.
+    - **Suggested Fix** — minimal corrected code snippet that resolves the finding. Must comply with `@rules/php/core-standards.mdc` and, for Laravel projects, `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when a snippet adds no value over the one-line Fix description (e.g. naming-only changes, dead-code removal, pointers to an existing helper whose name already says enough).
+- These four fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test and apply the fix directly from the PR comment.
 - Minor findings may omit these fields when no behavior change is implied.
 - If reviewed code violates project rules or architecture but is **out of scope** for the current PR, add a **Refactoring Proposals** section with issue drafts (justified by defined rules only)
 - The posted PR comment must always include a `## Coverage` section before the summary line. The section reports the tool used, command run, and coverage result for changed lines (or "tooling unavailable" with reason). Never post a CR comment without it.

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -19,6 +19,10 @@
    ```
    Expected Behavior: what the correct outcome (return value, exception, side effect) must be.
    Test Hint: one-sentence outline of the test that would fail today and pass after the fix.
+   Suggested Fix:
+   ```php
+   // minimal corrected snippet that resolves the finding; must comply with @rules/php/core-standards.mdc (and @rules/laravel/architecture.mdc on Laravel projects)
+   ```
 
 ## Moderate
 
@@ -36,10 +40,11 @@
    Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
    Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
 
-> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
+> **Faulty Example, Expected Behavior, Test Hint, and Suggested Fix are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test and apply the fix directly from the PR comment.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
 > - Test Hint must point at the layer the test belongs in (unit, integration, feature) and the entry point to call.
+> - Suggested Fix must be a minimal corrected snippet that complies with `@rules/php/core-standards.mdc` and, on Laravel projects, with `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when a snippet adds no value over the one-line Fix description.
 > - Minor findings may omit these fields when no behavior change is implied (e.g. naming, dead code).
 
 ## Refactoring Proposals

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -106,7 +106,8 @@ Before reviewing code, load and analyze the full JIRA issue:
     - **Faulty Example** — minimal code snippet or input payload reproducing the issue (redact secrets/PII)
     - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)
     - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
-- These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test directly from the PR comment.
+    - **Suggested Fix** — minimal corrected code snippet that resolves the finding. Must comply with `@rules/php/core-standards.mdc` and, for Laravel projects, `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when a snippet adds no value over the one-line Fix description (e.g. naming-only changes, dead-code removal, pointers to an existing helper whose name already says enough).
+- These four fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test and apply the fix directly from the PR comment.
 - Minor findings may omit these fields when no behavior change is implied.
 - The posted PR comment must always include a `## Coverage` section before the summary line. The section reports the tool used, command run, and coverage result for changed lines (or "tooling unavailable" with reason). Never post a CR comment without it.
 - Use the template defined in `templates/github-output.md`

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -19,6 +19,10 @@
    ```
    Expected Behavior: what the correct outcome (return value, exception, side effect) must be.
    Test Hint: one-sentence outline of the test that would fail today and pass after the fix.
+   Suggested Fix:
+   ```php
+   // minimal corrected snippet that resolves the finding; must comply with @rules/php/core-standards.mdc (and @rules/laravel/architecture.mdc on Laravel projects)
+   ```
 
 ## Moderate
 
@@ -36,10 +40,11 @@
    Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
    Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
 
-> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test.
+> **Faulty Example, Expected Behavior, Test Hint, and Suggested Fix are mandatory for every Critical and Moderate finding** so `process-code-review` can turn each finding into a reproducer test and apply the fix directly from the PR comment.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
 > - Test Hint must point at the layer the test belongs in (unit, integration, feature) and the entry point to call.
+> - Suggested Fix must be a minimal corrected snippet that complies with `@rules/php/core-standards.mdc` and, on Laravel projects, with `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when a snippet adds no value over the one-line Fix description.
 > - Minor findings may omit these fields when no behavior change is implied (e.g. naming, dead code).
 
 ## Refactoring Proposals

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -149,7 +149,8 @@ Run this section over the PR diff only — never over untouched code.
     - **Faulty Example** — minimal code snippet or input payload that reproduces the issue (redact secrets/PII)
     - **Expected Behavior** — single assertable statement (return value, exception, persisted state, emitted event)
     - **Test Hint** — one sentence pointing at the test layer (unit, integration, feature) and entry point
-- These three fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test without re-deriving context.
+    - **Suggested Fix** — minimal corrected code snippet that resolves the finding. Must comply with `@rules/php/core-standards.mdc` and, for Laravel projects, `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when a snippet adds no value over the one-line Fix description (e.g. naming-only changes, dead-code removal, pointers to an existing helper whose name already says enough).
+- These four fields exist so `@skills/process-code-review/SKILL.md` can convert each finding into a reproducer test and apply the fix without re-deriving context.
 - Minor findings may omit these fields when no behavior change is implied (naming, dead code, etc.).
 
 ---

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -19,6 +19,10 @@
    ```
    Expected Behavior: what the correct outcome (return value, exception, side effect) must be.
    Test Hint: one-sentence outline of the test that would fail today and pass after the fix.
+   Suggested Fix:
+   ```php
+   // minimal corrected snippet that resolves the finding; must comply with @rules/php/core-standards.mdc (and @rules/laravel/architecture.mdc on Laravel projects)
+   ```
 
 ## Moderate
 
@@ -36,10 +40,11 @@
    Suggested refactoring: concrete consolidation step (Data Builder, DTO, Service, Action, Repository, etc.)
    Why: which rule from `@rules/laravel/architecture.mdc` or `@skills/class-refactoring/SKILL.md` is satisfied by the change.
 
-> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and Moderate finding.** They feed `process-code-review` so each fix can be backed by a reproducer test.
+> **Faulty Example, Expected Behavior, Test Hint, and Suggested Fix are mandatory for every Critical and Moderate finding.** They feed `process-code-review` so each fix can be backed by a reproducer test and applied directly from the CR comment.
 > - Faulty Example must be a minimal, runnable snippet (or sample input/payload) — never paste secrets or real PII; redact with placeholders.
 > - Expected Behavior must be a single assertable statement (return value, thrown exception, persisted state, emitted event).
 > - Test Hint must point at the layer the test belongs in (unit, integration, feature) and the entry point to call.
+> - Suggested Fix must be a minimal corrected snippet that complies with `@rules/php/core-standards.mdc` and, on Laravel projects, with `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when a snippet adds no value over the one-line Fix description.
 > - Minor findings may omit these fields when no behavior change is implied (e.g. naming, dead code).
 
 ## Refactoring Proposals

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -39,6 +39,7 @@ For every Critical and Moderate finding, extract the reproducer fields published
 - **Faulty Example** — the minimal snippet or input that reproduces the bug
 - **Expected Behavior** — the assertion target the test must verify
 - **Test Hint** — the layer (unit, integration, feature) and entry point
+- **Suggested Fix** — the minimal corrected snippet that resolves the finding (may be `n/a — <reason>` when the Fix narrative is sufficient)
 
 For JIRA-originated reviews, read the reproducer fields off `comments[]` and `descriptionText` returned by `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` instead of re-fetching the issue. Never call `acli` directly.
 
@@ -46,9 +47,9 @@ Use these to write a failing test **before** applying the fix:
 
 1. Drop the Faulty Example into a new test case at the layer named in the Test Hint.
 2. Assert the Expected Behavior — the test must fail on the current code.
-3. Apply the fix from the finding; rerun the test until it passes.
+3. Apply the Suggested Fix snippet (or the Fix narrative when Suggested Fix is `n/a`); rerun the test until it passes.
 
-If a finding lacks one of these fields, request a CR rerun rather than guessing — the CR skills are responsible for providing them.
+If a finding lacks Faulty Example, Expected Behavior, or Test Hint, request a CR rerun rather than guessing — the CR skills are responsible for providing them. Suggested Fix may legitimately be `n/a` per the CR rules.
 
 ---
 

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -97,8 +97,9 @@ Avoid generic best-practice noise.
 - **Faulty Example** — minimal code snippet or attacker payload that reproduces the vulnerability (redact secrets, tokens, and PII)
 - **Expected Behavior** — single assertable security guarantee (rejection, authorization denial, escaped output, no side effect)
 - **Test Hint** — one sentence pointing at the test layer (unit, feature, HTTP) and entry point
+- **Suggested Fix** — minimal corrected code snippet that closes the vulnerability (parameterized query, authorization check, output escaping, signature verification, safer SDK call, etc.). Must comply with `@rules/php/core-standards.mdc`, `@rules/security/backend.mdc`, and, for Laravel projects, `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when the fix is purely configurational (env var, web-server header) and is described in the Recommended Fix narrative.
 
-These fields exist so `@skills/process-code-review/SKILL.md` can turn each finding into a regression test without re-deriving the attack vector. Medium and Low findings may omit them when no behavior change is implied.
+These fields exist so `@skills/process-code-review/SKILL.md` can turn each finding into a regression test and apply the fix without re-deriving the attack vector. Medium and Low findings may omit them when no behavior change is implied.
 
 ### Output format
 

--- a/skills/security-review/templates/audit-report.md
+++ b/skills/security-review/templates/audit-report.md
@@ -11,6 +11,10 @@
    ```
    Expected Behavior: what the application must do instead (rejected input, thrown exception, denied authorization, sanitized output).
    Test Hint: one-sentence outline of the security test (request shape, assertion target, layer).
+   Suggested Fix:
+   ```php
+   // minimal corrected snippet that closes the vulnerability; must comply with @rules/php/core-standards.mdc, @rules/security/backend.mdc, and @rules/laravel/architecture.mdc on Laravel projects
+   ```
 
 ### High
 - ...
@@ -21,10 +25,11 @@
 ### Low
 - ...
 
-> **Faulty Example, Expected Behavior, and Test Hint are mandatory for every Critical and High finding** so `process-code-review` can turn each finding into a regression test.
+> **Faulty Example, Expected Behavior, Test Hint, and Suggested Fix are mandatory for every Critical and High finding** so `process-code-review` can turn each finding into a regression test and apply the fix from the report.
 > - Faulty Example must be a minimal, runnable snippet or attacker payload — redact real secrets, tokens, and PII with placeholders.
 > - Expected Behavior must be a single assertable security guarantee (rejection, authorization denial, escaped output, no side effect).
 > - Test Hint must point at the layer the test belongs in (unit, feature, HTTP) and the entry point to call.
+> - Suggested Fix must be a minimal corrected snippet that closes the vulnerability and complies with `@rules/php/core-standards.mdc`, `@rules/security/backend.mdc`, and (on Laravel projects) `@rules/laravel/architecture.mdc`. Use `n/a — <reason>` only when the fix is purely configurational and already described in Recommended Fix.
 > - Medium and Low findings may omit these fields when no behavior change is implied.
 
 ### Action Items


### PR DESCRIPTION
## Souhrn

Code review skilly (`code-review`, `code-review-github`, `code-review-jira`, `security-review`) i jejich výstupní šablony nově vyžadují u každého **Critical** a **Moderate** findingu (resp. Critical/High pro security review) další povinné pole:

**Suggested Fix** — minimální opravný kód, který finding řeší. Snippet musí splňovat `@rules/php/core-standards.mdc` a na Laravel projektech `@rules/laravel/architecture.mdc`. Pokud snippet nepřináší žádnou hodnotu nad jednovětný popis (přejmenování, smazání dead code, ukazatel na existující helper), použije se \`n/a — <důvod>\`.

`process-code-review` nově snippet čte ve fázi *Reproducer extraction* a aplikuje ho přímo při řešení findingu — odpadá opětovné odvozování opravy z volného textu.

## Pre-commit code review

Provedl jsem CR-on-CR podle tvé instrukce *„před vytvořením kódu udělej code review nového kódu"*. Self-CR našel:
- **Moderate**: nová Suggested Fix bullet v `skills/code-review/SKILL.md` původně restatovala obsah pravidel přes závorkové výčty (\"explicit return types, named arguments, no globals, DTOs...\") — drift risk + nekonzistence vůči 3 sesterským SKILL.md souborům. Stejná lekce jako z PR #441. **Opraveno před commitem.**
- **Minor**: stejné závorkové výčty v 3 šablonách. **Opraveno před commitem.**
- **Refactoring (DRY)**: stejný odstavec ve 4 SKILL.md + 3 šablonách (7 míst) — odloženo jako pragmatický mirror per \`@rules/refactoring/general.mdc\`, stejné odůvodnění jako u PR #441.

Po opravách: 0 Critical, 0 Moderate, 0 Minor.

## Test plan

- [ ] \`composer build\` (lokálně proběhlo zeleně: 93 testů, 244 assertions, 0 errors, 0 warnings, 100 % skill validation)
- [ ] Smoke test: spustit \`code-review\` na malém PR s reálným Critical/Moderate findingem — výstup musí obsahovat sekci **Suggested Fix** se snippetem dle pravidel, případně \`n/a — <důvod>\`
- [ ] Smoke test: spustit \`security-review\` na PR s injection nebo missing-authorization findingem — Suggested Fix snippet musí ukazovat parametrizovaný dotaz / Policy check
- [ ] Smoke test: spustit \`process-code-review\` na PR, kde CR komentář obsahuje Suggested Fix — skill musí snippet aplikovat přímo (nikoli odvozovat z Fix narrative)