### PR TITLE
feat(skills): omit empty sections from technical CR output

### DIFF
--- a/skills/code-review-github/SKILL.md
+++ b/skills/code-review-github/SKILL.md
@@ -95,7 +95,7 @@ Before reviewing code, load and analyze the full linked issue:
 - Post all findings inside the single PR comment — never as line-anchored review comments.
 
 - If no findings:
-    - post: "No findings identified"
+    - post the header block (Status / Counts / Coverage / Issue tracker summary), the `## Coverage` section, and the final `Summary` line only. Omit every other section entirely. Do not append a "No findings identified" line — the Counts line `Critical 0 · Moderate 0 · Minor 0 · Refactoring 0` already signals the clean state and the omitted sections confirm there is nothing to fix.
 
 #### Issue tracker summary (mandatory)
 - After posting the PR comment, delegate the **non-technical summary on every linked issue** listed in `closingIssues[]` of the JSON loaded in step 1 to `@skills/pr-summary/SKILL.md`. This CR skill must not author its own non-technical template — the goal is a uniform *"Authors / Available behind / Summary of changes / How to test"* output across both trackers that non-technical project managers understand and can act on.
@@ -114,6 +114,7 @@ Before reviewing code, load and analyze the full linked issue:
 - Findings only
 - No praise
 - No “what was checked”
+- **Omit empty sections entirely.** Only the header block (Status / Counts / Coverage / Issue tracker summary), the `## Coverage` section, and the final `Summary` line are always rendered in the PR comment. Every other section — `Previous CR Status`, `Findings` (including each severity sub-heading), `Refactoring (DRY / Tech Debt Reduction)`, `Refactoring Proposals`, and `Database Analysis` — appears **only when it has at least one item**. Never emit `None.` / `Not applicable.` / `n/a` placeholders for empty sections; drop the whole heading and body instead. The Counts line is the single source of "zero" signal so a clean review stays scannable.
 - Use exactly three severity levels: Critical, Moderate, Minor
 - Add a **Refactoring (DRY / Tech Debt Reduction)** section after the Minor findings whenever the diff contains in-scope tech-debt-reducing changes (DRY duplication, oversized methods, mixed responsibilities). Each item must include `file:line` and a concrete refactoring step.
 - Each **Critical** and **Moderate** finding must include:

--- a/skills/code-review-github/templates/pr-comment-output.md
+++ b/skills/code-review-github/templates/pr-comment-output.md
@@ -1,5 +1,7 @@
 # Code Review
 
+> **Section visibility — render only sections that have content.** Always render the header block (Status / Counts / Coverage / Issue tracker summary), the `## Coverage` section, and the final `Summary` line. Every other section is conditional: omit its heading and body entirely when it has no items. Never emit `None.` / `Not applicable.` / `n/a` placeholders for empty sections — drop the whole section instead. The Counts line in the header is the single source of "zero" signal; the goal is a clean, scannable PR comment a human can read at a glance.
+
 **Status:** clean / needs-fix
 **Counts:** Critical {n} · Moderate {n} · Minor {n} · Refactoring {n}
 **Coverage:** {result} (tool: {name or "not available — <reason>"})
@@ -9,7 +11,7 @@
 
 ## Previous CR Status
 
-> Only on follow-up reviews. Omit on first review.
+> Render only on follow-up reviews that have at least one previous finding to classify. Omit on first reviews and on follow-up reviews whose previous-finding list is empty.
 
 | # | Finding | Status |
 |---|---------|--------|
@@ -18,6 +20,8 @@
 ---
 
 ## Findings
+
+> Render only when at least one Critical, Moderate, or Minor finding exists. Within this section, render only the severity sub-headings that have items — omit the others entirely. When all three severities are empty, omit the entire `## Findings` parent heading.
 
 ### 🔴 Critical 1. <short title>
 
@@ -48,7 +52,7 @@
 
 ## Refactoring (DRY / tech debt)
 
-> Only items on lines touched by this PR (added or modified). Each item must reduce tech debt — no stylistic preferences.
+> Render only when at least one in-scope refactoring item exists. Only items on lines touched by this PR (added or modified). Each item must reduce tech debt — no stylistic preferences. Omit the entire section when there are no items.
 
 1. **Location:** `path/to/file.php:42`
    **Problem:** one sentence — duplicated logic or structural breach in the changed code.
@@ -59,7 +63,7 @@
 
 ## Refactoring proposals
 
-> Out-of-scope structural improvements justified by rules. Omit when none.
+> Render only when at least one out-of-scope structural improvement is justified by a rule. Omit the entire section when there are no items.
 
 1. **Title:** short, actionable issue title
    **Scope:** affected file(s) or area

--- a/skills/code-review-jira/SKILL.md
+++ b/skills/code-review-jira/SKILL.md
@@ -110,6 +110,7 @@ Before reviewing code, load and analyze the full JIRA issue:
 - All technical findings go exclusively to GitHub PR comments
 - Include: file paths, line numbers, code references, severity levels, concrete fixes
 - Findings only — no praise, no explanations of what was checked
+- **Omit empty sections entirely.** Only the header block (Status / Counts / Coverage / Linked-tracker mirror), the `## Coverage` section, and the final `Summary` line are always rendered in the GitHub PR comment. Every other section — `Previous CR Status`, `Findings` (including each severity sub-heading), `Refactoring (DRY / tech debt)`, `Refactoring proposals`, and `Database Analysis` — appears **only when it has at least one item**. Never emit `None.` / `Not applicable.` / `n/a` placeholders for empty sections; drop the whole heading and body instead. The Counts line is the single source of "zero" signal so a clean review stays scannable.
 - Use severity levels: Critical, Moderate, Minor
 - Each **Critical** and **Moderate** finding must include:
     - **Faulty Example** — minimal code snippet or input payload reproducing the issue (redact secrets/PII)

--- a/skills/code-review-jira/templates/github-output.md
+++ b/skills/code-review-jira/templates/github-output.md
@@ -1,5 +1,7 @@
 # Code Review
 
+> **Section visibility — render only sections that have content.** Always render the header block (Status / Counts / Coverage / Linked-tracker mirror), the `## Coverage` section, and the final `Summary` line. Every other section is conditional: omit its heading and body entirely when it has no items. Never emit `None.` / `Not applicable.` / `n/a` placeholders for empty sections — drop the whole section instead. The Counts line in the header is the single source of "zero" signal; the goal is a clean, scannable PR comment a human can read at a glance.
+
 **Status:** clean / needs-fix
 **Counts:** Critical {n} · Moderate {n} · Minor {n} · Refactoring {n}
 **Coverage:** {result} (tool: {name or "not available — <reason>"})
@@ -9,7 +11,7 @@
 
 ## Previous CR Status
 
-> Only on follow-up reviews. Omit on first review.
+> Render only on follow-up reviews that have at least one previous finding to classify. Omit on first reviews and on follow-up reviews whose previous-finding list is empty.
 
 | # | Finding | Status |
 |---|---------|--------|
@@ -18,6 +20,8 @@
 ---
 
 ## Findings
+
+> Render only when at least one Critical, Moderate, or Minor finding exists. Within this section, render only the severity sub-headings that have items — omit the others entirely. When all three severities are empty, omit the entire `## Findings` parent heading.
 
 ### 🔴 Critical 1. <short title>
 
@@ -48,7 +52,7 @@
 
 ## Refactoring (DRY / tech debt)
 
-> Only items on lines touched by this PR. Each item must reduce tech debt — no stylistic preferences.
+> Render only when at least one in-scope refactoring item exists. Only items on lines touched by this PR. Each item must reduce tech debt — no stylistic preferences. Omit the entire section when there are no items.
 
 1. **Location:** `path/to/file.php:42`
    **Problem:** one sentence.
@@ -59,7 +63,7 @@
 
 ## Refactoring proposals
 
-> Out-of-scope structural improvements justified by rules. Omit when none.
+> Render only when at least one out-of-scope structural improvement is justified by a rule. Omit the entire section when there are no items.
 
 1. **Title:** short, actionable issue title
    **Scope:** affected file(s) or area

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -160,6 +160,7 @@ Run this section over the PR diff only — never over untouched code.
 
 - Output only findings
 - No praise, no summaries of what was checked
+- **Omit empty sections entirely.** Only the header block (Status / Counts / Coverage / tracker-status line), the `## Coverage` section, and the final `Summary` line are always rendered. Every other section — `Previous CR Status`, `Findings` (including each severity sub-heading), `Refactoring (DRY / tech debt)`, `Refactoring proposals`, `Database Analysis`, and any specialized-review sub-section — appears **only when it has at least one item**. Never emit `None.` / `Not applicable.` / `n/a` placeholders for empty sections; drop the whole heading and body instead. The Counts line in the header is the single source of "zero" signal so a clean review stays scannable.
 - Use severity levels:
     - Critical
     - Moderate

--- a/skills/code-review/templates/review-output.md
+++ b/skills/code-review/templates/review-output.md
@@ -1,5 +1,7 @@
 # Code Review
 
+> **Section visibility — render only sections that have content.** Always render the header block (Status / Counts / Coverage), the `## Coverage` section, and the final `Summary` line. Every other section is conditional: omit its heading and body entirely when it has no items. Never emit `None.` / `Not applicable.` / `n/a` placeholders for empty sections — drop the whole section instead. The Counts line in the header is the single source of "zero" signal; the goal is a clean, scannable PR comment a human can read at a glance.
+
 **Status:** clean / needs-fix
 **Counts:** Critical {n} · Moderate {n} · Minor {n} · Refactoring {n}
 **Coverage:** {result} (tool: {name or "not available — <reason>"})
@@ -8,7 +10,7 @@
 
 ## Previous CR Status
 
-> Only on follow-up reviews. Omit on first review.
+> Render only on follow-up reviews that have at least one previous finding to classify. Omit on first reviews and on follow-up reviews whose previous-finding list is empty.
 
 | # | Finding | Status |
 |---|---------|--------|
@@ -17,6 +19,8 @@
 ---
 
 ## Findings
+
+> Render only when at least one Critical, Moderate, or Minor finding exists. Within this section, render only the severity sub-headings that have items — omit the others entirely. When all three severities are empty, omit the entire `## Findings` parent heading.
 
 ### 🔴 Critical 1. <short title>
 
@@ -47,7 +51,7 @@
 
 ## Refactoring (DRY / tech debt)
 
-> Only items on lines touched by this PR (added or modified). Each item must reduce tech debt — no stylistic preferences.
+> Render only when at least one in-scope refactoring item exists. Only items on lines touched by this PR (added or modified). Each item must reduce tech debt — no stylistic preferences. Omit the entire section when there are no items.
 
 1. **Location:** `path/to/file.php:42`
    **Problem:** one sentence.
@@ -58,7 +62,7 @@
 
 ## Refactoring proposals
 
-> Out-of-scope structural improvements justified by rules. Omit when none.
+> Render only when at least one out-of-scope structural improvement is justified by a rule. Omit the entire section when there are no items.
 
 1. **Title:** short, actionable issue title
    **Scope:** affected file(s) or area
@@ -69,7 +73,7 @@
 
 ## Database Analysis
 
-> Mandatory when the diff touches database operations (raw SQL, Eloquent / query-builder calls, eager loads, model scopes, ModelManager / Repository methods, migrations, seeders, DynamoDB / NoSQL access). Omit the entire section when no DB operations are present in the diff — never leave a placeholder or fold it into Coverage.
+> Render only when the diff touches database operations (raw SQL, Eloquent / query-builder calls, eager loads, model scopes, ModelManager / Repository methods, migrations, seeders, DynamoDB / NoSQL access) **and** at least one finding is produced by `@skills/mysql-problem-solver/SKILL.md`. Omit the entire section when no DB operations are present in the diff, or when DB ops are present but no findings result — never leave a placeholder or fold it into Coverage.
 >
 > Report only findings (errors) and their fix recommendations. Never include the trigger decision, an inspected `file:line` list, or an EXPLAIN / static-analysis summary — those belong to the internal investigation, not the published review.
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1499,6 +1499,40 @@ test('code review templates include refactoring tech debt section', function ():
     }
 });
 
+test('code review output omits empty sections instead of rendering placeholders', function (): void {
+    $packageDir = dirname(__DIR__);
+
+    $templates = [
+        $packageDir . '/skills/code-review/templates/review-output.md',
+        $packageDir . '/skills/code-review-github/templates/pr-comment-output.md',
+        $packageDir . '/skills/code-review-jira/templates/github-output.md',
+    ];
+
+    foreach ($templates as $template) {
+        $content = (string) file_get_contents($template);
+        expect($content)->toContain('Section visibility — render only sections that have content.');
+        expect($content)->toContain('Render only when at least one Critical, Moderate, or Minor finding exists.');
+        expect($content)->toContain('Render only when at least one in-scope refactoring item exists.');
+        expect($content)->toContain('Render only when at least one out-of-scope structural improvement is justified by a rule.');
+        expect($content)->toContain('Render only on follow-up reviews that have at least one previous finding to classify.');
+    }
+
+    $skills = [
+        $packageDir . '/skills/code-review/SKILL.md',
+        $packageDir . '/skills/code-review-github/SKILL.md',
+        $packageDir . '/skills/code-review-jira/SKILL.md',
+    ];
+
+    foreach ($skills as $skillFile) {
+        $content = (string) file_get_contents($skillFile);
+        expect($content)->toContain('**Omit empty sections entirely.**');
+        expect($content)->toContain('the single source of "zero" signal');
+    }
+
+    $githubSkill = (string) file_get_contents($packageDir . '/skills/code-review-github/SKILL.md');
+    expect($githubSkill)->not->toContain('post: "No findings identified"');
+});
+
 test('install preserves executable bit on shipped scripts', function (): void {
     $root = installerCreateProjectRoot();
     $cwd = getcwd();


### PR DESCRIPTION
## Souhrn

- Technický CR PR komentář nově **vynechává sekce, které nemají obsah**. Cíl: krátký, přehledný výstup pro člověka, ne hromada `None.` placeholderů.
- Vždy se vykreslí jen: hlavička (Status / Counts / Coverage / tracker-status), `## Coverage` sekce a závěrečný `Summary` řádek. Counts line v hlavičce (`Critical 0 · Moderate 0 · Minor 0 · Refactoring 0`) nese jednoznačný signál „čistý review".
- Podmíněně se vykreslují: `Previous CR Status`, `Findings` (vč. jednotlivých severity sub-headingů), `Refactoring (DRY / tech debt)`, `Refactoring proposals`, `Database Analysis`. Sekce bez obsahu se kompletně vypustí — hlavička i tělo. Placeholdery typu `None.` / `Not applicable.` / `n/a` se nesmí emitovat.
- Pravidlo je uzamčené ve třech místech: `Output Rules` ve `skills/code-review/SKILL.md`, `skills/code-review-github/SKILL.md` a `skills/code-review-jira/SKILL.md`; v každé ze tří odpovídajících šablon přibyl `Section visibility` preambule + per-sekce `Render only when …` callout.
- Přidán regresní test `code review output omits empty sections instead of rendering placeholders` který kontrolu kotví.
- Closes #499.

## Test plan

- [x] `composer build` (skill-check + composer-normalize + phpcs + pint + rector + phpstan + security-audit + tests with 100% coverage) — passes (170 tests, 730 assertions).
- [ ] Manuální ověření: spusť `/code-review-github` nad čistým PR (žádné nálezy) a ověř, že výsledný komentář obsahuje pouze hlavičku, `## Coverage` a `Summary` line — žádné prázdné sekce `## Findings`, `## Refactoring (DRY / tech debt)`, `## Refactoring proposals` ani `## Database Analysis`.
- [ ] Manuální ověření: spusť `/code-review-github` nad PR s několika Critical / Moderate nálezy a ověř, že `## Findings` se zobrazí, ale `Refactoring proposals` / `Database Analysis` zůstanou skryté, pokud na ně diff nesahá.
- [ ] Manuální ověření: stejný test pro JIRA cestu přes `/code-review-jira` proti tiketu s napojeným PR — komentář na GitHubu (technická část) sleduje stejné pravidlo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)