### PR TITLE
feat(skills): require fixing pre-existing issues in separate PR commits

### DIFF
--- a/skills/create-missing-tests-in-pr/SKILL.md
+++ b/skills/create-missing-tests-in-pr/SKILL.md
@@ -23,7 +23,9 @@ metadata:
 -   Only add or modify tests when needed.
 -   Production code may only be changed if it is strictly required by
     the existing create-test skill or test infrastructure, otherwise do
-    not modify it.
+    not modify it — the only exception is the **Pre-existing issue
+    handling** workflow below, which lands its production-code fixes in
+    their own separate commits.
 -   Use @skills/create-test/SKILL.md for all test-writing work.
 
 **Steps:**
@@ -69,7 +71,29 @@ Provide a brief markdown summary including:
 -   which recommendations were already covered
 -   which tests were added or updated
 -   whether 100% coverage for current changes was achieved
+-   list of pre-existing fix commits (if any), each with a one-line rationale, plus any pre-existing issue deferred as a follow-up with the reason
 -   any blocker preventing full completion
+
+**Pre-existing issue handling**
+
+While writing the missing tests, you may uncover problems that are **unrelated to the current PR scope** but were already present in the code you had to read or exercise. The following categories qualify:
+
+-   **Bugs** — incorrect logic, broken edge cases, or runtime errors revealed by exploratory test runs, but already present before this task.
+-   **Project-rule violations** — code that contradicts any rule listed in this skill's *Constraint* block or any other rule under `.claude/rules/`.
+-   **Security vulnerabilities** — anything `@rules/security/backend.md`, `@rules/security/frontend.md`, or `@rules/security/mobile.md` would flag.
+
+Rules:
+
+1.  **Do not silently ignore** a pre-existing issue you encountered in code you had to read or exercise while writing the missing tests.
+2.  **Do not expand scope** by actively scanning unrelated files for additional pre-existing issues. Limit attention to files already touched or exercised by the current PR's changes.
+3.  Land each pre-existing fix (and its regression test) in its **own separate commit** inside the same PR, distinct from the missing-tests commit:
+    -   Use a Conventional Commits subject per `@rules/git/general.mdc`: `fix(<scope>): pre-existing — <description>` for bugs and security, `refactor(<scope>): pre-existing — <description>` for rule violations without behavior change.
+    -   The `pre-existing — ` prefix is mandatory so reviewers can identify these commits at a glance.
+    -   **Test coverage workflow depends on the commit type:**
+        -   `fix(<scope>): pre-existing — …` (bug, security) — add the regression test in the **same commit** as the fix; the test must fail before the fix lands and pass after.
+        -   `refactor(<scope>): pre-existing — …` (project-rule violation, behavior-preserving) — apply `@rules/refactoring/general.mdc` *Test Coverage Contract*: when the target lines are below 100% coverage, author a dedicated `test(<scope>): cover <area> before pre-existing refactor` commit **before** the refactor commit, and do **not** modify pre-existing tests inside the refactor commit (mechanical renames forced by the refactor itself stay exempt and must be flagged in the commit body).
+4.  The "Production code may only be changed if it is strictly required" constraint above is **overridden** for these fixes — the production-code change is the fix itself, and it lives in its own commit.
+5.  If a pre-existing issue is **non-trivial** (would significantly expand the PR or requires architectural discussion), do **not** fix it. Surface it in the delivered markdown summary as a deferred follow-up with the reason.
 
 **After completing the tasks**
 
@@ -83,7 +107,7 @@ Provide a brief markdown summary including:
 -   Confirm whether current changes now meet the required test coverage (must be 100%).
 -   If something is still missing, clearly describe the blocker or
     uncovered scenario.
-- Create a new commit with the missing tests
+- Create a new commit with the missing tests, separate from any pre-existing fix commits produced by *Pre-existing issue handling* above
 - If according to @skills/test-like-human/SKILL.md the changes can be tested, do it!
 
 ## Principles

--- a/skills/create-test/SKILL.md
+++ b/skills/create-test/SKILL.md
@@ -16,7 +16,7 @@ Create or update tests to cover current changes according to project conventions
 ## Constraints
 - Apply @rules/code-testing/general.mdc
 - If the current project uses Laravel, also apply `@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, and `@rules/laravel/livewire.mdc`
-- Do not modify production code unless strictly required
+- Do not modify production code unless strictly required — the only exception is the **Pre-existing issue handling** workflow below, which lands its production-code fixes in their own separate commits
 
 ---
 
@@ -58,6 +58,27 @@ Create or update tests to cover current changes according to project conventions
 - Run a quick code review of the created/updated tests against `@rules/code-testing/general.mdc`
 - Fix any findings before finalizing
 
+### 8. Pre-existing issue handling
+
+While writing tests, you may uncover problems that are **unrelated to the current change** but were already present in the code you had to read or exercise. The following categories qualify:
+
+- **Bugs** — incorrect logic, broken edge cases, or runtime errors revealed by exploratory test runs, but already present before this task.
+- **Project-rule violations** — code that contradicts any rule listed in this skill's *Constraints* block or any other rule under `.claude/rules/`.
+- **Security vulnerabilities** — anything `@rules/security/backend.md`, `@rules/security/frontend.md`, or `@rules/security/mobile.md` would flag.
+
+Rules:
+
+1. **Do not silently ignore** a pre-existing issue you encountered in code you had to read or exercise to write the tests for the current change.
+2. **Do not expand scope** by actively scanning unrelated files for pre-existing issues. Limit attention to files already touched or exercised by the current change.
+3. Land each pre-existing fix (and its regression test) in its **own separate commit**, distinct from the test-coverage commit for the current change:
+   - Use a Conventional Commits subject per `@rules/git/general.mdc`: `fix(<scope>): pre-existing — <description>` for bugs and security, `refactor(<scope>): pre-existing — <description>` for rule violations without behavior change.
+   - The `pre-existing — ` prefix is mandatory so reviewers can identify these commits at a glance.
+   - **Test coverage workflow depends on the commit type:**
+     - `fix(<scope>): pre-existing — …` (bug, security) — add the regression test in the **same commit** as the fix; the test must fail before the fix lands and pass after.
+     - `refactor(<scope>): pre-existing — …` (project-rule violation, behavior-preserving) — apply `@rules/refactoring/general.mdc` *Test Coverage Contract*: when the target lines are below 100% coverage, author a dedicated `test(<scope>): cover <area> before pre-existing refactor` commit **before** the refactor commit, and do **not** modify pre-existing tests inside the refactor commit (mechanical renames forced by the refactor itself stay exempt and must be flagged in the commit body).
+4. The "Do not modify production code unless strictly required" constraint above is **overridden** for these fixes — the production-code change is the fix itself, and it lives in its own commit.
+5. If a pre-existing issue is **non-trivial** (would significantly expand the change or requires architectural discussion), do **not** fix it. Surface it in the skill's output report as a deferred follow-up with the reason.
+
 ---
 
 ## Output
@@ -65,6 +86,7 @@ Create or update tests to cover current changes according to project conventions
 - Created or updated test files
 - Coverage status for current changes (must be 100%)
 - Test review result
+- List of pre-existing fix commits (if any), each with a one-line rationale, plus any pre-existing issue deferred as a follow-up with the reason
 
 ---
 

--- a/skills/process-code-review/SKILL.md
+++ b/skills/process-code-review/SKILL.md
@@ -77,10 +77,27 @@ If a **CR-skill finding** lacks Faulty Example, Expected Behavior, or Test Hint,
 
 ---
 
-### Pre-fix phase
+### Pre-fix phase — pre-existing issue handling
 
-- Scan affected files for pre-existing bugs
-- Fix them in a **separate commit** before applying review fixes
+While reading the affected files in preparation for the CR fixes, you may encounter problems that are **unrelated to the reviewer feedback** but were already present in those files. The following categories qualify:
+
+- **Bugs** — incorrect logic, broken edge cases, null-dereference risks, race conditions, or runtime errors that exist before this CR.
+- **Project-rule violations** — code that contradicts any rule listed in this skill's *Constraints* block (`@rules/php/core-standards.mdc`, `@rules/git/general.mdc`, `@rules/laravel/*`, …) or any other rule under `.claude/rules/`.
+- **Security vulnerabilities** — anything `@rules/security/backend.md`, `@rules/security/frontend.md`, or `@rules/security/mobile.md` would flag (injection, missing authn/authz, unsafe deserialization, sensitive-data exposure, …).
+
+Rules:
+
+1. **Do not silently ignore** a pre-existing issue you encountered in a file you had to read for the CR fixes — fix it in this PR.
+2. **Do not expand scope** by actively scanning unrelated files for additional pre-existing issues. Limit attention to files already touched by the CR fixes.
+3. Land each pre-existing fix in its **own separate commit**, ordered **before** the CR-fix commits:
+   - Use a Conventional Commits subject per `@rules/git/general.mdc`: `fix(<scope>): pre-existing — <description>` for bugs and security, `refactor(<scope>): pre-existing — <description>` for rule violations without behavior change.
+   - The `pre-existing — ` prefix is mandatory so reviewers can identify these commits at a glance.
+   - **Test coverage workflow depends on the commit type:**
+     - `fix(<scope>): pre-existing — …` (bug, security) — add the regression test in the **same commit** as the fix; the test must fail before the fix lands and pass after.
+     - `refactor(<scope>): pre-existing — …` (project-rule violation, behavior-preserving) — apply `@rules/refactoring/general.mdc` *Test Coverage Contract*: when the target lines are below 100% coverage, author a dedicated `test(<scope>): cover <area> before pre-existing refactor` commit **before** the refactor commit, and do **not** modify pre-existing tests inside the refactor commit (mechanical renames forced by the refactor itself stay exempt and must be flagged in the commit body).
+   - Either way, pre-existing fixes follow the same diff-scoped 100% coverage rule as CR fixes.
+4. In the `cr-status` PR comment posted during **PR update**, list every pre-existing fix under a `## Pre-existing fixes` heading with a one-line rationale, so reviewers can review them independently of the CR thread.
+5. If a pre-existing issue is **non-trivial** (would significantly expand the PR or requires architectural discussion), do **not** fix it. Surface it in the `cr-status` comment as a deferred follow-up with the reason — the reviewer can then file a follow-up issue.
 
 ---
 
@@ -153,6 +170,7 @@ This is a **blocking loop**. Do not advance to **Finalization**, **PR update**, 
   - JIRA-originated reviews that also mirror to a JIRA ticket: `skills/code-review-jira/scripts/upsert-comment.sh <KEY|URL> - cr-status`. The helper appends `{anchor:cr-status-actor-<slug>}` and edits / adds the comment via `acli` (JIRA MCP fallback on exit code 4) — JIRA-side upsert behavior is unchanged.
 - Do **not** quote / reply to a previous CR or status comment — the always-new-comment convention (GitHub) replaces the previous quoting / in-place edit flow entirely, and every converge run adds its own self-contained status comment so the chronological sequence is the audit trail. The CR comment (`cr-comment` namespace) stays untouched by this skill.
 - Mark resolved items (checkbox or inline) inside the freshly posted body in all cases.
+- When **Pre-fix phase** produced at least one pre-existing fix commit, render a dedicated `## Pre-existing fixes` section in the `cr-status` body listing each commit subject (`fix/refactor(<scope>): pre-existing — …`) with a one-line rationale derived from the commit body, so reviewers can review the pre-existing fixes independently of the CR thread. Omit the section entirely when no pre-existing fix landed (consistent with the always-omit-empty-section convention).
 
 #### Resolve addressed reviewer threads (GitHub)
 

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -70,9 +70,10 @@ Run `@skills/prepare-issue-context/SKILL.md` with `MODE=resolve-issue` and the s
 6. **Gate — assignment specificity.** The pre-flight in step 5 already guarantees every scenario is mapped to a concrete code path; this gate only decides how clear the *requirements* are. Pick **specific** or **general** based on the scenario table and the current requirements from comment analysis:
    - **Specific** — expected behavior is unambiguous for every scenario, and the root cause (for bugs) or target behavior (for features) is explicitly stated in the assignment or current requirements. **Skip** `@skills/analyze-problem/SKILL.md` and use the scenario table together with the current requirements as the input for step 7.
    - **General** — requirements are vague, acceptance criteria are missing or open-ended, or the root cause is not identified. When in doubt, treat the assignment as general. **Run** `@skills/analyze-problem/SKILL.md` using the issue description, the scenario table, current requirements, and any available context, and use its output as the input for step 7.
-7. Review the input from step 6 and split the identified items into two groups:
+7. Review the input from step 6 and split the identified items into three groups:
    - **In scope** — items that directly match the issue requirements. These will be implemented.
-   - **Out of scope** — items that are valid findings but fall outside the current issue. These will be added to the PR summary as a TODO list for future tasks.
+   - **Pre-existing issues** — bugs, project-rule violations, or security vulnerabilities already present in the affected files before this task (see *Pre-existing issue handling* below). These will be fixed in **separate commits** inside the same PR.
+   - **Out of scope (deferred)** — valid findings that fall outside the current issue **and** do not qualify as pre-existing issues to fix now (e.g. enhancements, refactors, future features). These will be added to the PR summary as a `## TODO` list for future tasks.
 
 ### Phase planning (commit plan)
 
@@ -84,6 +85,28 @@ Before writing any code, decide how the in-scope work will be split into commits
 4. **If the assignment is small and atomic:** keep it as a single commit. Do not invent artificial phases.
 5. Record the planned phases as a numbered list (one line per commit, with the intended commit message in `type(scope): description` form per `@rules/git/general.mdc`) **before** starting implementation. This list is the commit plan for step 11.
 6. During implementation, commit at the end of each phase. Run pre-push fixers and tests on the changes belonging to that phase before moving on.
+
+### Pre-existing issue handling
+
+While reading and modifying the files required for the in-scope work, you may encounter problems that are **unrelated to the current assignment** but were already present in those files. The following categories qualify as pre-existing issues that must be fixed in this PR:
+
+- **Bugs** — incorrect logic, broken edge cases, null-dereference risks, race conditions, or runtime errors that exist before this task.
+- **Project-rule violations** — code that contradicts any rule listed in this skill's *Constraints* block (`@rules/php/core-standards.mdc`, `@rules/laravel/*`, `@rules/sql/optimalize.mdc`, etc.) or any other rule under `.claude/rules/`.
+- **Security vulnerabilities** — anything `@rules/security/backend.md`, `@rules/security/frontend.md`, or `@rules/security/mobile.md` would flag (injection, missing authn/authz, unsafe deserialization, sensitive-data exposure, …).
+
+Rules:
+
+1. **Do not silently ignore** a pre-existing issue you encountered in a file you had to read for the in-scope work — fix it in this PR.
+2. **Do not expand scope** by actively scanning unrelated files for additional pre-existing issues. Limit attention to files already touched by the in-scope changes (or their direct dependencies you must read to understand the change).
+3. Land each pre-existing fix in its **own separate commit** inside the same PR:
+   - Use a Conventional Commits subject per `@rules/git/general.mdc`: `fix(<scope>): pre-existing — <description>` for bugs and security, `refactor(<scope>): pre-existing — <description>` for rule violations without behavior change.
+   - The `pre-existing — ` prefix is mandatory so reviewers can identify these commits at a glance (e.g. `fix(user): pre-existing — null check before dispatching welcome mail`).
+   - **Test coverage workflow depends on the commit type:**
+     - `fix(<scope>): pre-existing — …` (bug, security) — add the regression test in the **same commit** as the fix; the test must fail before the fix lands and pass after.
+     - `refactor(<scope>): pre-existing — …` (project-rule violation, behavior-preserving) — apply `@rules/refactoring/general.mdc` *Test Coverage Contract*: when the target lines are below 100% coverage, author a dedicated `test(<scope>): cover <area> before pre-existing refactor` commit **before** the refactor commit, and do **not** modify pre-existing tests inside the refactor commit (mechanical renames forced by the refactor itself stay exempt and must be flagged in the commit body).
+   - Either way, pre-existing fixes follow the same 100% coverage rule on changed lines as in-scope changes (step 16).
+4. Order pre-existing fix commits **before** the in-scope commits in the commit plan from the previous section, so they form an independently revertable base. Update the recorded commit plan to include them before starting implementation.
+5. If a pre-existing issue is **non-trivial** (would significantly expand the PR, requires architectural decisions, or affects shared infrastructure beyond the touched files), do **not** fix it inline. Move it to the *Out of scope (deferred)* group from step 7 and surface it under the PR's `## TODO` section with a one-line reason for deferral.
 
 ### If bug
 8. Reproduce the issue if possible.
@@ -139,7 +162,8 @@ Once review and testing are clean:
   - reference to the original issue
   - testing instructions
   - **Summary** — concise overview of what changed and why
-  - **TODO list** — if any **out-of-scope** items were identified in step 7, include them in the PR summary under a `## TODO` section as a checklist of potential follow-up tasks
+  - **Pre-existing fixes** — if any pre-existing issues were fixed per *Pre-existing issue handling*, list each fix commit under a `## Pre-existing fixes` section with a one-line rationale so reviewers can review them independently of the assignment
+  - **TODO list** — if any **out-of-scope (deferred)** items were identified in step 7 (or non-trivial pre-existing issues were deferred), include them under a `## TODO` section as a checklist of potential follow-up tasks
 
 ## Final report
 
@@ -165,6 +189,7 @@ The non-technical report must be understandable by non-technical testers and pro
 - **What changed:** a brief, plain-language summary of the fix or feature
 - **How to test:** step-by-step instructions a tester can follow to verify the change works correctly
 - **Risk areas and edge cases:** specific scenarios the tester should focus on to catch potential regressions or unexpected behavior
+- **Pre-existing fixes also covered by this PR (when any):** plain-language one-line summary per pre-existing fix commit produced by *Pre-existing issue handling*, plus a one-line "what to re-verify" hint per fix so the tester knows the additional regression surface to validate. Omit the bullet entirely when no pre-existing fix landed.
 
 ### GitHub-specific follow-up
 - If the original repository uses a `ready for review` (or equivalent) label, apply it to the source issue once the PR is open to signal it is ready for reviewers. Skip this step when the project does not use such labels.


### PR DESCRIPTION
## Shrnutí

Do čtyř skillů (`resolve-issue`, `process-code-review`, `create-test`, `create-missing-tests-in-pr`) přidává konzistentní workflow pro **pre-existing chyby** — bugy, porušení projektových pravidel a security zranitelnosti, na které agent narazí v souborech, které musel číst pro svou hlavní práci. Místo tichého ignorování (původní *Surgical Changes* default) je teď opraví v **samostatném commitu** ve stejném PR s prefixem `fix/refactor(<scope>): pre-existing — …`.

## Klíčové změny

- **Společný pattern napříč 4 skilly** — žádné aktivní hledání mimo dotčené soubory, oprava do samostatného commitu, regression test, deferral non-trivial případů do `## TODO`.
- **Větvení test-coverage workflow podle typu commitu:**
  - `fix(...): pre-existing — …` (bug, security) — regression test ve stejném commitu jako fix.
  - `refactor(...): pre-existing — …` (porušení pravidla bez behavior change) — respektuje `@rules/refactoring/general.mdc` *Test Coverage Contract* (samostatný pre-coverage commit před refactor commitem, žádné edity stávajících testů uvnitř refactor commitu).
- **resolve-issue** — krok 7 nyní dělí findings do tří skupin (In scope / Pre-existing issues / Out of scope-deferred); nová sekce `Pre-existing issue handling` po Phase planning; `## Pre-existing fixes` v PR description; nový bullet v non-technical reportu pro testery.
- **process-code-review** — rozšířená `Pre-fix phase`; PR update nově emituje `## Pre-existing fixes` blok v `cr-status` komentáři.

## Test plan

- [x] `composer skill-check` — 29/29 skillů 100/100
- [x] `composer build` — 184 testů prošlo, 0 errors
- [ ] Při manuálním běhu `/resolve-issue` ověřit, že agent při nálezu pre-existing chyby skutečně vytvoří samostatný commit s prefixem `pre-existing — `
- [ ] Při běhu `/process-code-review` ověřit render `## Pre-existing fixes` v `cr-status` komentáři, když Pre-fix phase něco vytvoří