### PR TITLE
feat(rules): add Laravel DynamoDB query safety rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `cursor-rules` will be documented in this file.
 
 ## [Unreleased]
 
+- ✨ **Added**: new Laravel rule `laravel/dynamodb.mdc` covering DynamoDB query safety — scan prevention for every query-builder change, required key-targeted access patterns (`GetItem` / `Query`), GSI usage, review checklist, and Tinker-based testing/debugging when `laravel/tinker` is available (#447)
 - 📝 **Changed**: code review and security-review skills (`code-review`, `code-review-github`, `code-review-jira`, `security-review`) and their output templates now require a **Suggested Fix** code snippet alongside Faulty Example / Expected Behavior / Test Hint for every Critical and Moderate finding (Critical/High for security). The snippet must comply with `@rules/php/core-standards.mdc` and, on Laravel projects, `@rules/laravel/architecture.mdc`. `process-code-review` reads the snippet and applies it directly when resolving the finding
 - 📝 **Changed**: code review skills (`code-review`, `code-review-github`, `code-review-jira`) and the shared `code-review/general.mdc` rule now require reviewers to flag newly added or modified logic that duplicates behavior already present elsewhere in the codebase — reuse the existing implementation to keep logic unified across the application (#440)
 - 🐛 **Fixed**: CR skills now systematically review all open PRs per issue instead of only one (#227)

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Rules included in this package:
 | `laravel/filament.mdc`        | Filament v4 specific rules                                 | Filament |
 | `laravel/livewire.mdc`        | Livewire component rules and conventions                   | Livewire |
 | `laravel/queue-debouncing.mdc`| Safe Laravel queue debouncing, urgency separation, and replaceable work | Laravel  |
+| `laravel/dynamodb.mdc`        | DynamoDB query safety: scan prevention, key-targeted reads, Tinker debug | Laravel  |
 | `sql/optimalize.mdc`          | SQL query optimization, index design, schema standards     | Always   |
 | `security/backend.md`         | Backend security rules and OWASP Top 10 checks             | Always   |
 | `security/frontend.md`        | Frontend security rules (XSS, CSRF, CSP)                  | Frontend |

--- a/rules/laravel/dynamodb.mdc
+++ b/rules/laravel/dynamodb.mdc
@@ -20,8 +20,8 @@ Apply these rules whenever the project integrates with DynamoDB — via the `bao
 ## Required Access Patterns
 - `GetItem` / `BatchGetItem` — single-item or known-keys reads.
 - `Query` with a partition key (and optionally a sort key) — collection reads inside one partition.
-- `Query` against a Global Secondary Index (GSI) — non-primary-key access patterns. Pass the index name to the query (e.g. `->index('status-createdAt-index')`).
-- `Scan` is allowed only for explicit, documented offline/admin tasks (one-off backfills, maintenance scripts). The justification must live in code or in the PR description.
+- `Query` against a Global Secondary Index (GSI) — non-primary-key access patterns. Pass the index name to the query (`->index('status-createdAt-index')` with `baopham/laravel-dynamodb`; `IndexName` in `QueryInput` when calling the AWS SDK directly).
+- `Scan` is allowed only for explicit, documented offline/admin tasks (one-off backfills, maintenance scripts) — see the Review Checklist below for the justification requirement.
 
 Reject patterns that omit a key:
 
@@ -51,11 +51,12 @@ For every PR that touches DynamoDB code, reviewers must verify:
 - When a GSI is used, the index exists in the table definition and the query passes the correct index name.
 
 ## Testing and Debugging with Tinker
-- If Laravel Tinker is available in the project (check `composer.json` for `laravel/tinker`), use `php artisan tinker` for every ad-hoc DynamoDB query test or debug session instead of writing throwaway routes, commands, or seeders.
+- If Laravel Tinker is available in the project (check `composer.json` for `laravel/tinker`), use `php artisan tinker` for every ad-hoc DynamoDB query verification or debug session instead of writing throwaway routes, commands, or seeders.
+- Tinker complements but does not replace the Pest tests required by `@rules/code-testing/general.mdc` for every behavior change.
 - Use Tinker to:
   - Confirm whether a builder produces a `Query` or a `Scan` before merging — inspect the builder, dump the underlying AWS SDK request, or enable SDK logging.
   - Verify the shape of items returned by repositories against real data.
-  - Reproduce production-like read paths against the configured DynamoDB endpoint (live, LocalStack, or DynamoDB Local).
+  - Reproduce production-like read paths against the configured DynamoDB endpoint.
 - Never paste secrets or production credentials into Tinker — rely on the project's configured `.env` or IAM role.
 
 ## Red Flags

--- a/rules/laravel/dynamodb.mdc
+++ b/rules/laravel/dynamodb.mdc
@@ -1,0 +1,65 @@
+---
+description: Laravel DynamoDB query safety — scan prevention and Tinker-based verification
+globs:
+  - app/**/*.php
+  - config/dynamodb.php
+  - tests/**/*.php
+alwaysApply: false
+---
+
+# Laravel DynamoDB
+
+## Scope
+Apply these rules whenever the project integrates with DynamoDB — via the `baopham/laravel-dynamodb` package, a DynamoDB-backed Eloquent model, a custom DynamoDB query builder, or the AWS SDK called directly from PHP.
+
+## Core Principle
+- Every read must target a key. `Scan` is the slow, expensive default and must never be the access pattern for production code paths.
+- Treat every change to a DynamoDB query builder, repository, or any code that issues DynamoDB requests as a place that may silently introduce a `Scan`.
+- A missing partition key turns the call into a `Scan` even when a `FilterExpression` is present — filters run **after** the read and do not replace a key condition.
+
+## Required Access Patterns
+- `GetItem` / `BatchGetItem` — single-item or known-keys reads.
+- `Query` with a partition key (and optionally a sort key) — collection reads inside one partition.
+- `Query` against a Global Secondary Index (GSI) — non-primary-key access patterns. Pass the index name to the query (e.g. `->index('status-createdAt-index')`).
+- `Scan` is allowed only for explicit, documented offline/admin tasks (one-off backfills, maintenance scripts). The justification must live in code or in the PR description.
+
+Reject patterns that omit a key:
+
+```php
+Model::all();                                  // full scan
+Model::where('status', 'active')->get();      // scan if `status` is not the PK / GSI hash
+Model::whereNotNull('email')->first();        // scan
+```
+
+Prefer patterns that target a key:
+
+```php
+Model::find($id);                                                       // GetItem
+Model::where('userId', $userId)->get();                                 // Query on PK
+Model::index('status-createdAt-index')                                  // Query on GSI
+    ->where('status', 'active')
+    ->get();
+```
+
+## Review Checklist
+For every PR that touches DynamoDB code, reviewers must verify:
+
+- Each new or changed read specifies a partition key or uses `GetItem` / `BatchGetItem`.
+- No new `Scan` requests were introduced.
+- Any pre-existing `Scan` that is modified is re-justified in code or in the PR description.
+- `FilterExpression` is not used as the primary access pattern.
+- When a GSI is used, the index exists in the table definition and the query passes the correct index name.
+
+## Testing and Debugging with Tinker
+- If Laravel Tinker is available in the project (check `composer.json` for `laravel/tinker`), use `php artisan tinker` for every ad-hoc DynamoDB query test or debug session instead of writing throwaway routes, commands, or seeders.
+- Use Tinker to:
+  - Confirm whether a builder produces a `Query` or a `Scan` before merging — inspect the builder, dump the underlying AWS SDK request, or enable SDK logging.
+  - Verify the shape of items returned by repositories against real data.
+  - Reproduce production-like read paths against the configured DynamoDB endpoint (live, LocalStack, or DynamoDB Local).
+- Never paste secrets or production credentials into Tinker — rely on the project's configured `.env` or IAM role.
+
+## Red Flags
+- A new method on a DynamoDB repository or query builder that has no `where()` on the partition key.
+- `FilterExpression` used as the only constraint on a read.
+- `Scan` calls added without a clear maintenance/offline justification.
+- Ad-hoc verification scripts or temporary routes added "just to test" a query when Tinker would suffice.


### PR DESCRIPTION
## Summary

- Add `rules/laravel/dynamodb.mdc` covering DynamoDB query safety: scan prevention for every query-builder change, required key-targeted access patterns (`GetItem` / `Query`), GSI usage, and a review checklist.
- Add a Tinker-based testing/debugging section that applies when `laravel/tinker` is available.
- Register the new rule in `README.md` Rules Overview and in `CHANGELOG.md` Unreleased.

Closes #447

## Test plan

- [x] `composer build` — skill-check PASS (24/24 skills, 0 errors, 0 warnings), Composer normalize OK, Rector OK, PHPCS/Pint passed, all 95 tests passed, 100% coverage
- [x] New rule file follows the same frontmatter + section layout as `rules/laravel/queue-debouncing.mdc` and `rules/laravel/filament.mdc`
- [x] `README.md` Rules Overview table includes the new rule
- [x] `CHANGELOG.md` Unreleased section references the new rule with the issue number

🤖 Generated with [Claude Code](https://claude.com/claude-code)