### PR TITLE
docs(readme): sync skill descriptions and composer scripts (#473)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 
 | Skill | Description |
 |---|---|
-| `assignment-compliance-check` | Plain-language check that the PR implementation fulfills the linked issue's business requirements; returns an Assignment Compliance section embedded directly in the CR comment (no file written). |
+| `assignment-compliance-check` | Plain-language check that the PR implementation fulfills the linked issue's business requirements; reports only Critical functional gaps as a dedicated comment on the originating issue tracker — no local file written and never embedded in the PR comment. |
 | `code-review` | Senior PHP code review focused on architecture, risk, and behavior (read-only). |
-| `code-review-github` | Review GitHub pull requests with severity-based findings and review comments. |
-| `code-review-jira` | Review JIRA-linked changes with GitHub PR comments and structured findings. |
+| `code-review-github` | Review GitHub pull requests; posts technical findings on the PR and a non-technical `pr-summary` comment on every linked GitHub issue. |
+| `code-review-jira` | Review changes linked to a JIRA ticket; posts technical findings on the GitHub PR and a non-technical `pr-summary` comment on the JIRA ticket (with mirrored summary on any linked GitHub issues). |
 | `process-code-review` | Process existing review feedback, resolve comments, and prepare next review cycle. |
 | `security-review` | OWASP-focused security review (injection, auth, SSRF, exposure, misconfigurations). |
 | `class-refactoring` | Refactor PHP classes using SOLID and Laravel best practices with testability focus. |
@@ -185,11 +185,11 @@ All `.mdc` and `.md` files are ready for automatic injection by Cursor so every 
 ### Composer Scripts
 
 ```bash
-composer check              # run full quality check (normalize, phpcs, pint, rector, phpstan, audit, tests)
-composer fix                # run all automatic fixes (normalize, rector, pint, phpcs)
-composer build              # fix then check
+composer check              # run full quality check (skill-check, normalize, phpcs, pint, rector, phpstan, audit, tests)
+composer fix                # run all automatic fixes (skill-check-fix, normalize, rector, pint, phpcs)
+composer build              # install (cursor-rules install --force) then fix then check
 composer analyse            # run PHPStan static analysis
-composer test:coverage       # run tests with 100% coverage
+composer test:coverage      # run tests with 100% coverage
 composer coverage           # alias for test:coverage
 composer security-audit     # run security audit of dependencies
 ```
@@ -197,12 +197,16 @@ composer security-audit     # run security audit of dependencies
 ### Individual Commands
 
 ```bash
-composer phpcs-check        # PHP CodeSniffer check
-composer phpcs-fix          # PHP CodeSniffer fix
-composer pint-check         # Laravel Pint check
-composer pint-fix           # Laravel Pint fix
-composer rector-check       # Rector check (dry-run)
-composer rector-fix         # Rector fix
+composer skill-check                # SKILL.md linter (validation + scoring across every skill)
+composer skill-check-fix            # SKILL.md linter with auto-fix
+composer composer-normalize-check   # validate composer.json normalization (dry-run)
+composer composer-normalize-fix     # apply composer.json normalization
+composer phpcs-check                # PHP CodeSniffer check
+composer phpcs-fix                  # PHP CodeSniffer fix
+composer pint-check                 # Laravel Pint check
+composer pint-fix                   # Laravel Pint fix
+composer rector-check               # Rector check (dry-run)
+composer rector-fix                 # Rector fix
 ```
 
 ### Testing


### PR DESCRIPTION
## Souhrn

Podle issue #473 aktualizuji `README.md` tak, aby odpovídal aktuálnímu obsahu repository. Auditoval jsem README proti reálnému stavu skills/, rules/ a composer.json scripts a opravil čtyři nesoulady — žádný z nich nemění chování projektu, jde o čistě dokumentační sync.

## Co se mění

### Skill descriptions (Code Review tabulka)

- **`assignment-compliance-check`** — README říkalo *"returns an Assignment Compliance section embedded directly in the CR comment"*, což je **stará behaviour** před #464. SKILL.md i CHANGELOG entry pod `[Unreleased]` to už dávno přepnuly na dedikovaný komentář na originálním issue trackeru, který se do PR komentáře **nevkládá**. Nový popis: *"reports only Critical functional gaps as a dedicated comment on the originating issue tracker — no local file written and never embedded in the PR comment"*. Tohle byla jediná **aktivně zavádějící** položka v README.
- **`code-review-github`** — doplňuji informaci o netechnickém `pr-summary` komentáři na navázané GitHub issues (per #472).
- **`code-review-jira`** — doplňuji dual publication target (technické findings na GitHub PR + netechnický `pr-summary` komentář na JIRA ticket, plus mirrored summary na navázaných GitHub issues).

### Composer scripts

- **`composer check`** description rozšířena o `skill-check` (je v `@check` pipeline per `composer.json` od přidání skill-check-cli).
- **`composer fix`** description rozšířena o `skill-check-fix` (analogicky v `@fix`).
- **`composer build`** description rozšířena o `install (cursor-rules install --force)` (je první krok `@build`).
- **Individual Commands** dostává čtyři nové řádky:
  - `composer skill-check` — SKILL.md linter
  - `composer skill-check-fix` — SKILL.md linter s auto-fixem
  - `composer composer-normalize-check` — validate composer.json normalization
  - `composer composer-normalize-fix` — apply composer.json normalization

  Všechny čtyři jsou v `composer.json` `scripts` sekci, ale doteď nebyly v README zdokumentované.

## Co se vědomě **NE**mění

- **Skill count** zůstává `26 comprehensive Agent skills` / `26 skills for issue resolution` — žádný skill se nepřidává ani neubývá, žádná tabulková kategorie se nemění. To je důležité, protože regresní test `'readme lists tester-cookbook and bumps skill count to 26'` v `tests/InstallerTest.php` na obě tyto stringy spoléhá; PR ho **NE**rozbíjí.
- **Rules Overview** je beze změny — všech 16 `.mdc`/`.md` rule souborů z `rules/` je už v README správně uvedeno (`php/examples/named-arguments.md` je examples soubor, ne top-level rule, takže ho do tabulky neuvádím).
- **Installer flow, CLI switches, ostatní sekce** beze změny — popisy odpovídají reálnému kódu v `src/`.

## Quality gates

- `composer build` → **113/113 testů prošlo**, **100 % coverage** na `src/`. Skill-check 100/100 napříč 26 skilly, 0 errors, 0 warnings.
- Regresní test pro README skill-count nedotčen.
- Žádné `@rules/*` ani `@skills/*` reference v diffu (jen popisné texty); žádný invented path.

## Test plan

- [ ] CI `Quality Checks (PHP 8.4)` přejde.
- [ ] Otevřít vyrenderovaný README na GitHubu a zkontrolovat, že:
  - tabulka Code Review obsahuje aktualizované popisy tří skillů,
  - sekce Composer Scripts a Individual Commands obsahují přidané řádky.
- [ ] Opětovně spustit `composer check` v projektu, kde je `cursor-rules` nainstalovaný — měl by reálně provést všechny kroky, které README teď uvádí.

Closes #473