### PR TITLE
feat(rules): prefer Laravel filled()/blank() over !== '' in conditions

### DIFF
--- a/rules/laravel/laravel.mdc
+++ b/rules/laravel/laravel.mdc
@@ -121,3 +121,7 @@ globs:
     - middleware, exceptions, routes in `bootstrap/app.php`
     - providers in `bootstrap/providers.php`
     - console configuration in `routes/console.php`
+
+## String Emptiness Checks
+- In conditions, prefer the Laravel `filled()` / `blank()` helpers over `!== ''` / `=== ''` comparisons. Write `filled($value)` instead of `$value !== ''` and `blank($value)` instead of `$value === ''`.
+- Keep the raw `!== ''` / `=== ''` form only when the exact PHP semantics matter (e.g. a `null`, whitespace-only, or empty-collection value must be treated as non-empty).

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1142,6 +1142,17 @@ test('query scopes rule is present in class refactoring skill', function (): voi
     expect($content)->toContain('query scopes');
 });
 
+test('laravel rules prefer filled()/blank() helpers over strict empty-string comparisons', function (): void {
+    $packageDir = dirname(__DIR__);
+    $content = (string) file_get_contents($packageDir . '/rules/laravel/laravel.mdc');
+
+    expect($content)->toContain('## String Emptiness Checks');
+    expect($content)->toContain('`filled()`');
+    expect($content)->toContain('`blank()`');
+    expect($content)->toContain('`!== \'\'`');
+    expect($content)->toContain('`=== \'\'`');
+});
+
 test('code-review skill After Completion section runs test-like-human unconditionally', function (): void {
     $packageDir = dirname(__DIR__);
     $content = (string) file_get_contents($packageDir . '/skills/code-review/SKILL.md');


### PR DESCRIPTION
## Shrnutí
Issue #449 žádá, aby Laravel skilly a pravidla preferovaly Laravel helper místo zápisu `!== ''` / `=== ''` v podmínkách — `filled()` resp. `blank()` jsou pro tento účel idiomatické a v Laravelu vždy k dispozici.

Žádné stávající `!== ''` / `=== ''` v `rules/` ani `skills/` neexistují (ověřeno přes `grep`), takže úkol je deklarativní — doplnit pravidlo do `rules/laravel/laravel.mdc`, aby ho každý projekt aplikující tyto Cursor rules zdědil.

## Změny
- `rules/laravel/laravel.mdc` — nová subsekce **String Emptiness Checks** s dvěma body:
  1. preferuj `filled($value)` místo `$value !== ''` a `blank($value)` místo `$value === ''`;
  2. raw `!== ''` / `=== ''` ponech pouze tam, kde záleží na přesné PHP sémantice (např. `null`, whitespace-only nebo prázdná kolekce má být brána jako neprázdná).
- `tests/InstallerTest.php` — regresní Pest test, který ověřuje, že nová subsekce a klíčová slova (`filled()`, `blank()`, `!== ''`, `=== ''`) jsou v dodávaném souboru pravidel. Vychází ze stejného vzoru jako už existující testy obsahu pravidel/skillů.

## Test plan
- [x] `vendor/bin/pest --no-coverage tests/` — 97 passed (277 assertions)
- [x] `composer build` — skill-check, composer-normalize, phpcs, pint, rector, phpstan, audit i test suite projdou (coverage step lokálně selhává pouze kvůli chybějícímu PCOV driveru — stejně jako v PR #451; v CI projde)
- [ ] Manuální ověření: po instalaci pravidel do projektu (`bin/cursor-rules install --editor=...`) obsahuje `<.cursor|.claude|.codex>/rules/laravel/laravel.mdc` novou subsekci.

Closes #449