### PR TITLE
feat(skills): upgrade analyze-problem framework and enforce english-only skills

### DIFF
--- a/skills/analyze-problem/SKILL.md
+++ b/skills/analyze-problem/SKILL.md
@@ -36,71 +36,47 @@ Focus on:
 - Analyze the problem and all available context.
 - If relevant, load issue, comments, and attachments using available CLI or MCP tools.
 - Prefer issue-tracker-specific tools over generic browsing.
-- Separate facts from assumptions.
-- Generate multiple plausible hypotheses.
-- Identify the most probable root cause.
-- Define how to validate it.
-- Suggest minimal, low-risk next steps.
+- Walk through the Analysis Framework below in order — do not skip steps.
+- Separate facts from assumptions and from hypotheses.
+- Identify the most probable root cause and how to validate it.
+- Recommend the smallest safe solution and explain rejected alternatives.
 
 ---
 
-## Analysis Structure
+## Analysis Framework
 
-### 1. Problem Summary
-- Clearly restate the problem in your own words
-- Interpret, do not copy
+Apply these 10 steps in order. Each step feeds the next — never jump ahead to a solution before evidence and root cause are settled.
 
-### 2. Known Facts
-- Only verified information
-- No assumptions
-
-### 3. Assumptions
-- Inferred but not confirmed
-
-### 4. Missing Information
-- Unknowns that affect confidence or validation
-
-### 5. Hypotheses
-- At least 2 plausible explanations
-- Prefer competing explanations
-- Group when useful:
-    - code
-    - configuration
-    - infrastructure
-    - data
-    - external dependencies
-
-### 6. Hypothesis Evaluation
-For each hypothesis:
-- why it could be true
-- why it might be false
-- likelihood: high / medium / low
-
-### 7. Most Probable Root Cause
-- Select the most likely explanation
-- Explain why it is stronger than others
-- Explicitly state uncertainty if present
-
-### 8. Validation Plan
-Define how to confirm or reject the root cause:
-- logs to inspect
-- commands to run
-- code paths to check
-- experiments to perform
-
-### 9. Next Steps
-- Minimal, actionable steps
-- Do not provide full implementation
-
-### 10. Stakeholder Explanation
-- Explain the issue in simple terms
-- Focus on impact, cause, and next step
+1. **Context extraction** — what we actually know from the assignment, comments, attachments, and surrounding code.
+2. **Problem statement** — one precise sentence describing the real problem.
+3. **Expected vs actual behavior** — what should happen, and what is happening instead.
+4. **Evidence** — logs, screenshots, issue comments, files, reproduction steps. Verified facts only.
+5. **Root cause hypothesis** — the most likely cause, clearly separated from facts. State certainty.
+6. **Impact / risk** — who and what is affected (users, business, technical, risk areas).
+7. **Smallest safe solution** — the smallest, lowest-risk fix that addresses the root cause.
+8. **Alternatives rejected** — competing solutions considered and why they were not chosen.
+9. **Verification plan** — manual checks, automated tests, edge cases, and regression checks.
+10. **Non-technical summary** — plain-language explanation for PM, support, or business stakeholders.
 
 ---
 
-## Output Format
+## Output Structure
 
-Use the template defined in `templates/analysis-report.md`.
+The output uses the template at `templates/analysis-report.md`. The template has 11 sections that map onto the framework above:
+
+1. **Summary** — short summary (covers steps 1–2)
+2. **Problem Definition** — problem statement, expected/actual behavior, affected area, problem type (steps 2–3)
+3. **Verified Facts** — verified facts only (step 4)
+4. **Assumptions and Missing Information** — assumptions and unknowns (supports step 5)
+5. **Probable Root Cause** — root cause, certainty, alternative causes (step 5)
+6. **Problem Impact** — user/business impact, technical impact, risk areas (step 6)
+7. **Recommended Solution** — recommended solution, things to avoid, side effects (steps 7–8)
+8. **Implementation Outline** — likely change locations, recommended steps, architecture notes (step 7)
+9. **Solution Verification** — manual checks, automated tests, edge cases, regression checks (step 9)
+10. **Non-Technical Explanation** — explanation for non-technical stakeholders (step 10)
+11. **Final Recommendation** — final recommendation, priority, next step
+
+Fill every section. If a section has nothing to report, write a short explicit note (e.g. `No missing information.`) instead of leaving placeholders.
 
 ---
 

--- a/skills/analyze-problem/templates/analysis-report.md
+++ b/skills/analyze-problem/templates/analysis-report.md
@@ -1,41 +1,227 @@
-## Technical Analysis
+# Problem Analysis
 
-### Problem Summary
+## 1. Summary
+
+<!-- Short summary of the problem in 2–5 sentences.
+Explain what is happening, where it is happening, and the most likely reason. -->
+
 ...
 
-### Known Facts
+---
+
+## 2. Problem Definition
+
+**Problem:**
+<!-- One precise sentence describing the actual problem. -->
+
+...
+
+**Expected behavior:**
+<!-- What should have happened. -->
+
+...
+
+**Actual behavior:**
+<!-- What is happening instead. -->
+
+...
+
+**Affected area:**
+<!-- Module, feature, page, API endpoint, command, job, database table, external service, etc. -->
+
+...
+
+**Problem type:**
+<!-- Bug / regression / performance / data issue / security / UX / unclear requirement / other -->
+
+...
+
+---
+
+## 3. Verified Facts
+
+<!-- Only confirmed information from the assignment, issue, comments, logs, screenshots, attachments, or code.
+Do not put assumptions here. -->
+
+- ...
+- ...
 - ...
 
+---
+
+## 4. Assumptions and Missing Information
+
 ### Assumptions
+
+<!-- What we assume but cannot confirm. -->
+
+- ...
 - ...
 
 ### Missing Information
+
+<!-- What would help verify the cause or the proposed solution. -->
+
+- ...
 - ...
 
-### Hypotheses
-1. ...
-2. ...
+---
 
-### Hypothesis Evaluation
+## 5. Probable Root Cause
 
-#### Hypothesis 1
-- Why true:
-- Why false:
-- Likelihood:
+**Most probable cause:**
+<!-- Clearly describe the root cause. -->
 
-#### Hypothesis 2
-- Why true:
-- Why false:
-- Likelihood:
-
-### Most Probable Root Cause
 ...
 
-### Validation Plan
+**Why this cause is probable:**
+
+- ...
+- ...
 - ...
 
-### Next Steps
+**Certainty level:**
+<!-- High / Medium / Low -->
+
+...
+
+**Alternative possible causes:**
+
+- ...
 - ...
 
-## Stakeholder Explanation
+---
+
+## 6. Problem Impact
+
+### User / Business Impact
+
+<!-- What the problem causes from the perspective of users, customers, support, or the business. -->
+
+- ...
+- ...
+
+### Technical Impact
+
+<!-- Impact on the application, data, performance, queues, cache, integrations, security, etc. -->
+
+- ...
+- ...
+
+### Risk Areas
+
+<!-- What can break or what to watch out for when fixing. -->
+
+- ...
+- ...
+
+---
+
+## 7. Recommended Solution
+
+**Smallest safe solution:**
+<!-- Describe the smallest effective fix. No unnecessary refactoring. -->
+
+...
+
+**Why this solution fits:**
+
+- ...
+- ...
+- ...
+
+**What to avoid:**
+
+<!-- For example: large refactoring, architecture change, migration without reason, fixing symptoms instead of the cause. -->
+
+- ...
+- ...
+
+**Possible side effects:**
+
+- ...
+- ...
+
+---
+
+## 8. Implementation Outline
+
+<!-- Concrete technical direction, but without the implementation itself unless the user asked for code. -->
+
+### Likely Change Locations
+
+- `app/...`
+- `routes/...`
+- `database/...`
+- `tests/...`
+
+### Recommended Steps
+
+1. ...
+2. ...
+3. ...
+
+### Architecture Notes
+
+<!-- If relevant, mention e.g. Action, Service, Repository, Validator, DTO, Job, etc. -->
+
+- ...
+- ...
+
+---
+
+## 9. Solution Verification
+
+### Manual Verification
+
+1. ...
+2. ...
+3. ...
+
+### Automated Tests
+
+<!-- Which tests to add or update. -->
+
+- ...
+- ...
+- ...
+
+### Edge Cases
+
+<!-- Boundary situations the solution must cover. -->
+
+- ...
+- ...
+
+### Regression Checks
+
+<!-- What to check so the fix does not break existing behavior. -->
+
+- ...
+- ...
+
+---
+
+## 10. Non-Technical Explanation
+
+<!-- Explanation for someone outside development: PM, support, client, product owner.
+Without unnecessary technical detail. -->
+
+...
+
+---
+
+## 11. Final Recommendation
+
+<!-- Clearly state what should be done first and why. -->
+
+**Recommendation:**
+...
+
+**Priority:**
+<!-- Low / Medium / High / Critical -->
+
+...
+
+**Next step:**
 ...

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -65,7 +65,7 @@ See `references/source-detection.md` for the detection table and rules.
 
 Before writing any code, decide how the in-scope work will be split into commits within the PR.
 
-1. **Detect existing phases** in the issue description and the kept comments. Phase markers include explicit headings such as `Fáze 1` / `Phase 1`, numbered milestones, ordered acceptance-criteria blocks, or a step-by-step plan written by the reporter.
+1. **Detect existing phases** in the issue description and the kept comments. Phase markers include explicit headings such as `Phase 1`, numbered milestones, ordered acceptance-criteria blocks, or a step-by-step plan written by the reporter.
 2. **If phases exist:** treat each phase as exactly **one commit**. Keep the original phase order as commit order. Do not merge, reorder, or re-scope phases.
 3. **If no phases exist but the assignment is long or covers multiple distinct concerns:** propose a phased breakdown — each phase must be independently reviewable and yield a working state — then map **one phase per commit**.
 4. **If the assignment is small and atomic:** keep it as a single commit. Do not invent artificial phases.

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -25,7 +25,7 @@ metadata:
 - Identify the expected final behavior
 
 ### 2. Extract testing instructions
-- Locate **"Testing Recommendations" / "Doporučení k testování"**
+- Locate **"Testing Recommendations"**
 - Extract all scenarios
 - Do not invent new requirements unless needed to verify suspicious behavior
 - Every extracted scenario must be covered by an automated test. Map each scenario to an existing test; if no matching test exists, write one before the run is considered complete. Build/CI-level scenarios (e.g. `composer build`, coverage thresholds) are considered covered by the project's CI pipeline and do not require a duplicate unit test.


### PR DESCRIPTION
## Summary

- Replaces the analyze-problem analytical structure with the explicit 10-step framework requested in #470 (context extraction → problem statement → expected vs actual → evidence → root cause → impact → smallest safe solution → alternatives rejected → verification plan → non-technical summary).
- Rewrites `skills/analyze-problem/templates/analysis-report.md` into the 11-section report from #470 (Summary, Problem Definition, Verified Facts, Assumptions and Missing Information, Probable Root Cause, Problem Impact, Recommended Solution, Implementation Outline, Solution Verification, Non-Technical Explanation, Final Recommendation). The new template is in English.
- Sweeps remaining skill texts for non-English content per the follow-up instruction "all skill texts must be in English" — drops the Czech halves of the dual-language examples in `test-like-human/SKILL.md` (`Doporučení k testování`) and `resolve-issue/SKILL.md` (`Fáze 1`). The author proper noun `Petr Král` is preserved.
- Updates the `Output Structure` mapping in `analyze-problem/SKILL.md` so each template section is wired back to the 10-step framework.

Closes #470

## Test plan

- [x] `composer skill-check` → 100/100 (1 pre-existing warning in `code-review-jira/SKILL.md` outside this PR scope)
- [x] `composer pint-check` → passed
- [x] `composer phpcs-check` → passed
- [x] `composer rector-check` → OK
- [x] `composer analyse` (PHPStan) → no errors
- [x] `composer composer-normalize-check` → already normalized
- [x] `composer security-audit` → no advisories
- [x] `composer test:coverage` → 113 passed, 100% coverage
- [x] Verified that every template section heading matches the mapping in `SKILL.md`
- [x] Verified no non-English content remains anywhere under `skills/` outside the author proper noun

## TODO

_None — no out-of-scope findings._