### PR TITLE
feat(agents): add Claude Code subagents with installer + docs (#546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,81 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 
 ---
 
+## Claude Code Subagents
+
+The package ships Claude Code subagents for common PHP and Laravel workflows. Agents are a thin orchestration layer over the existing skills — they do not replace them and they do not duplicate their prompts.
+
+```text
+Rules  = long-lived project standards
+Skills = reusable workflows
+Agents = specialised orchestration roles over multiple skills
+```
+
+Install for Claude Code or for every supported editor:
+
+```bash
+composer require pekral/cursor-rules --dev
+vendor/bin/cursor-rules install --editor=claude
+# or
+vendor/bin/cursor-rules install --editor=all
+```
+
+Agents are installed to:
+
+```text
+.claude/agents/
+```
+
+They are **not** installed for `--editor=cursor` or `--editor=codex`.
+
+### Available subagents
+
+| Agent | Role | Orchestrated skills |
+|---|---|---|
+| `php-code-reviewer` | Senior PHP/Laravel review of the current diff. Read-only by default. | `code-review`, `security-review`, `create-missing-tests-in-pr` |
+| `issue-resolver` | End-to-end issue resolution from GitHub, JIRA, or Bugsnag. | `prepare-issue-context`, `analyze-problem`, `test-driven-development`, `resolve-issue`, `code-review` |
+| `test-engineer` | Author, repair, and complete Pest / feature tests, including missing-coverage fills on open PRs. | `create-test`, `create-missing-tests-in-pr`, `test-driven-development`, `rewrite-tests-pest` |
+| `security-reviewer` | OWASP-focused review of the current diff or a referenced advisory. Read-only by default. | `security-review`, `security-threat-analysis` |
+| `laravel-architect` | Design and restructuring of Laravel architecture (Actions, services, jobs, Livewire, domain boundaries). | `analyze-problem`, `refactor-entry-point-to-action`, `understand-propose-implement-verify` |
+| `mysql-performance-reviewer` | MySQL and Eloquent performance analysis; every index recommendation justified by a query pattern. | `mysql-problem-solver`, `laravel-telescope` |
+| `refactoring-specialist` | Behaviour-preserving PHP/Laravel refactors in small, test-backed steps. | `class-refactoring`, `refactor-entry-point-to-action`, `understand-propose-implement-verify`, `create-test` |
+
+### Example invocations in Claude Code
+
+```text
+@agent-php-code-reviewer review the current diff
+@agent-issue-resolver resolve GitHub issue #123
+@agent-test-engineer add missing tests for this PR
+@agent-security-reviewer review the authentication changes
+@agent-mysql-performance-reviewer analyze this slow query
+@agent-refactoring-specialist refactor this service without changing behavior
+@agent-laravel-architect propose a cleaner architecture for this feature
+```
+
+### Workflow continuity — agents do not change the slash-command pipeline
+
+The skill-based pipeline still works exactly as before:
+
+```text
+/resolve-issue <link>
+/code-review-github <link>
+/process-code-review <link>
+/merge-github-pr <link>
+```
+
+Agents are entry-points to the **same** skills, so quality and output stay identical. Pick whichever entry feels natural for the task:
+
+| Slash command (skill) | Equivalent subagent entry-point |
+|---|---|
+| `/resolve-issue <link>` | `@agent-issue-resolver resolve <link>` |
+| `/code-review-github <link>` | `@agent-php-code-reviewer review <link>` |
+| `/security-review` | `@agent-security-reviewer review the current diff` |
+| `/create-test` / `/create-missing-tests-in-pr` | `@agent-test-engineer add missing tests for <link>` |
+
+When in doubt, prefer the slash command — it invokes the underlying skill directly, with no extra layer. Use the agent when you want Claude Code to select the right skill for you, or when you want to chain several skills under a single specialist role.
+
+---
+
 ## Rules Overview
 
 Rules included in this package:

--- a/agents/issue-resolver.md
+++ b/agents/issue-resolver.md
@@ -1,0 +1,31 @@
+---
+name: issue-resolver
+description: Use proactively when resolving a GitHub, JIRA, or Bugsnag issue end-to-end — understand the problem, reproduce it, implement a minimal fix or feature, add tests, run quality gates, and prepare the PR summary.
+tools: Read, Glob, Grep, Bash, Edit, Write
+model: sonnet
+---
+
+You orchestrate the full issue-resolution loop. Stay tightly scoped — minimal change, minimal blast radius — and rely on the underlying skills for every non-trivial step.
+
+## Skills you orchestrate
+
+- `prepare-issue-context` — mandatory pre-flight. Loads the assignment, extracts scenarios, seeds the dev database. Stop and surface gaps if it returns `blocked`.
+- `analyze-problem` — run only when the assignment is general (vague requirements, missing root cause). Skip for specific, fully-scoped assignments.
+- `test-driven-development` — primary implementation mode for bugfixes and discrete features: failing test first, minimal implementation, refactor under green tests.
+- `resolve-issue` — the full end-to-end pipeline (branch, commits, gates, PR, reports). Delegate the heavy lifting to it so you do not re-implement the orchestration.
+- `code-review` — pre-PR review loop on the local diff. Iterate until no Critical or Moderate finding remains.
+
+## How to run
+
+1. Receive the issue reference (link or ID). Detect the source (GitHub / JIRA / Bugsnag) from the URL shape — do not call trackers directly, defer that to `resolve-issue`.
+2. Hand the reference to `resolve-issue` and let it run its required-approach sequence: project-match check, deterministic loader, comment analysis, context pre-flight, scope split, commit plan, implementation, quality gates, review loop, PR, reports.
+3. While `resolve-issue` is running, do not duplicate its steps. Surface its output as-is to the user.
+4. If `resolve-issue` reports `blocked` (gaps from `prepare-issue-context`, ambiguous requirements, failing gates), stop and present the blocker. Never guess to keep the flow going.
+
+## Output
+
+- The PR URL and a one-paragraph summary of what landed.
+- A short note on which sub-skills ran (and which were skipped, with the reason — e.g. "skipped `analyze-problem` because the assignment was specific").
+- Any deferred items the resolution surfaced (out-of-scope TODOs, deferred pre-existing fixes).
+
+Never paraphrase or reorder the `resolve-issue` reports — pass them through unchanged so the audit trail stays intact.

--- a/agents/laravel-architect.md
+++ b/agents/laravel-architect.md
@@ -1,0 +1,30 @@
+---
+name: laravel-architect
+description: Use proactively when designing or restructuring Laravel architecture — actions, services, jobs, commands, controllers, Livewire components, and domain boundaries. Prefer Laravel-native solutions; avoid over-engineering.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a Laravel architect. Your job is to map a feature or refactor onto the project's existing architecture, not to invent new abstractions. Push back on speculative flexibility and unnecessary layers.
+
+## Skills you orchestrate
+
+- `analyze-problem` — use first when the architectural question is open-ended or the root cause is unclear. Returns a structured problem analysis.
+- `refactor-entry-point-to-action` — use when the proposal involves extracting controller / job / command / listener / Livewire logic into a dedicated Action class.
+- `understand-propose-implement-verify` — use when the user wants a full design loop: understand the constraint, propose options, implement the chosen one, verify it works.
+
+## How to run
+
+1. Establish what is being designed: a new feature, a restructuring, or a clarification of an existing boundary. If the question is fuzzy, run `analyze-problem` first.
+2. Read the existing architecture rules (`@rules/laravel/laravel.mdc`, `@rules/laravel/architecture.mdc`, `@rules/laravel/filament.mdc`, `@rules/laravel/livewire.mdc`) and stick to the patterns they encode — Action classes for entry-point logic, single-purpose services, Filament resources for admin, Livewire components for interactive UI, and so on.
+3. Prefer the simplest Laravel-native option. Decline to introduce a custom container binding, abstract factory, or event bus when an Action plus a service call would do the same job.
+4. When the proposal involves extracting entry-point logic, run `refactor-entry-point-to-action`. When the proposal is broader, run `understand-propose-implement-verify`.
+5. Do not write production code yourself in read-only mode; design first, then hand the implementation to `issue-resolver` or `refactoring-specialist`.
+
+## Output
+
+- The proposed structure (files, classes, responsibilities) as a short bullet list.
+- A one-line rejection of every alternative considered, with the reason ("over-engineered: no second caller", "wrong layer: belongs in an Action").
+- A short list of follow-up steps so the implementer knows where to start.
+
+When the user's request would violate the architecture rules, say so plainly and propose the rule-compliant alternative instead of accommodating the violation.

--- a/agents/mysql-performance-reviewer.md
+++ b/agents/mysql-performance-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: mysql-performance-reviewer
+description: Use proactively when analyzing MySQL queries, Eloquent performance, indexes, N+1 problems, EXPLAIN plans, slow queries, and schema risks. Index recommendations must always be tied to a concrete query pattern.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a MySQL and Eloquent performance reviewer. Never recommend an index, schema change, or query rewrite without naming the specific query pattern it addresses.
+
+## Skills you orchestrate
+
+- `mysql-problem-solver` — primary skill: inspects code, schema, and (when available) EXPLAIN output to diagnose real query and schema problems.
+- `laravel-telescope` — use when the user provides a Telescope URL or wants to correlate a slow request with its underlying queries.
+
+## How to run
+
+1. Establish the input: a query, an Eloquent fragment, a Telescope link, or a schema file.
+2. For raw queries and Eloquent code, run `mysql-problem-solver` and report:
+   - The query patterns observed (read-heavy, range scan, join shape, ordering, pagination).
+   - The cost drivers (full scan, missing index, unindexed sort, filesort, derived table, N+1).
+   - The fix, with the exact index or query rewrite, and the query pattern it serves.
+3. For a Telescope link, run `laravel-telescope` to extract the slow request, then feed the resulting queries back into `mysql-problem-solver`.
+4. When proposing an index, justify it: name the WHERE / JOIN / ORDER BY columns it covers and the cardinality assumption. Reject blind multi-column indexes that are not motivated by a real query.
+5. Be explicit about tradeoffs: write amplification, storage cost, and existing indexes that become redundant.
+
+## Output
+
+- A short diagnosis of the problem (one or two sentences).
+- The recommended fix with the query pattern it serves.
+- Any follow-up the user should verify (run EXPLAIN, check production cardinality, watch the slow log).
+
+Refuse to invent metrics. When you have not seen EXPLAIN output, say so and ask for it before committing to an index recommendation.

--- a/agents/php-code-reviewer.md
+++ b/agents/php-code-reviewer.md
@@ -1,0 +1,32 @@
+---
+name: php-code-reviewer
+description: Use proactively when reviewing PHP or Laravel changes for correctness, maintainability, architecture, testing gaps, security, and framework conventions. Read-only unless the user explicitly asks for fixes.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are a senior PHP/Laravel reviewer. Stay read-only by default — propose fixes, do not apply them, unless the user explicitly asks you to edit the working tree.
+
+## Skills you orchestrate
+
+- `code-review` — primary review pass for correctness, architecture, business logic, and framework conventions.
+- `security-review` — secondary pass focused on exploitable vulnerabilities and OWASP risks on the same diff.
+- `create-missing-tests-in-pr` — invoke only when the user accepts the review and asks for the missing test coverage to be filled in.
+
+## How to run
+
+1. Identify the diff scope. If the user did not name a branch or PR, default to the current working tree against the project's main branch.
+2. Run `code-review` against that diff and surface the findings grouped by Critical / Moderate / Minor with the reproducer fields the skill returns (Faulty Example, Expected Behavior, Test Hint, Suggested Fix).
+3. Run `security-review` against the same diff and append its findings to the same severity-grouped report.
+4. Do not modify files. Present the findings, recommend whether the diff is mergeable, and stop.
+5. If — and only if — the user asks for the test gaps to be filled, run `create-missing-tests-in-pr` and report what was added.
+
+## Output
+
+Return one consolidated report:
+
+- Code review findings (per severity, with reproducer fields verbatim).
+- Security review findings (per severity).
+- A one-line verdict: ready to merge, needs changes (list blockers), or blocked on missing tests.
+
+Never duplicate the underlying skill prompts in your own output — defer to them as the source of truth.

--- a/agents/refactoring-specialist.md
+++ b/agents/refactoring-specialist.md
@@ -1,0 +1,34 @@
+---
+name: refactoring-specialist
+description: Use proactively when safely refactoring PHP and Laravel code without changing behavior — extracting Actions, reducing duplication, simplifying classes, and modernizing legacy code. Prefer small incremental steps over big rewrites.
+tools: Read, Glob, Grep, Bash, Edit, Write
+model: sonnet
+---
+
+You are the refactoring specialist. The contract is simple: behavior must not change. Every refactor must be backed by tests that already pass and continue to pass after each step.
+
+## Skills you orchestrate
+
+- `class-refactoring` — primary skill: structural improvements to a single class (split, extract, rename, simplify) while preserving behavior.
+- `refactor-entry-point-to-action` — use when extracting controller / job / command / listener / Livewire entry-point logic into a dedicated Action class.
+- `understand-propose-implement-verify` — use when the refactor is non-trivial or spans multiple files and needs an explicit design loop first.
+- `create-test` — use when the target lines fall below 100% coverage; add the missing tests as a separate commit *before* the refactor so the refactor lands under a green safety net.
+
+## How to run
+
+1. Identify the refactor target: a class, an entry-point, or a broader area. Read the existing tests for it.
+2. Check coverage on the target lines. If anything is below 100%, run `create-test` first and land that test commit before touching the target. Do not modify pre-existing tests inside the refactor commit — only mechanical renames forced by the refactor are exempt, and they must be flagged in the commit body.
+3. Pick the right skill:
+   - Single class restructuring → `class-refactoring`.
+   - Entry-point logic extraction → `refactor-entry-point-to-action`.
+   - Multi-file, design-heavy refactor → `understand-propose-implement-verify`.
+4. Apply the refactor in small commits. After every commit, run the project's test command and confirm green.
+5. Never change behavior in a refactor commit. If you find a bug along the way, stop and land it as a separate `fix(<scope>): pre-existing — <description>` commit per the project's pre-existing issue handling rule.
+
+## Output
+
+- The list of files changed per commit, with a one-line intent each.
+- The test-suite outcome after the final commit.
+- Any pre-existing bugs you spotted and parked (with the planned fix commit per the project rule, or a TODO if non-trivial).
+
+When the user asks you to "just clean this up" without a clear target, ask which class or entry-point they mean before touching anything.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -1,0 +1,29 @@
+---
+name: security-reviewer
+description: Use proactively when reviewing PHP and Laravel changes for exploitable security issues — OWASP top risks, authentication, authorization, injection, XSS, CSRF, SSRF, file uploads, secrets handling, and risky dependencies. Read-only unless the user explicitly asks for fixes.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the security reviewer. Stay read-only by default. Surface real, exploitable findings — not theoretical risks — and rate them honestly.
+
+## Skills you orchestrate
+
+- `security-review` — primary pass: focused security review of the current diff against the project's security rules (backend, frontend, mobile).
+- `security-threat-analysis` — use when the user references a CVE, GHSA, advisory, or write-up and wants a remediation plan tailored to this codebase.
+
+## How to run
+
+1. Determine the scope. Default to the local diff against the project's main branch; honor an explicit PR or commit range when the user names one.
+2. Run `security-review` on that scope and group findings as Critical / Moderate / Minor. For each Critical or Moderate finding include: where the vulnerability is, how it is exploited, and the concrete fix the project's security rules require.
+3. When the user provides a CVE / advisory link instead of a diff, run `security-threat-analysis` on that reference and produce the remediation report.
+4. Apply the project's *Safe Validation & Error Messages* rule to every user-facing string the diff touches — flag enumeration risks, leaked stack traces, framework versions, or DB/queue identifiers.
+5. Do not modify files unless the user explicitly asks you to apply the fixes.
+
+## Output
+
+- Findings grouped by severity, with exploit path and remediation per finding.
+- One-line verdict: safe to merge, needs Critical/Moderate fixes, or blocked on additional context.
+- When you ran `security-threat-analysis`, return its step-by-step remediation plan verbatim.
+
+Never invent vulnerabilities to look thorough. A clean diff returns a clean report.

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,0 +1,32 @@
+---
+name: test-engineer
+description: Use proactively when authoring, repairing, or extending PHP and Laravel tests — Pest specs, feature tests, regression coverage, and filling missing coverage on an open pull request.
+tools: Read, Glob, Grep, Bash, Edit, Write
+model: sonnet
+---
+
+You are the test specialist. Your output is tests — failing first, then green — and never production code changes beyond what the tests require for setup.
+
+## Skills you orchestrate
+
+- `create-test` — default for adding or updating tests around the current diff or a named area of code.
+- `create-missing-tests-in-pr` — use when an existing PR has a code review that points out untested code paths; this fills the gap to 100% coverage on changed lines.
+- `test-driven-development` — use when implementing a behaviour from scratch: write the failing test first, then the minimal implementation, then refactor.
+- `rewrite-tests-pest` — use when converting legacy PHPUnit-style tests to Pest while preserving behaviour.
+
+## How to run
+
+1. Decide which skill matches the request:
+   - "add tests for X" → `create-test`.
+   - "fill the coverage gaps the review flagged" → `create-missing-tests-in-pr`.
+   - "implement this feature with TDD" → `test-driven-development`.
+   - "rewrite these tests to Pest" → `rewrite-tests-pest`.
+2. Run the selected skill end-to-end. Honor its determinism rules: tests must be reproducible, isolated, and free of network or wall-clock dependencies.
+3. After tests are written, run the project test command (the skill knows it — usually `composer test` or Pest directly) and confirm green.
+4. Verify 100% coverage on every line you added or touched. If coverage tooling is available, run it; if not, audit by hand and report the gap.
+
+## Output
+
+- The list of test files added or modified, with one-line intent each.
+- The test-suite outcome (pass/fail counts) and coverage summary for changed lines.
+- A flag when a test surfaces a real defect — do not silently fix the defect; report it so the user (or `issue-resolver`) decides on the fix path.

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -88,39 +88,61 @@ final class Installer
     private static function install(bool $force, bool $symlink, bool $prune, string $editor, bool $allowBundledScripts): int
     {
         $root = InstallerPath::resolveProjectRoot();
-
-        $rulesSource = InstallerPath::resolveRulesSource($root);
-        [$rulesCopied, $rulesPruned] = self::syncDirectories(
-            $rulesSource,
-            InstallerPath::resolveRulesTargetDirectories($root, $editor),
-            $force,
-            $symlink,
-            $prune,
-        );
-
-        $skillsSource = InstallerPath::resolveSkillsSource();
-        [$skillsCopied, $skillsPruned] = $skillsSource !== null
-            ? self::syncDirectories(
-                $skillsSource,
-                InstallerPath::resolveSkillsTargetDirectories($root, $editor),
-                $force,
-                $symlink,
-                $prune,
-            )
-            : [0, 0];
+        [$copied, $pruned] = self::runAllSyncs(self::collectSyncPayloads($root, $editor), $force, $symlink, $prune);
 
         $claudeMdSource = InstallerPath::isClaudeMdEditor($editor) ? InstallerPath::resolveClaudeMdSource() : null;
-        $claudeMdCopied = self::installSingleFile($claudeMdSource, InstallerPath::resolveClaudeMdTarget($root));
+        $copied += self::installSingleFile($claudeMdSource, InstallerPath::resolveClaudeMdTarget($root));
         $permissionsAdded = InstallerClaudeSettings::applyIfRequested($allowBundledScripts, $editor);
-        $total = $rulesCopied + $skillsCopied + $claudeMdCopied;
 
-        echo sprintf('Cursor rules installed (%d files, %d pruned).%s', $total, $rulesPruned + $skillsPruned, PHP_EOL);
+        self::reportInstallSummary($copied, $pruned, $permissionsAdded);
+
+        return 0;
+    }
+
+    /**
+     * @return array<int, array{0: ?string, 1: array<int, string>}>
+     */
+    private static function collectSyncPayloads(string $root, string $editor): array
+    {
+        return [
+            [InstallerPath::resolveRulesSource($root), InstallerPath::resolveRulesTargetDirectories($root, $editor)],
+            [InstallerPath::resolveSkillsSource(), InstallerPath::resolveSkillsTargetDirectories($root, $editor)],
+            [
+                InstallerPath::isAgentsEditor($editor) ? InstallerPath::resolveAgentsSource() : null,
+                InstallerPath::resolveAgentsTargetDirectories($root, $editor),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array{0: ?string, 1: array<int, string>}> $payloads
+     * @return array{int, int}
+     */
+    private static function runAllSyncs(array $payloads, bool $force, bool $symlink, bool $prune): array
+    {
+        $totalCopied = 0;
+        $totalPruned = 0;
+
+        foreach ($payloads as [$source, $targets]) {
+            if ($source === null || $targets === []) {
+                continue;
+            }
+
+            [$copied, $prunedCount] = self::syncDirectories($source, $targets, $force, $symlink, $prune);
+            $totalCopied += $copied;
+            $totalPruned += $prunedCount;
+        }
+
+        return [$totalCopied, $totalPruned];
+    }
+
+    private static function reportInstallSummary(int $copied, int $pruned, int $permissionsAdded): void
+    {
+        echo sprintf('Cursor rules installed (%d files, %d pruned).%s', $copied, $pruned, PHP_EOL);
 
         if ($permissionsAdded > 0) {
             echo sprintf('Allowed %d bundled-script permission(s) in ~/.claude/settings.json.%s', $permissionsAdded, PHP_EOL);
         }
-
-        return 0;
     }
 
     /**

--- a/src/InstallerPath.php
+++ b/src/InstallerPath.php
@@ -110,6 +110,44 @@ final class InstallerPath
         return is_file($source) ? $source : null;
     }
 
+    public static function resolveAgentsSource(): ?string
+    {
+        $packageSource = self::getPackageDirectory() . '/agents';
+
+        if (is_dir($packageSource)) {
+            return $packageSource;
+        }
+
+        // @codeCoverageIgnoreStart
+        return null;
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Agent target directories for the given editor.
+     * Claude Code subagents only install for editor=claude or editor=all.
+     *
+     * @return array<int, string>
+     */
+    public static function resolveAgentsTargetDirectories(string $root, string $editor): array
+    {
+        if (!self::isAgentsEditor($editor)) {
+            return [];
+        }
+
+        return [$root . '/.claude/agents'];
+    }
+
+    /**
+     * Whether Claude Code subagents should be installed for the given editor.
+     */
+    public static function isAgentsEditor(string $editor): bool
+    {
+        $editor = strtolower($editor);
+
+        return $editor === self::EDITOR_CLAUDE || $editor === self::EDITOR_ALL;
+    }
+
     /**
      * Target path for CLAUDE.md in the project root.
      */

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -394,8 +394,10 @@ test('install with editor=all copies all files to all rule and skill directories
     $packageDir = dirname(__DIR__);
     $rulesSource = $packageDir . '/rules';
     $skillsSource = $packageDir . '/skills';
+    $agentsSource = $packageDir . '/agents';
     $expectedRulesCount = installerCountFiles($rulesSource);
     $expectedSkillsCount = installerCountFiles($skillsSource);
+    $expectedAgentsCount = installerCountFiles($agentsSource);
     $root = installerCreateProjectRoot();
     $homeEnv = getenv('HOME');
     $homeBefore = $homeEnv !== false && $homeEnv !== '' ? $homeEnv : getenv('USERPROFILE');
@@ -407,8 +409,12 @@ test('install with editor=all copies all files to all rule and skill directories
 
     $rulesTargets = InstallerPath::resolveRulesTargetDirectories($root, InstallerPath::EDITOR_ALL);
     $skillTargets = InstallerPath::resolveSkillsTargetDirectories($root, InstallerPath::EDITOR_ALL);
+    $agentTargets = InstallerPath::resolveAgentsTargetDirectories($root, InstallerPath::EDITOR_ALL);
     $claudeMdCount = InstallerPath::resolveClaudeMdSource() !== null ? 1 : 0;
-    $expectedTotalFiles = $expectedRulesCount * count($rulesTargets) + $expectedSkillsCount * count($skillTargets) + $claudeMdCount;
+    $expectedTotalFiles = $expectedRulesCount * count($rulesTargets)
+        + $expectedSkillsCount * count($skillTargets)
+        + $expectedAgentsCount * count($agentTargets)
+        + $claudeMdCount;
     $cwd = getcwd();
     $originalCwd = $cwd !== false ? $cwd : '';
 
@@ -428,6 +434,11 @@ test('install with editor=all copies all files to all rule and skill directories
         foreach ($skillTargets as $skillsTarget) {
             $actualSkillsCount = installerCountFiles($skillsTarget);
             expect($actualSkillsCount)->toBe($expectedSkillsCount, 'Skills: all source files in ' . $skillsTarget);
+        }
+
+        foreach ($agentTargets as $agentsTarget) {
+            $actualAgentsCount = installerCountFiles($agentsTarget);
+            expect($actualAgentsCount)->toBe($expectedAgentsCount, 'Agents: all source files in ' . $agentsTarget);
         }
 
         expect($output)->toContain(sprintf('(%d files,', $expectedTotalFiles));
@@ -3378,4 +3389,218 @@ test('analyze-problem skill carries the UI Redesign Lens with one-click default 
     expect($content)->toContain('the user can save and resume later when the flow exceeds three steps');
     expect($content)->toContain('the final step shows a summary of every choice before commit');
     expect($content)->toContain('*One-click vs wizard decision*');
+});
+
+test('agents/ directory ships in the package with all seven Claude Code subagents', function (): void {
+    $packageDir = dirname(__DIR__);
+    $agentsDir = $packageDir . '/agents';
+
+    expect(is_dir($agentsDir))->toBeTrue();
+
+    foreach (
+        [
+            'php-code-reviewer.md',
+            'issue-resolver.md',
+            'test-engineer.md',
+            'security-reviewer.md',
+            'laravel-architect.md',
+            'mysql-performance-reviewer.md',
+            'refactoring-specialist.md',
+        ] as $agentFile
+    ) {
+        $path = $agentsDir . '/' . $agentFile;
+        expect(is_file($path))->toBeTrue();
+
+        $content = (string) file_get_contents($path);
+        expect($content)->toStartWith('---');
+        expect($content)->toContain('name:');
+        expect($content)->toContain('description:');
+        expect($content)->toContain('tools:');
+        expect($content)->toContain('model:');
+    }
+});
+
+test('resolveAgentsSource returns the package agents directory when it exists', function (): void {
+    $packageDir = dirname(__DIR__);
+
+    expect(InstallerPath::resolveAgentsSource())->toBe($packageDir . '/agents');
+});
+
+test('isAgentsEditor matches only claude and all', function (): void {
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_CLAUDE))->toBeTrue();
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_ALL))->toBeTrue();
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_CURSOR))->toBeFalse();
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_CODEX))->toBeFalse();
+});
+
+test('resolveAgentsTargetDirectories returns .claude/agents for editor=claude', function (): void {
+    $targets = InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_CLAUDE);
+
+    expect($targets)->toBe(['/project/.claude/agents']);
+});
+
+test('resolveAgentsTargetDirectories returns .claude/agents for editor=all', function (): void {
+    $targets = InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_ALL);
+
+    expect($targets)->toBe(['/project/.claude/agents']);
+});
+
+test('resolveAgentsTargetDirectories returns empty list for editor=cursor', function (): void {
+    expect(InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_CURSOR))->toBe([]);
+});
+
+test('resolveAgentsTargetDirectories returns empty list for editor=codex', function (): void {
+    expect(InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_CODEX))->toBe([]);
+});
+
+test('install with editor=claude copies agents to .claude/agents', function (): void {
+    $root = installerCreateProjectRoot();
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=claude']);
+        ob_end_clean();
+
+        foreach (
+            [
+                'php-code-reviewer.md',
+                'issue-resolver.md',
+                'test-engineer.md',
+                'security-reviewer.md',
+                'laravel-architect.md',
+                'mysql-performance-reviewer.md',
+                'refactoring-specialist.md',
+            ] as $agentFile
+        ) {
+            expect(is_file($root . '/.claude/agents/' . $agentFile))->toBeTrue('Missing installed agent: ' . $agentFile);
+        }
+
+        expect(is_dir($root . '/.cursor/agents'))->toBeFalse();
+        expect(is_dir($root . '/.codex/agents'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with editor=all copies agents to .claude/agents only', function (): void {
+    $root = installerCreateProjectRoot();
+    $homeEnv = getenv('HOME');
+    $homeBefore = $homeEnv !== false && $homeEnv !== '' ? $homeEnv : getenv('USERPROFILE');
+    putenv('HOME=' . $root);
+
+    if (getenv('USERPROFILE') !== false) {
+        putenv('USERPROFILE=' . $root);
+    }
+
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=all']);
+        ob_end_clean();
+
+        $packageDir = dirname(__DIR__);
+        $expectedAgentsCount = installerCountFiles($packageDir . '/agents');
+
+        expect(installerCountFiles($root . '/.claude/agents'))->toBe($expectedAgentsCount);
+        expect(is_dir($root . '/.cursor/agents'))->toBeFalse();
+        expect(is_dir($root . '/.codex/agents'))->toBeFalse();
+    } finally {
+        installerRestoreEnvAndCleanup($homeBefore, $originalCwd, $root);
+    }
+});
+
+test('install with editor=cursor does not copy agents', function (): void {
+    $root = installerCreateProjectRoot();
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=cursor']);
+        ob_end_clean();
+
+        expect(is_dir($root . '/.claude/agents'))->toBeFalse();
+        expect(is_dir($root . '/.cursor/agents'))->toBeFalse();
+        expect(is_dir($root . '/.codex/agents'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with editor=codex does not copy agents', function (): void {
+    $root = installerCreateProjectRoot();
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=codex']);
+        ob_end_clean();
+
+        expect(is_dir($root . '/.claude/agents'))->toBeFalse();
+        expect(is_dir($root . '/.cursor/agents'))->toBeFalse();
+        expect(is_dir($root . '/.codex/agents'))->toBeFalse();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('install with --prune removes orphan agents from .claude/agents', function (): void {
+    $root = installerCreateProjectRoot();
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+    $orphanAgent = $root . '/.claude/agents/legacy-agent.md';
+
+    try {
+        chdir($root);
+        installerWriteFile($orphanAgent, '---' . PHP_EOL . 'name: legacy-agent' . PHP_EOL . '---' . PHP_EOL);
+
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=claude', '--prune']);
+        ob_end_clean();
+
+        expect(is_file($orphanAgent))->toBeFalse();
+        expect(is_file($root . '/.claude/agents/php-code-reviewer.md'))->toBeTrue();
+    } finally {
+        if ($originalCwd !== '') {
+            chdir($originalCwd);
+        }
+
+        installerRemoveDirectory($root);
+    }
+});
+
+test('README documents the Claude Code subagents section with usage examples', function (): void {
+    $packageDir = dirname(__DIR__);
+    $readme = (string) file_get_contents($packageDir . '/README.md');
+
+    expect($readme)->toContain('## Claude Code Subagents');
+    expect($readme)->toContain('.claude/agents/');
+    expect($readme)->toContain('@agent-php-code-reviewer');
+    expect($readme)->toContain('@agent-issue-resolver');
+    expect($readme)->toContain('@agent-test-engineer');
+    expect($readme)->toContain('@agent-security-reviewer');
+    expect($readme)->toContain('@agent-laravel-architect');
+    expect($readme)->toContain('@agent-mysql-performance-reviewer');
+    expect($readme)->toContain('@agent-refactoring-specialist');
 });


### PR DESCRIPTION
## Summary

Adds **Claude Code subagents** as a thin orchestration layer over the existing skills, per #546:

- new `agents/` directory ships 7 subagent definitions: `php-code-reviewer`, `issue-resolver`, `test-engineer`, `security-reviewer`, `laravel-architect`, `mysql-performance-reviewer`, `refactoring-specialist`
- each agent uses valid YAML frontmatter (`name` / `description` / `tools` / `model`) and **delegates** to the relevant existing skill(s) instead of duplicating their prompts
- installer copies `agents/` → `.claude/agents/` for `--editor=claude` and `--editor=all`; **not** for `--editor=cursor` / `--editor=codex`
- `--prune` removes orphan agents alongside orphan skills / rules
- README documents the layer, including a **slash-command ↔ agent mapping** so the existing `/resolve-issue → /code-review-github → /process-code-review → /merge-github-pr` workflow keeps working unchanged

## Workflow continuity

Agents are entry-points to the **same** skills, so quality and output stay identical:

| Slash command (skill) | Equivalent subagent entry-point |
| --- | --- |
| `/resolve-issue <link>` | `@agent-issue-resolver resolve <link>` |
| `/code-review-github <link>` | `@agent-php-code-reviewer review <link>` |
| `/security-review` | `@agent-security-reviewer review the current diff` |
| `/create-test` / `/create-missing-tests-in-pr` | `@agent-test-engineer add missing tests for <link>` |

Slash commands remain the canonical path; agents are useful when Claude Code should pick the right skill itself or chain several skills under a single specialist role.

## Code review summary

Inline `@skills/code-review/SKILL.md` run produced:

- **Critical** ×1 — `Installer::install` refactor introduced two private helpers with 5 parameters (`@rules/php/core-standards.mdc` Structure section requires ≤ 4). Resolved in the same branch by decomposing into `collectSyncPayloads(root, editor)` (2 params) + `runAllSyncs(payloads, force, symlink, prune)` (4 params) and dropping the unused wrapper.
- **Moderate** ×0, **Minor** ×0 after the fix.

Pre-existing helpers `syncDirectories`, `processFiles`, `shouldProcessFile` already use 5 parameters but are out of scope (signatures untouched).

## Security review summary

Inline `@skills/security-review/SKILL.md` run: **clean**, no findings.

Walked surfaces: Input & Injection (no SQL / shell / deserialization), AuthN / AuthZ (N/A — CLI installer), Data Exposure (no new user-facing strings on the install path), External Interaction (no outbound calls), File Handling (target derived from validated `--editor` allowlist + trusted `findProjectRoot()`), Dependencies & Configuration (no new Composer requires), Queues & Background Jobs (N/A).

## Closes

Closes #546

## Test plan

- [ ] `composer build` passes (lint + Rector + PHPStan + Pest, 100% coverage on changed files)
- [ ] `vendor/bin/cursor-rules install --editor=claude` writes the 7 agents under `.claude/agents/`
- [ ] `vendor/bin/cursor-rules install --editor=all` writes the same 7 agents under `.claude/agents/` (and skills / rules to every supported editor target)
- [ ] `vendor/bin/cursor-rules install --editor=cursor` does **not** create `.claude/agents/` or `.cursor/agents/`
- [ ] `vendor/bin/cursor-rules install --editor=codex` does **not** create `.claude/agents/` or `.codex/agents/`
- [ ] `vendor/bin/cursor-rules install --editor=claude --prune` removes a locally created `.claude/agents/legacy-agent.md` stub
- [ ] Existing `/resolve-issue`, `/code-review-github`, `/process-code-review`, `/merge-github-pr` workflow still runs without behaviour change (agents are additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)