### PR TITLE
fix(skills): require minimal user interaction across all skills

### DIFF
--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -18,6 +18,11 @@ globs: ["*"]
 - Do not ask the user to verify something that is already visible in the provided code or files.
 - Do not suggest file changes when no actual modification is needed.
 - Fix obvious grammatical issues in user-facing text you modify.
+- Default to autonomous execution: proceed without asking when the answer can be inferred from the issue, the codebase, the project configuration, or prior conversation context.
+- Only ask the user when the next step is genuinely ambiguous **and** the ambiguity cannot be resolved from the available context. State the specific ambiguity that blocks the work.
+- Never ask the user to confirm a fact the agent can verify itself (tests passing, fixers clean, branch up-to-date, file exists, etc.) — verify it directly instead.
+- Never gate on user approval for work the assignment already authorizes (creating commits, opening PRs, applying review fixes mandated by the calling skill).
+- When user input is genuinely required, batch all questions into a single round; do not serialize one question at a time.
 
 ## Naming
 - Use clear, descriptive names that reveal purpose.

--- a/skills/create-issues-from-text/SKILL.md
+++ b/skills/create-issues-from-text/SKILL.md
@@ -29,7 +29,7 @@ Split a complex assignment into multiple clear, structured issues.
 
 ### 2. Propose Breakdown
 - List steps with short descriptions
-- Wait for confirmation (if not explicitly skipped)
+- Proceed directly to step 3; do not gate on a confirmation round when the breakdown is unambiguous
 
 ### 3. Create Issues
 - One issue per step

--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -81,7 +81,7 @@ Provide a brief markdown summary including:
 -   Confirm whether current changes now meet the required test coverage (must be 100%).
 -   If something is still missing, clearly describe the blocker or
     uncovered scenario.
-- Ask for create new commit with missing tests
+- Create a new commit with the missing tests
 - If according to @skills/test-like-human/SKILL.md the changes can be tested, do it!
 
 ## Principles

--- a/skills/refactor-entry-point-to-action/SKILL.md
+++ b/skills/refactor-entry-point-to-action/SKILL.md
@@ -22,7 +22,7 @@ metadata:
 Always include:
 - Entry-point file path
 - Target method (`Class::method`)
-- Expected Action class name and domain folder, or ask to propose one
+- Expected Action class name and domain folder (optional — the skill proposes a default name and domain when not provided, instead of asking the user)
 - Any response/signature compatibility constraints
 
 Example input:


### PR DESCRIPTION
## Souhrn

Zadání issue #491: *„Uprav všechny skilly tak, aby se AI agent neptal na zbytečné věci a na věci které jsou jasné, požaduj minimální interakci s uživatelem."*

Změna ve dvou fázích (po jednom commitu):

1. **`feat(rules)`** — do sekce `## AI Behavior` v `rules/php/core-standards.mdc` (`alwaysApply: true`, globs `["*"]`) jsem doplnil pět směrnic, které kodifikují minimální interakci s uživatelem: defaultně postupovat autonomně, ptát se jen na skutečně dvojznačné a z kontextu neodvoditelné věci, neptat se na self-verifiable fakta, neblokovat se na autorizaci, kterou už zadání pokrylo, a případné otázky bundleovat do jediného kola.
2. **`fix(skills)`** — chirurgicky odstraněny tři konkrétní zbytečné prompts ve skill instructions:
   - `skills/create-issues-from-text/SKILL.md` — krok „Wait for confirmation" nahrazen autonomním pokračováním
   - `skills/create-missing-tests-in-pr/SKILL.md` — „Ask for create new commit with missing tests" → „Create a new commit with the missing tests"
   - `skills/refactor-entry-point-to-action/SKILL.md` — Action class name a domain folder jsou nyní volitelné inputy; skill defaultně navrhne jméno místo dotazu

Pravidlo z fáze 1 platí pro všechny ostatní skilly automaticky díky `alwaysApply: true` — žádný per-skill Constraint patch není potřeba.

Resolves #491.

## Test plan
- [x] `composer build` — 169 tests / 100% coverage zůstává zelený po obou fázích
- [ ] Manuálně ověřit při příští spuštění `create-issues-from-text` skillu, že už nečeká na potvrzení mezi breakdownem a vytvořením issues
- [ ] Manuálně ověřit při příští spuštění `create-missing-tests-in-pr` skillu, že po doplnění testů agent rovnou commitne bez dotazu
- [ ] Manuálně ověřit při volání `refactor-entry-point-to-action` bez Action class name, že skill navrhne jméno sám místo dotazu

🤖 Generated with [Claude Code](https://claude.com/claude-code)