### PR TITLE
feat(rules): require DTO for methods with more than 4 parameters

### DIFF
--- a/rules/php/core-standards.mdc
+++ b/rules/php/core-standards.mdc
@@ -44,6 +44,7 @@ globs: ["*"]
 - Extract deeply nested conditionals into well-named methods where it improves readability.
 - Prefer small, simple classes or functions unless state is genuinely needed.
 - Prefer typed DTOs over raw arrays across important boundaries.
+- When a method requires more than 4 parameters, introduce a dedicated DTO and pass it as a single argument instead of a long parameter list.
 - Use `readonly` for immutable data where practical.
 - Use PHP attributes when they provide a cleaner and more idiomatic solution than manual wiring.
 


### PR DESCRIPTION
## Shrnutí

Doplňuje do `rules/php/core-standards.mdc` (sekce **Structure**) explicitní práh pro zavedení DTO: pokud metoda potřebuje více než 4 parametry, je nutné zavést dedikovaný DTO a předávat jej jako jediný argument místo dlouhého seznamu parametrů.

Pravidlo navazuje na stávající bod *"Prefer typed DTOs over raw arrays across important boundaries."* a doplňuje obecnou poznámku ze sekce *Named Arguments* (*"Many parameters is a code smell. It often means the method does too much or should accept a DTO/value object."*) o konkrétní, vymahatelnou hranici.

## Změny

- `rules/php/core-standards.mdc` — přidána jedna řádka v sekci **Structure**.

## Jak otestovat

- Otevřít `rules/php/core-standards.mdc` a ověřit, že v sekci **Structure** přibyl bod:
  > When a method requires more than 4 parameters, introduce a dedicated DTO and pass it as a single argument instead of a long parameter list.
- Pravidlo je dokumentační (`*.mdc`), žádné běhové testy nejsou potřeba: **no**.