### PR TITLE
fix(installer): preserve executable bit when copying scripts

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -214,11 +214,25 @@ final class Installer
             }
         } else {
             self::copy($src, $dst);
+            self::preserveExecutableBit($src, $dst);
         }
 
         InstallerHumanizer::appendIfNeeded($dst);
 
         return true;
+    }
+
+    private static function preserveExecutableBit(string $src, string $dst): void
+    {
+        $mode = fileperms($src);
+
+        if ($mode === false || ($mode & 0111) === 0) {
+            return;
+        }
+
+        set_error_handler(static fn (): bool => true);
+        chmod($dst, ($mode & 0777) | 0111);
+        restore_error_handler();
     }
 
     private static function removeExistingTarget(string $destination): void

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1216,6 +1216,35 @@ test('code review templates include refactoring tech debt section', function ():
     }
 });
 
+test('install preserves executable bit on shipped scripts', function (): void {
+    $root = installerCreateProjectRoot();
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=cursor']);
+        ob_end_clean();
+
+        $installedScripts = [
+            $root . '/.cursor/skills/code-review-github/scripts/load-issue.sh',
+            $root . '/.cursor/skills/code-review-jira/scripts/load-issue.sh',
+        ];
+
+        foreach ($installedScripts as $script) {
+            expect(is_file($script))->toBeTrue($script . ' should exist after install');
+            expect(is_executable($script))->toBeTrue($script . ' must be executable after install');
+        }
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
 test('github code review skills do not describe inline review comment workflow', function (): void {
     $packageDir = dirname(__DIR__);
     $githubFacingSkills = [


### PR DESCRIPTION
## Shrnutí
Shellové skripty dodávané v balíčku (např. `skills/*/scripts/load-issue.sh`) ztrácely po instalaci `executable` bit, protože PHP `copy()` vytvoří cíl s výchozími právy `0644`. Při spuštění nainstalovaného skriptu pak shell hlásil `permission denied` (exit 126):

```
Error: Exit code 126
(eval):1: permission denied: /Users/.../.claude/skills/code-review-jira/scripts/load-issue.sh
```

Po zkopírování souboru se nyní přebírají executable bity ze zdrojového souboru, takže dodávané skripty zůstanou spustitelné i po `install` / refreshi pravidel. Symlink instalace nejsou dotčeny (symlink dědí oprávnění z cíle).

## Změny
- `src/Installer.php` — po `copy()` zavoláme nové `preserveExecutableBit()`, které pomocí `chmod` doplní `u+x,g+x,o+x`, pokud zdroj měl executable bit. Pokud zdroj spustitelný není (běžné `.mdc` / `.md` soubory), funkce se okamžitě vrátí.
- `tests/InstallerTest.php` — regresní test, který po instalaci ověřuje, že `is_executable()` platí pro oba dodávané `load-issue.sh` skripty.

## Test plan
- [x] `vendor/bin/pest --no-coverage tests/` — 96 passed (272 assertions)
- [x] `composer build` — všechny statické checky a testy projdou (coverage step selhává pouze kvůli chybějícímu PCOV driveru lokálně, není to regrese této změny)
- [ ] Manuální ověření: po `composer build` / `bin/cursor-rules install --editor=claude` mít možnost spustit `.../.claude/skills/code-review-github/scripts/load-issue.sh https://github.com/pekral/cursor-rules/issues/450` bez chyby 126.

Closes #450