### PR TITLE
feat(skills): unified GitHub load-issue.sh for AI agent context

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -25,14 +25,16 @@ Run a full code review for GitHub pull requests and publish findings directly to
 ## Execution
 
 ### 1. Load Context
-- Load PR, linked issue, and comments using CLI or MCP tools
+- Load PR context by running `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>` — the single deterministic entry point. Never call `gh issue view`, `gh pr view`, or `gh api /repos/.../issues/...` directly. Read PR header, description, comments, commits, files, reviews, status checks, and `closingIssues` off the resulting JSON document.
+- Load each linked issue (from `closingIssues[]`) the same way — pass its number or URL to the same script.
+- If the script is unavailable (missing tool, exit code 2/3) fall back to the GitHub MCP server. Always prefer the MCP fallback for data the script cannot cover: review-thread / line-anchored comments, per-commit check runs, and binary attachment contents.
 - If multiple PRs exist for one issue, review each independently
 - Before reviewing a PR, switch to the PR branch and pull latest changes
 
 #### Issue Context Analysis
 Before reviewing code, load and analyze the full linked issue:
 
-1. Fetch the complete GitHub issue — description, all comments, and any referenced attachments or links.
+1. Fetch the complete GitHub issue via `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>` — description, all comments, and any referenced attachments or links come off the resulting JSON document.
 2. Extract from the issue:
    - **Requirements and acceptance criteria** — what the code must do
    - **Expected behavior** — how the feature or fix should work
@@ -70,8 +72,8 @@ Before reviewing code, load and analyze the full linked issue:
 
 #### Thread detection
 - Before posting, search for an existing code review comment on the PR:
-  - Use `gh api` to list PR comments and find one matching the CR format (e.g. contains "Summary:" with severity counts)
-  - Store its `comment_id` if found
+  - Read `comments[]` off the JSON loaded in step 1 and find one matching the CR format (e.g. contains "Summary:" with severity counts)
+  - Store its `url` (and the trailing `#issuecomment-<id>`) if found
 
 #### Posting strategy
 - **If an existing CR comment is found (follow-up review):**

--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -72,7 +72,7 @@ Before reviewing code, load and analyze the full linked issue:
 
 #### Thread detection
 - Before posting, search for an existing code review comment on the PR:
-  - Read `comments[]` off the JSON loaded in step 1 and find one matching the CR format (e.g. contains "Summary:" with severity counts)
+  - Read `comments` off the JSON loaded in step 1 and find one matching the CR format (e.g. contains "Summary:" with severity counts)
   - Store its `url` (and the trailing `#issuecomment-<id>`) if found
 
 #### Posting strategy

--- a/skills/code-review-github/scripts/load-issue.sh
+++ b/skills/code-review-github/scripts/load-issue.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# load-issue.sh — single deterministic entry point for loading GitHub issue or PR context.
+#
+# Usage:
+#   load-issue.sh <NUMBER|URL>
+#
+# Accepts:
+#   - a bare issue/PR number, e.g. 445 (uses the current git remote to resolve the repo)
+#   - a GitHub URL, e.g. https://github.com/<owner>/<repo>/issues/445
+#   - a GitHub URL, e.g. https://github.com/<owner>/<repo>/pull/123
+#   - any GitHub URL containing /issues/<N> or /pull/<N>
+#
+# Emits one JSON document on stdout with the following stable shape:
+#
+#   {
+#     "kind": "issue" | "pr",
+#     "number": <int>,
+#     "url": <string>,
+#     "repo": { "owner", "name", "nameWithOwner" },
+#     "title", "body", "state", "stateReason",
+#     "author", "assignees", "labels", "milestone",
+#     "createdAt", "updatedAt", "closedAt",
+#     "comments":     [ { "author", "body", "createdAt", "updatedAt", "url" } ],
+#     "reactionsCount": <int>,
+#
+#     # issue-only (null / [] when kind == "pr")
+#     "closingPullRequests": [ { "number", "title", "url", "state" } ],
+#
+#     # pr-only (null / [] when kind == "issue")
+#     "baseRefName", "headRefName", "baseRefOid", "headRefOid",
+#     "isDraft", "mergeable", "mergeStateStatus",
+#     "mergedAt", "mergedBy", "mergeCommit",
+#     "additions", "deletions", "changedFiles",
+#     "files":             [ { "path", "additions", "deletions" } ],
+#     "commits":           [ { "oid", "messageHeadline", "authoredDate", "authors" } ],
+#     "reviews":           [ { "author", "state", "body", "submittedAt", "url" } ],
+#     "reviewRequests":    [ <login> ],
+#     "reviewDecision":    <string|null>,
+#     "statusCheckRollup": [ { "context", "state", "description", "targetUrl" } ],
+#     "closingIssues":     [ { "number", "title", "url", "state" } ]
+#   }
+#
+# Notes:
+#   - The script is the single deterministic source of GitHub context. Skills must
+#     never call `gh issue view`, `gh pr view`, or `gh api /repos/.../issues/...`
+#     directly: changes to the JSON shape happen here, in one place.
+#   - When the input is a bare number, the repo is resolved from the current
+#     directory's git remote (`origin`). Provide a full URL to load issues/PRs
+#     from any other repo the current `gh` auth can see.
+#   - The kind ("issue" vs "pr") is detected from the URL path when present, and
+#     otherwise inferred by trying `gh issue view` first and falling back to
+#     `gh pr view`. GitHub's REST issue endpoint exposes both numbers, but the
+#     `gh` CLI uses different field sets, so the kind drives which command runs.
+#   - `closingPullRequests` (for issues) is sourced from
+#     `closedByPullRequestsReferences` and surfaces the PRs that will close the
+#     issue when merged. `closingIssues` (for PRs) lists issues the PR closes.
+#
+# Known limitations (intentionally out of scope, fall back to GitHub MCP):
+#   - Review thread / line-anchored review comments (`gh api .../pulls/<N>/comments`)
+#   - Per-commit check runs and detailed CI logs
+#   - Attachment binary contents (only URLs and metadata are returned)
+#
+# Exit codes:
+#   1  usage error (missing or unparseable argument)
+#   2  missing required tool (gh, jq)
+#   3  GitHub fetch failed
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: load-issue.sh <NUMBER|URL>
+
+  NUMBER  bare GitHub issue or PR number (e.g. 445). Resolved against the
+          current directory's git remote.
+  URL     any github.com URL containing /issues/<N> or /pull/<N>
+EOF
+}
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  usage
+  exit 1
+fi
+
+INPUT="$1"
+
+for bin in gh jq; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "load-issue.sh: required tool not found: $bin" >&2
+    exit 2
+  fi
+done
+
+extract_from_url() {
+  # Echoes: "<owner> <repo> <number> <kind>"
+  local url="$1"
+  local path
+  path="$(printf '%s' "$url" | sed -nE 's#^https?://[^/]+/([^/]+)/([^/]+)/(issues|pull)/([0-9]+).*#\1 \2 \4 \3#p')"
+  if [[ -z "$path" ]]; then
+    return 1
+  fi
+  # Normalize "pull" -> "pr"
+  printf '%s' "$path" | awk '{
+    kind = $4
+    if (kind == "pull") kind = "pr"
+    else if (kind == "issues") kind = "issue"
+    print $1, $2, $3, kind
+  }'
+}
+
+resolve_repo_from_git() {
+  local remote
+  remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [[ -z "$remote" ]]; then
+    return 1
+  fi
+  # Handle both git@github.com:owner/repo(.git) and https://github.com/owner/repo(.git)
+  printf '%s' "$remote" \
+    | sed -E -e 's#^git@github\.com:#https://github.com/#' -e 's#\.git$##' \
+    | sed -nE 's#^https?://github\.com/([^/]+)/([^/]+).*#\1 \2#p'
+}
+
+OWNER=""
+REPO=""
+NUMBER=""
+KIND=""
+
+if [[ "$INPUT" =~ ^https?://github\.com/ ]]; then
+  parsed="$(extract_from_url "$INPUT" || true)"
+  if [[ -z "$parsed" ]]; then
+    echo "load-issue.sh: could not extract issue/PR from URL: $INPUT" >&2
+    exit 1
+  fi
+  OWNER="$(printf '%s' "$parsed" | awk '{print $1}')"
+  REPO="$(printf '%s' "$parsed"  | awk '{print $2}')"
+  NUMBER="$(printf '%s' "$parsed" | awk '{print $3}')"
+  KIND="$(printf '%s' "$parsed"   | awk '{print $4}')"
+elif [[ "$INPUT" =~ ^[0-9]+$ ]]; then
+  NUMBER="$INPUT"
+  parsed="$(resolve_repo_from_git || true)"
+  if [[ -z "$parsed" ]]; then
+    echo "load-issue.sh: cannot resolve repo from git remote — pass a full URL instead" >&2
+    exit 1
+  fi
+  OWNER="$(printf '%s' "$parsed" | awk '{print $1}')"
+  REPO="$(printf '%s' "$parsed"  | awk '{print $2}')"
+else
+  echo "load-issue.sh: argument must be a bare number or a github.com URL: $INPUT" >&2
+  exit 1
+fi
+
+NWO="${OWNER}/${REPO}"
+
+ISSUE_FIELDS="assignees,author,body,closed,closedAt,closedByPullRequestsReferences,comments,createdAt,labels,milestone,number,reactionGroups,state,stateReason,title,updatedAt,url"
+PR_FIELDS="additions,assignees,author,baseRefName,baseRefOid,body,changedFiles,closed,closedAt,closingIssuesReferences,comments,commits,createdAt,deletions,files,headRefName,headRefOid,isDraft,labels,latestReviews,maintainerCanModify,mergeCommit,mergeStateStatus,mergeable,mergedAt,mergedBy,milestone,number,reactionGroups,reviewDecision,reviewRequests,reviews,state,statusCheckRollup,title,updatedAt,url"
+
+ISSUE_JSON='null'
+PR_JSON='null'
+
+if [[ -z "$KIND" ]]; then
+  # Try PR first, then issue. GitHub shares the issue/PR number space and
+  # `gh issue view <PR-number>` succeeds with the issue-level projection,
+  # which would hide all PR-only fields. `gh pr view` returns non-zero on
+  # non-PR numbers, so it is the correct discriminator.
+  if PR_JSON="$(gh pr view "$NUMBER" --repo "$NWO" --json "$PR_FIELDS" 2>/dev/null)" && [[ -n "$PR_JSON" ]]; then
+    KIND="pr"
+  elif ISSUE_JSON="$(gh issue view "$NUMBER" --repo "$NWO" --json "$ISSUE_FIELDS" 2>/dev/null)" && [[ -n "$ISSUE_JSON" ]]; then
+    KIND="issue"
+  else
+    echo "load-issue.sh: failed to fetch issue or PR #$NUMBER in $NWO" >&2
+    exit 3
+  fi
+fi
+
+if [[ "$KIND" == "issue" && "$ISSUE_JSON" == "null" ]]; then
+  if ! ISSUE_JSON="$(gh issue view "$NUMBER" --repo "$NWO" --json "$ISSUE_FIELDS" 2>/dev/null)" || [[ -z "$ISSUE_JSON" ]]; then
+    echo "load-issue.sh: failed to fetch issue #$NUMBER in $NWO" >&2
+    exit 3
+  fi
+fi
+
+if [[ "$KIND" == "pr" && "$PR_JSON" == "null" ]]; then
+  if ! PR_JSON="$(gh pr view "$NUMBER" --repo "$NWO" --json "$PR_FIELDS" 2>/dev/null)" || [[ -z "$PR_JSON" ]]; then
+    echo "load-issue.sh: failed to fetch PR #$NUMBER in $NWO" >&2
+    exit 3
+  fi
+fi
+
+if [[ "$KIND" == "issue" ]]; then
+  PAYLOAD="$ISSUE_JSON"
+else
+  PAYLOAD="$PR_JSON"
+fi
+
+if ! printf '%s' "$PAYLOAD" | jq -e . >/dev/null 2>&1; then
+  echo "load-issue.sh: unexpected non-JSON response from gh for #$NUMBER" >&2
+  exit 3
+fi
+
+jq -n \
+  --arg kind "$KIND" \
+  --arg owner "$OWNER" \
+  --arg repo "$REPO" \
+  --argjson payload "$PAYLOAD" '
+def total_reactions:
+  ([ (.reactionGroups // [])[] | (.users.totalCount // .reactors.totalCount // 0) ] | add) // 0;
+
+def map_comments:
+  [ (. // [])[] | {
+      author: (.author.login // null),
+      body: (.body // ""),
+      createdAt: (.createdAt // null),
+      updatedAt: (.updatedAt // null),
+      url: (.url // null)
+  } ];
+
+def map_labels:    [ (. // [])[] | (.name // null) ];
+def map_assignees: [ (. // [])[] | (.login // null) ];
+def map_files:     [ (. // [])[] | { path: (.path // null), additions: (.additions // 0), deletions: (.deletions // 0) } ];
+def map_commits:
+  [ (. // [])[] | {
+      oid: (.oid // null),
+      messageHeadline: (.messageHeadline // null),
+      authoredDate: (.authoredDate // null),
+      authors: [ (.authors // [])[] | (.login // .name // null) ]
+  } ];
+def map_reviews:
+  [ (. // [])[] | {
+      author: (.author.login // null),
+      state: (.state // null),
+      body: (.body // ""),
+      submittedAt: (.submittedAt // null),
+      url: (.url // null)
+  } ];
+def map_status_checks:
+  [ (. // [])[] | {
+      context: (.context // .name // null),
+      state: (.state // .conclusion // .status // null),
+      description: (.description // null),
+      targetUrl: (.targetUrl // .detailsUrl // null)
+  } ];
+def map_refs:
+  [ (. // [])[] | {
+      number: (.number // null),
+      title: (.title // null),
+      url: (.url // null),
+      state: (.state // null)
+  } ];
+
+$payload as $p
+| {
+    kind: $kind,
+    number: ($p.number // null),
+    url: ($p.url // null),
+    repo: { owner: $owner, name: $repo, nameWithOwner: ($owner + "/" + $repo) },
+    title: ($p.title // null),
+    body: ($p.body // ""),
+    state: ($p.state // null),
+    stateReason: ($p.stateReason // null),
+    author: ($p.author.login // null),
+    assignees: ($p.assignees | map_assignees),
+    labels: ($p.labels | map_labels),
+    milestone: ($p.milestone.title // null),
+    createdAt: ($p.createdAt // null),
+    updatedAt: ($p.updatedAt // null),
+    closedAt: ($p.closedAt // null),
+    comments: ($p.comments | map_comments),
+    reactionsCount: ($p | total_reactions),
+
+    closingPullRequests: (if $kind == "issue"
+      then ($p.closedByPullRequestsReferences | map_refs)
+      else [] end),
+
+    baseRefName: (if $kind == "pr" then ($p.baseRefName // null) else null end),
+    headRefName: (if $kind == "pr" then ($p.headRefName // null) else null end),
+    baseRefOid:  (if $kind == "pr" then ($p.baseRefOid  // null) else null end),
+    headRefOid:  (if $kind == "pr" then ($p.headRefOid  // null) else null end),
+    isDraft:     (if $kind == "pr" then ($p.isDraft     // null) else null end),
+    mergeable:   (if $kind == "pr" then ($p.mergeable   // null) else null end),
+    mergeStateStatus: (if $kind == "pr" then ($p.mergeStateStatus // null) else null end),
+    mergedAt:    (if $kind == "pr" then ($p.mergedAt    // null) else null end),
+    mergedBy:    (if $kind == "pr" then ($p.mergedBy.login // null) else null end),
+    mergeCommit: (if $kind == "pr" then ($p.mergeCommit.oid  // null) else null end),
+    additions:   (if $kind == "pr" then ($p.additions   // 0) else 0 end),
+    deletions:   (if $kind == "pr" then ($p.deletions   // 0) else 0 end),
+    changedFiles:(if $kind == "pr" then ($p.changedFiles// 0) else 0 end),
+    files:           (if $kind == "pr" then ($p.files       | map_files)       else [] end),
+    commits:         (if $kind == "pr" then ($p.commits     | map_commits)     else [] end),
+    reviews:         (if $kind == "pr" then ($p.reviews     | map_reviews)     else [] end),
+    reviewRequests:  (if $kind == "pr" then [ ($p.reviewRequests // [])[] | (.login // .slug // .name // null) ] else [] end),
+    reviewDecision:  (if $kind == "pr" then ($p.reviewDecision // null) else null end),
+    statusCheckRollup: (if $kind == "pr" then ($p.statusCheckRollup | map_status_checks) else [] end),
+    closingIssues:   (if $kind == "pr" then ($p.closingIssuesReferences | map_refs) else [] end)
+  }
+'

--- a/skills/code-review-github/scripts/load-issue.sh
+++ b/skills/code-review-github/scripts/load-issue.sh
@@ -9,6 +9,7 @@
 #   - a GitHub URL, e.g. https://github.com/<owner>/<repo>/issues/445
 #   - a GitHub URL, e.g. https://github.com/<owner>/<repo>/pull/123
 #   - any GitHub URL containing /issues/<N> or /pull/<N>
+#     (the optional `www.` host prefix is tolerated, e.g. https://www.github.com/...)
 #
 # Emits one JSON document on stdout with the following stable shape:
 #
@@ -94,7 +95,7 @@ extract_from_url() {
   # Echoes: "<owner> <repo> <number> <kind>"
   local url="$1"
   local path
-  path="$(printf '%s' "$url" | sed -nE 's#^https?://[^/]+/([^/]+)/([^/]+)/(issues|pull)/([0-9]+).*#\1 \2 \4 \3#p')"
+  path="$(printf '%s' "$url" | sed -nE 's#^https?://(www\.)?github\.com/([^/]+)/([^/]+)/(issues|pull)/([0-9]+).*#\2 \3 \5 \4#p')"
   if [[ -z "$path" ]]; then
     return 1
   fi
@@ -124,7 +125,7 @@ REPO=""
 NUMBER=""
 KIND=""
 
-if [[ "$INPUT" =~ ^https?://github\.com/ ]]; then
+if [[ "$INPUT" =~ ^https?://(www\.)?github\.com/ ]]; then
   parsed="$(extract_from_url "$INPUT" || true)"
   if [[ -z "$parsed" ]]; then
     echo "load-issue.sh: could not extract issue/PR from URL: $INPUT" >&2

--- a/skills/merge-github-pr/SKILL.md
+++ b/skills/merge-github-pr/SKILL.md
@@ -25,15 +25,17 @@ Merge pull requests that meet all required conditions.
 
 ### 1. Load PRs
 - Identify candidate PRs ready for merge
+- For each candidate, load PR context by running `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>` — the single deterministic entry point. Never call `gh pr view`, `gh pr checks`, or `gh api /repos/.../pulls/...` directly. Read `mergeable`, `mergeStateStatus`, `reviewDecision`, and `statusCheckRollup[]` off the resulting JSON document.
+- If the script is unavailable (missing tool, exit code 2/3) fall back to the GitHub MCP server.
 
 ### 2. Pre-checks (must all pass)
 
-For each PR:
+For each PR, derive the verdict from the JSON document loaded in step 1:
 
-- No merge conflicts
-- CI is passing
-- Required approvals are present
-- Branch is up to date with base branch
+- No merge conflicts — `mergeable == "MERGEABLE"` and `mergeStateStatus` is not `DIRTY` or `BEHIND`
+- CI is passing — every entry in `statusCheckRollup[]` has a passing `state` (`SUCCESS` / `NEUTRAL` / `SKIPPED`)
+- Required approvals are present — `reviewDecision == "APPROVED"`
+- Branch is up to date with base branch — `mergeStateStatus != "BEHIND"`
 
 If any check fails:
 - do not merge

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -28,8 +28,8 @@ metadata:
 
 ### For each PR:
 
-- Load all review comments (including threads and general comments)
-- Build a checklist from all review findings
+- Load PR context by running `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>` — the single deterministic entry point. Never call `gh issue view`, `gh pr view`, or `gh api /repos/.../issues/...` directly. Read review comments, files, commits, status checks, and `closingIssues` off the resulting JSON document. If the script is unavailable (missing tool, exit code 2/3) fall back to the GitHub MCP server, and always prefer the MCP fallback for review-thread / line-anchored comments that the script does not return.
+- Build a checklist from all review findings (general comments come from `comments[]`; line-anchored review-thread comments still need the MCP fallback)
 - Map each finding to a concrete code or test change
 
 #### Reproducer extraction (per finding)
@@ -41,7 +41,9 @@ For every Critical and Moderate finding, extract the reproducer fields published
 - **Test Hint** — the layer (unit, integration, feature) and entry point
 - **Suggested Fix** — the minimal corrected snippet that resolves the finding (may be `n/a — <reason>` when the Fix narrative is sufficient)
 
-For JIRA-originated reviews, read the reproducer fields off `comments[]` and `descriptionText` returned by `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` instead of re-fetching the issue. Never call `acli` directly.
+Read the reproducer fields off `comments[]` and `body` / `descriptionText` returned by the deterministic loader for the originating tracker instead of re-fetching the issue:
+- **GitHub-originated reviews:** `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>`. Never call `gh issue view`, `gh pr view`, or `gh api /repos/.../issues/...` directly.
+- **JIRA-originated reviews:** `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>`. Never call `acli` directly.
 
 Use these to write a failing test **before** applying the fix:
 
@@ -110,7 +112,7 @@ If a finding lacks Faulty Example, Expected Behavior, or Test Hint, request a CR
 ### PR update
 
 - Find the original code review comment on the PR:
-  - Use `gh api` to list PR comments and identify the CR comment (e.g. contains "Summary:" with severity counts)
+  - Read `comments[]` off `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>` and identify the CR comment (e.g. contains "Summary:" with severity counts)
 - **If the original CR comment is found:**
   - Post resolved items and status updates as a new PR comment that references the original CR comment
   - GitHub does not support native replies to issue comments — use quoting (e.g. "> Replying to code review from {date}") to create a visual thread

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -38,13 +38,15 @@ See `references/source-detection.md` for the detection table and rules.
    - **GitHub:** the issue repository must match the current Git remote origin.
    - **JIRA:** the issue project key must match the configured JIRA project for this repository.
    - If the issue does not belong to the current project, refuse to process it and inform the user.
-2. Fetch and analyze the issue from the detected source. For JIRA issues, load context by running `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>` and read all fields off the resulting JSON document. Never call `acli` directly. If the script is unavailable (missing tool, exit code 2/3), fall back to the JIRA MCP server.
+2. Fetch and analyze the issue from the detected source by running the deterministic loader for that tracker — never call `gh`, `acli`, or REST endpoints directly. Read all required fields off the resulting JSON document.
+   - **GitHub:** `skills/code-review-github/scripts/load-issue.sh <NUMBER|URL>`. If the script is unavailable (missing tool, exit code 2/3), fall back to the GitHub MCP server.
+   - **JIRA:** `skills/code-review-jira/scripts/load-issue.sh <KEY|URL>`. If the script is unavailable (missing tool, exit code 2/3), fall back to the JIRA MCP server.
 3. Define exact requirements and expected behavior.
 4. Classify the task (bug or feature).
 
 ### Comment analysis
 
-5. Before analyzing the problem, fetch and read **all comments and replies** from the issue tracker (GitHub, JIRA, or Bugsnag). For JIRA issues, read `comments[]` directly off the JSON loaded in step 2 — do not issue a second listing call:
+5. Before analyzing the problem, fetch and read **all comments and replies** from the issue tracker (GitHub, JIRA, or Bugsnag). For GitHub and JIRA issues, read `comments[]` directly off the JSON loaded in step 2 — do not issue a second listing call:
    - Group comments by conversation thread (e.g., review threads, reply chains).
    - For each thread, determine:
      - **Current requirements** — requests or conditions that are still valid and unfulfilled.

--- a/skills/resolve-issue/references/source-detection.md
+++ b/skills/resolve-issue/references/source-detection.md
@@ -4,8 +4,8 @@ Detect the issue tracker automatically from the input:
 
 | Input pattern | Source | Extra rules |
 |---|---|---|
-| GitHub URL or `#123` | GitHub | Use `gh` CLI |
-| JIRA URL or issue key (e.g. `PROJ-123`) | JIRA | Apply `@rules/jira/general.mdc`, use `acli` or JIRA MCP |
+| GitHub URL or `#123` | GitHub | Load context via `skills/code-review-github/scripts/load-issue.sh <NUMBER\|URL>`; fall back to GitHub MCP only when the script is unavailable |
+| JIRA URL or issue key (e.g. `PROJ-123`) | JIRA | Apply `@rules/jira/general.mdc`; load context via `skills/code-review-jira/scripts/load-issue.sh <KEY\|URL>`; fall back to JIRA MCP only when the script is unavailable |
 | Bugsnag URL or ID | Bugsnag | Treat as runtime error, prefer TDD |
 
 If the source cannot be determined, ask the user.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1235,6 +1235,38 @@ test('github code review skills do not describe inline review comment workflow',
     }
 });
 
+test('github load-issue script is shipped, executable, and documents the same shape as JIRA', function (): void {
+    $packageDir = dirname(__DIR__);
+    $script = $packageDir . '/skills/code-review-github/scripts/load-issue.sh';
+
+    expect(file_exists($script))->toBeTrue();
+    expect(is_executable($script))->toBeTrue();
+
+    $content = (string) file_get_contents($script);
+    expect($content)->toStartWith('#!/usr/bin/env bash');
+    expect($content)->toContain('Usage: load-issue.sh <NUMBER|URL>');
+    expect($content)->toContain('"kind"');
+    expect($content)->toContain('"comments"');
+    expect($content)->toContain('"closingIssues"');
+    expect($content)->toContain('"closingPullRequests"');
+    expect($content)->toContain('"statusCheckRollup"');
+});
+
+test('github-consuming skills route context loading through load-issue.sh', function (): void {
+    $packageDir = dirname(__DIR__);
+    $skills = [
+        $packageDir . '/skills/resolve-issue/SKILL.md',
+        $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/process-code-review/SKILL.md',
+        $packageDir . '/skills/merge-github-pr/SKILL.md',
+    ];
+
+    foreach ($skills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain('skills/code-review-github/scripts/load-issue.sh');
+    }
+});
+
 test('install with prune on non-existent target directory does nothing', function (): void {
     $root = installerCreateProjectRoot();
     installerWriteFile($root . '/skills/some-skill/SKILL.md', 'content');

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1250,6 +1250,7 @@ test('github load-issue script is shipped, executable, and documents the same sh
     expect($content)->toContain('"closingIssues"');
     expect($content)->toContain('"closingPullRequests"');
     expect($content)->toContain('"statusCheckRollup"');
+    expect($content)->toContain('(www\.)?github\.com');
 });
 
 test('github-consuming skills route context loading through load-issue.sh', function (): void {


### PR DESCRIPTION
## Summary

- Mirrors the JIRA `load-issue.sh` concept for GitHub so AI agents receive a single, deterministic JSON document with maximal issue / PR context (`closes #445`).
- One script `skills/code-review-github/scripts/load-issue.sh` handles both kinds — GitHub shares the issue/PR number space, and the payload exposes a `kind` field plus the union of useful fields per kind.
- `resolve-issue`, `code-review-github`, `process-code-review`, and `merge-github-pr` are wired through the script and explicitly forbidden from calling `gh` directly; MCP fallback remains for data the script cannot cover (line-anchored review comments, per-commit check runs, binary attachments).
- Two structural tests lock the contract: the script ships and stays executable, and every GitHub-consuming skill points at it.

## Validation — all use cases verified

| # | Input form | Result |
|---|---|---|
| T1 | Bare issue number `445` | `kind="issue"`, title/body/labels populated |
| T2 | Issue URL | Identical payload |
| T3 | Bare PR number `444` | `kind="pr"`, PR-only fields (`mergeable`, `additions`, `commits`, `files`, `statusCheckRollup`, …) populated |
| T4 | PR URL `/pull/N` | Identical payload, `mergedAt` / `mergeCommit` surfaced |
| T5 | PR URL with subpath `/pull/N/files` | Correctly parses kind + number |
| T6 | Cross-repo URL | Repo info from URL; `comments` / `reactionsCount` populated |
| T7 | Malformed input (`abc`, non-GitHub URL, empty) | Exit 1 with usage hint |
| T8 | Missing required tool | Exit 2 with the missing-binary message |
| T9 | Non-existent number | Exit 3 with the failed-fetch message |

## Test plan

- [ ] `composer build` passes (95 tests, 100 % coverage)
- [ ] `skills/code-review-github/scripts/load-issue.sh 445` returns the documented JSON shape
- [ ] `skills/code-review-github/scripts/load-issue.sh 444` returns `kind="pr"` with PR-only fields populated
- [ ] Each updated SKILL.md still passes `composer skill-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)