### PR TITLE
fix(skills): run test-like-human on demand only, not after CR

### DIFF
--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -141,4 +141,4 @@ Before reviewing code, load and analyze the full JIRA issue:
 
 ## After Completion
 
-- Always run @skills/test-like-human/SKILL.md, regardless of code review findings.
+- Do **not** auto-invoke `@skills/test-like-human/SKILL.md`. The user-perspective testing skill runs **on demand only** (via `/test-like-human` or an explicit follow-up); CR-track skills must never chain into it.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -182,4 +182,4 @@ Use the template defined in `templates/review-output.md`.
 
 ## After Completion
 
-- Always run @skills/test-like-human/SKILL.md, regardless of code review findings.
+- Do **not** auto-invoke `@skills/test-like-human/SKILL.md`. The user-perspective testing skill runs **on demand only** (via `/test-like-human` or an explicit follow-up); CR-track skills must never chain into it.

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -114,7 +114,7 @@ This is a **blocking loop**. Do not advance to **Finalization**, **PR update**, 
 
 **Precondition:** the Review loop above must have exited with `criticalCount + moderateCount == 0`. If the loop hit `maxIterations` without converging, do not proceed — return the remaining findings to the user for manual triage instead.
 
-- Run @skills/test-like-human/SKILL.md if changes are testable
+- Do **not** auto-invoke `@skills/test-like-human/SKILL.md`. The user-perspective testing skill runs **on demand only** — leave it for the user to trigger via `/test-like-human` after the PR is updated.
 - Commit and push changes
 - If PR does not exist, create it according to @rules/git/general.mdc
   - Title in English (per `@rules/git/general.mdc`)

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 ## Constraints
 - Apply `@rules/php/core-standards.mdc`
 - Apply `@rules/git/general.mdc`
-- Apply `@rules/reports/general.mdc`. The **final technical report** this skill posts on the GitHub PR (code-review / security-review / test-like-human summary block) stays in canonical English per the rule's *Exception — technical CR findings on the GitHub PR*. The **non-technical report** posted on the original issue / JIRA ticket / Bugsnag-linked GitHub issue follows the language of the source assignment. Code identifiers, file paths, severity labels, and CLI commands stay verbatim regardless of the surrounding prose language; never mix two natural languages inside a single comment.
+- Apply `@rules/reports/general.mdc`. The **final technical report** this skill posts on the GitHub PR (code-review and security-review summary block) stays in canonical English per the rule's *Exception — technical CR findings on the GitHub PR*. The **non-technical report** posted on the original issue / JIRA ticket / Bugsnag-linked GitHub issue follows the language of the source assignment. Code identifiers, file paths, severity labels, and CLI commands stay verbatim regardless of the surrounding prose language; never mix two natural languages inside a single comment.
 - If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
 - Follow project architecture and testing rules
 - Do not expose sensitive/internal details in user-facing messages
@@ -121,9 +121,10 @@ PR-comment processing via `@skills/process-code-review/SKILL.md` remains the pat
 After the code review loop passes clean, and **still before creating the pull request**, validate the change:
 
 1. Run `@skills/security-review/SKILL.md`
-2. Run `@skills/test-like-human/SKILL.md`
 
-Resolve any **Critical** or **Moderate** findings from these skills before continuing. If a finding requires code changes, re-run the **Code quality and review loop** to re-validate.
+Resolve any **Critical** or **Moderate** finding from the security review before continuing. If a finding requires code changes, re-run the **Code quality and review loop** to re-validate.
+
+`@skills/test-like-human/SKILL.md` is **not** part of this gate. It runs **on demand only** (via `/test-like-human` or an explicit follow-up after the PR is open); resolve-issue must never auto-chain into it.
 
 ## Pull request
 
@@ -147,7 +148,6 @@ Post the technical report as a comment on the GitHub PR, since that is where the
 
 - **Code review summary** — outcome of `@skills/code-review/SKILL.md` (findings addressed during the loop and the final clean state)
 - **Security review summary** — outcome of `@skills/security-review/SKILL.md`
-- **Testing notes** — outcome of `@skills/test-like-human/SKILL.md`, including scenarios exercised and any caveats
 
 ### Non-technical report → original task tracker
 
@@ -183,7 +183,6 @@ The non-technical report must be understandable by non-technical testers and pro
 - No sensitive data is exposed
 - Code review loop passed with no Critical or Moderate findings **before the PR was created**
 - Security review completed **before the PR was created**
-- Test-like-human completed **before the PR was created**
 - A clean pull request is created with a summary
 - Technical report posted on the GitHub PR
 - Non-technical report posted on the original issue tracker

--- a/skills/test-like-human/SKILL.md
+++ b/skills/test-like-human/SKILL.md
@@ -18,6 +18,8 @@ metadata:
 - You need to validate a pull request from a real user perspective
 - You want structured testing based on PR instructions
 
+This skill runs **on demand only** — never auto-chained from `@skills/code-review/SKILL.md`, `@skills/code-review-github/SKILL.md`, `@skills/code-review-jira/SKILL.md`, `@skills/process-code-review/SKILL.md`, or `@skills/resolve-issue/SKILL.md`. Invoke it explicitly via `/test-like-human` (or the equivalent in-conversation request) after the CR has been published, when a real user-perspective validation is genuinely wanted.
+
 ## Required approach
 
 ### 1. Understand the context

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1419,33 +1419,39 @@ test('class-refactoring skill enforces the seven business logic layers including
     expect($content)->toContain('**Eloquent model**');
 });
 
-test('code-review skill After Completion section runs test-like-human unconditionally', function (): void {
+test('code-review skill After Completion section keeps test-like-human on demand', function (): void {
     $packageDir = dirname(__DIR__);
     $content = (string) file_get_contents($packageDir . '/skills/code-review/SKILL.md');
 
-    expect($content)->toMatch('/##\s*After Completion[^#]*Always run @skills\/test-like-human\/SKILL\.md, regardless of code review findings\./s');
-    expect($content)->not->toContain('If no **Critical** or **Moderate**');
+    expect($content)->not->toMatch('/##\s*After Completion[^#]*Always run @skills\/test-like-human\/SKILL\.md/s');
+    expect($content)->toMatch('/##\s*After Completion[^#]*Do \*\*not\*\* auto-invoke `@skills\/test-like-human\/SKILL\.md`/s');
 });
 
-test('code-review-jira skill After Completion section runs test-like-human unconditionally', function (): void {
+test('code-review-jira skill After Completion section keeps test-like-human on demand', function (): void {
     $packageDir = dirname(__DIR__);
     $content = (string) file_get_contents($packageDir . '/skills/code-review-jira/SKILL.md');
 
-    expect($content)->toMatch('/##\s*After Completion[^#]*Always run @skills\/test-like-human\/SKILL\.md, regardless of code review findings\./s');
-    expect($content)->not->toContain('If no **Critical** or **Moderate**');
+    expect($content)->not->toMatch('/##\s*After Completion[^#]*Always run @skills\/test-like-human\/SKILL\.md/s');
+    expect($content)->toMatch('/##\s*After Completion[^#]*Do \*\*not\*\* auto-invoke `@skills\/test-like-human\/SKILL\.md`/s');
 });
 
-test('test-like-human guard rejects gating regressions', function (): void {
-    $guardRegex = '/##\s*After Completion[^#]*Always run @skills\/test-like-human\/SKILL\.md, regardless of code review findings\./s';
-    $regressionWithGating = "## After Completion\n\n- If no **Critical** or **Moderate** findings:\n  - run @skills/test-like-human/SKILL.md\n";
-    $regressionWithoutRegardless = "## After Completion\n\n- Always run @skills/test-like-human/SKILL.md\n";
-    $regressionDirectiveOutsideSection = "## Other Section\n\n"
-        . "- Always run @skills/test-like-human/SKILL.md, regardless of code review findings.\n"
-        . "## After Completion\n\n- something else\n";
+test('CR and resolution skills never auto-invoke test-like-human', function (): void {
+    $packageDir = dirname(__DIR__);
+    $forbiddenSubstrings = [
+        'Always run @skills/test-like-human/SKILL.md, regardless of code review findings',
+        'Run @skills/test-like-human/SKILL.md if changes are testable',
+        '- Run `@skills/test-like-human/SKILL.md`',
+        '2. Run `@skills/test-like-human/SKILL.md`',
+    ];
+    $skills = ['code-review', 'code-review-github', 'code-review-jira', 'process-code-review', 'resolve-issue'];
 
-    expect((bool) preg_match($guardRegex, $regressionWithGating))->toBeFalse();
-    expect((bool) preg_match($guardRegex, $regressionWithoutRegardless))->toBeFalse();
-    expect((bool) preg_match($guardRegex, $regressionDirectiveOutsideSection))->toBeFalse();
+    foreach ($skills as $skill) {
+        $content = (string) file_get_contents($packageDir . '/skills/' . $skill . '/SKILL.md');
+
+        foreach ($forbiddenSubstrings as $needle) {
+            expect($content)->not->toContain($needle);
+        }
+    }
 });
 
 test('every code review skill references class-refactoring skill', function (): void {


### PR DESCRIPTION
## Souhrn

Zadání issue #497: *„Uprav skilly pro cr trak, aby nespustili skill test-like-human, ten se bude spouštět jen na vyžádání a tento skill upraví text reportu podle `/pr-summary`."*

Změna v jednom commitu (5 SKILL.md + jeden testovací soubor):

- `skills/code-review/SKILL.md`, `skills/code-review-jira/SKILL.md` — sekce **After Completion** už nechainuje do `test-like-human`; nahrazena explicitním zákazem auto-invokace.
- `skills/process-code-review/SKILL.md` — krok **Finalization** mezi konvergencí a commitem už `test-like-human` nespouští.
- `skills/resolve-issue/SKILL.md` — sekce **Testing** drží pouze běh security-review; v Constraints, technickém reportu (*Testing notes*) a **Done when** checklistu odpadají odkazy na `test-like-human`.
- `skills/test-like-human/SKILL.md` — v **Use when** doplněno, že skill běží **jen na vyžádání** a žádný CR / resolution skill ho nesmí auto-chainovat. Existující kapitola *After completion* (delegace na `pr-summary`) zůstává — druhý požadavek ze zadání (text reportu podle `pr-summary`) byl už dříve splněn.
- `tests/InstallerTest.php` — dva existující CR After-Completion testy byly invertovány na nový on-demand contract; přidán třetí test, který napříč všemi pěti dotčenými skilly hlídá, aby se auto-invokační direktiva už neobjevila zpět.

Resolves #497.

## Test plan
- [x] `composer build` — 169 testů (852 assertions) zelený, 100 % coverage
- [ ] Manuálně ověřit, že běh `/code-review` / `/code-review-github` / `/code-review-jira` se po dokončení neřetězí do `test-like-human`
- [ ] Manuálně ověřit, že `/process-code-review` po konvergenci přejde rovnou na commit + push bez auto-běhu `test-like-human`
- [ ] Manuálně ověřit, že `/resolve-issue` po code-review smyčce vykoná pouze security-review a vytvoří PR; `test-like-human` zůstane uživatelské vyvolání
- [ ] Manuálně ověřit, že přímé spuštění `/test-like-human` stále publikuje výstup přes `pr-summary` šablonu (Authors / Available behind / Summary of changes / How to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)