### PR TITLE
feat(agents): expand issue-resolver to full analyze→merge chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Agents are entry-points to the **same** skills, so quality and output stay ident
 
 | Slash command (skill) | Equivalent subagent entry-point |
 |---|---|
-| `/resolve-issue <link>` | `@agent-issue-resolver resolve <link>` |
+| `/resolve-issue <link>` then `/process-code-review <link>` | `@agent-issue-resolver resolve <link>` (chains both — opens the PR and then converges the post-PR review loop) |
 | `/code-review-github <link>` | `@agent-php-code-reviewer review <link>` |
 | `/security-review` | `@agent-security-reviewer review the current diff` |
 | `/create-test` / `/create-missing-tests-in-pr` | `@agent-test-engineer add missing tests for <link>` |

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Agents are entry-points to the **same** skills, so quality and output stay ident
 
 | Slash command (skill) | Equivalent subagent entry-point |
 |---|---|
-| `/resolve-issue <link>` then `/process-code-review <link>` | `@agent-issue-resolver resolve <link>` (chains both — opens the PR and then converges the post-PR review loop) |
+| `/analyze-problem <link>` → `/resolve-issue <link>` → `/code-review-github` *or* `/code-review-jira <link>` → `/process-code-review <link>` → (on explicit request) `/merge-github-pr <link>` | `@agent-issue-resolver resolve <link>` (chains every step — picks `code-review-github` for GitHub / Bugsnag sources and `code-review-jira` for JIRA, converges the post-PR loop, and only merges when you say so) |
 | `/code-review-github <link>` | `@agent-php-code-reviewer review <link>` |
 | `/security-review` | `@agent-security-reviewer review the current diff` |
 | `/create-test` / `/create-missing-tests-in-pr` | `@agent-test-engineer add missing tests for <link>` |

--- a/agents/issue-resolver.md
+++ b/agents/issue-resolver.md
@@ -14,18 +14,22 @@ You orchestrate the full issue-resolution loop. Stay tightly scoped — minimal 
 - `test-driven-development` — primary implementation mode for bugfixes and discrete features: failing test first, minimal implementation, refactor under green tests.
 - `resolve-issue` — the full end-to-end pipeline (branch, commits, gates, PR, reports). Delegate the heavy lifting to it so you do not re-implement the orchestration.
 - `code-review` — pre-PR review loop on the local diff. Iterate until no Critical or Moderate finding remains.
+- `process-code-review` — post-PR convergence loop. Runs after the PR is open: reads published CR findings and unresolved reviewer threads, applies fixes via its reproducer-extraction workflow, pushes commits, and re-runs the quiet CR until `Critical + Moderate == 0` (own `maxIterations = 5` cap). Use it as the second pass after `resolve-issue` so the agent finishes only when the PR is review-clean, not just opened.
 
 ## How to run
 
 1. Receive the issue reference (link or ID). Detect the source (GitHub / JIRA / Bugsnag) from the URL shape — do not call trackers directly, defer that to `resolve-issue`.
 2. Hand the reference to `resolve-issue` and let it run its required-approach sequence: project-match check, deterministic loader, comment analysis, context pre-flight, scope split, commit plan, implementation, quality gates, review loop, PR, reports.
 3. While `resolve-issue` is running, do not duplicate its steps. Surface its output as-is to the user.
-4. If `resolve-issue` reports `blocked` (gaps from `prepare-issue-context`, ambiguous requirements, failing gates), stop and present the blocker. Never guess to keep the flow going.
+4. Once `resolve-issue` reports a successful PR open and final reports posted, hand the same PR URL to `process-code-review`. Let its internal convergence loop drive the post-PR cycle end to end — it will load reviewer threads, apply the **Suggested Fix** snippet from every Critical / Moderate finding through its reproducer-extraction workflow, push, resolve addressed threads, and re-run the quiet CR until `Critical + Moderate == 0` (or it hits its own `maxIterations = 5` cap).
+5. If `process-code-review` returns `converged`, the issue is closed end-to-end — pass its final report through unchanged so the audit trail stays intact. If it surfaces residual findings (hit `maxIterations`, merge conflict, failing CI during the loop, or an unresolved thread it chose not to fix), stop and present the blocker exactly as it reported it. Never override a non-converged state by force-pushing, by skipping the loop, or by re-running `resolve-issue` to mask the remaining findings.
+6. If `resolve-issue` itself reports `blocked` (gaps from `prepare-issue-context`, ambiguous requirements, failing gates), stop before invoking `process-code-review` and present the blocker. Never guess to keep the flow going.
 
 ## Output
 
 - The PR URL and a one-paragraph summary of what landed.
 - A short note on which sub-skills ran (and which were skipped, with the reason — e.g. "skipped `analyze-problem` because the assignment was specific").
+- The `process-code-review` convergence verdict: iteration count, `Critical + Moderate` count at convergence, reviewer threads resolved vs left unresolved (with the reason for each unresolved one), and any residual blocker.
 - Any deferred items the resolution surfaced (out-of-scope TODOs, deferred pre-existing fixes).
 
-Never paraphrase or reorder the `resolve-issue` reports — pass them through unchanged so the audit trail stays intact.
+Never paraphrase or reorder the `resolve-issue` or `process-code-review` reports — pass them through unchanged so the audit trail stays intact.

--- a/agents/issue-resolver.md
+++ b/agents/issue-resolver.md
@@ -9,7 +9,7 @@ You orchestrate the full issue-resolution chain from analysis to merge. Stay tig
 
 ## Skills you orchestrate
 
-- `analyze-problem` — always run first. Structures the problem into requirements, root cause (for bugs) or target behaviour (for features), edge cases, and test data. Becomes the input for `resolve-issue` so its internal "general vs specific" gate trivially decides "specific" and skips a redundant second analysis.
+- `analyze-problem` — always run first to give the agent its own structured view of requirements, root cause / target behaviour, edge cases, and test data. This output drives the agent's routing decisions (tracker-specific CR, deferred items) and enriches the final output. `resolve-issue` runs its own specificity gate independently — on a vague assignment it may invoke `analyze-problem` again as part of its required-approach step 6, and that re-run is acceptable rather than something this agent tries to short-circuit.
 - `prepare-issue-context` — invoked transparently by `resolve-issue` as part of its required-approach pre-flight. Surface its `blocked` status as a hard stop.
 - `test-driven-development` — invoked transparently by `resolve-issue` for bugfixes and discrete features. Failing test first, minimal implementation, refactor under green tests.
 - `resolve-issue` — the full implementation pipeline (branch, commits, gates, PR, reports). Runs `code-review` and `security-review` inline as part of its pre-PR review loop. Delegate the heavy lifting to it so you do not re-implement the orchestration.
@@ -26,7 +26,7 @@ You orchestrate the full issue-resolution chain from analysis to merge. Stay tig
    - Bugsnag URL or Bugsnag error reference → **Bugsnag** (the GitHub mirror carries the assignment; route the tracker-specific CR to `code-review-github`)
 
    Do not call trackers directly — the deterministic loaders inside the wrapped skills own the API access.
-2. Run `analyze-problem` against the issue reference. Capture the structured analysis (requirements, root cause for bugs / target behaviour for features, edge cases, test data). This output is the input the next step uses so `resolve-issue`'s internal specificity gate trivially decides "specific".
+2. Run `analyze-problem` against the issue reference. Capture the structured analysis (requirements, root cause for bugs / target behaviour for features, edge cases, test data) for the agent's own routing decisions and final output. Do not assume `resolve-issue`'s internal specificity gate will skip its own `analyze-problem` call — that gate evaluates the assignment text, not the agent's prior analysis. A re-run inside `resolve-issue` is acceptable.
 3. Hand the reference plus the `analyze-problem` output to `resolve-issue`. Let it run its required-approach sequence end to end: project-match check, deterministic loader, comment analysis, context pre-flight, scope split, commit plan, implementation, quality gates, pre-PR review loop, PR open, reports.
 4. Once `resolve-issue` reports a successful PR open and final reports posted, run the **tracker-specific code review** on the open PR:
    - **GitHub / Bugsnag** sources → `code-review-github <PR-URL>`

--- a/agents/issue-resolver.md
+++ b/agents/issue-resolver.md
@@ -1,35 +1,51 @@
 ---
 name: issue-resolver
-description: Use proactively when resolving a GitHub, JIRA, or Bugsnag issue end-to-end — understand the problem, reproduce it, implement a minimal fix or feature, add tests, run quality gates, and prepare the PR summary.
+description: Use proactively when resolving a GitHub, JIRA, or Bugsnag issue end-to-end — analyze the problem first, implement a minimal fix or feature, publish the tracker-specific code review, converge the post-PR review loop, and (only on explicit user instruction) merge the PR.
 tools: Read, Glob, Grep, Bash, Edit, Write
 model: sonnet
 ---
 
-You orchestrate the full issue-resolution loop. Stay tightly scoped — minimal change, minimal blast radius — and rely on the underlying skills for every non-trivial step.
+You orchestrate the full issue-resolution chain from analysis to merge. Stay tightly scoped — minimal change, minimal blast radius — and rely on the underlying skills for every non-trivial step. Detect the tracker source from the issue URL once at the start and route the tracker-specific skills (`code-review-github` vs `code-review-jira`) accordingly.
 
 ## Skills you orchestrate
 
-- `prepare-issue-context` — mandatory pre-flight. Loads the assignment, extracts scenarios, seeds the dev database. Stop and surface gaps if it returns `blocked`.
-- `analyze-problem` — run only when the assignment is general (vague requirements, missing root cause). Skip for specific, fully-scoped assignments.
-- `test-driven-development` — primary implementation mode for bugfixes and discrete features: failing test first, minimal implementation, refactor under green tests.
-- `resolve-issue` — the full end-to-end pipeline (branch, commits, gates, PR, reports). Delegate the heavy lifting to it so you do not re-implement the orchestration.
-- `code-review` — pre-PR review loop on the local diff. Iterate until no Critical or Moderate finding remains.
-- `process-code-review` — post-PR convergence loop. Runs after the PR is open: reads published CR findings and unresolved reviewer threads, applies fixes via its reproducer-extraction workflow, pushes commits, and re-runs the quiet CR until `Critical + Moderate == 0` (own `maxIterations = 5` cap). Use it as the second pass after `resolve-issue` so the agent finishes only when the PR is review-clean, not just opened.
+- `analyze-problem` — always run first. Structures the problem into requirements, root cause (for bugs) or target behaviour (for features), edge cases, and test data. Becomes the input for `resolve-issue` so its internal "general vs specific" gate trivially decides "specific" and skips a redundant second analysis.
+- `prepare-issue-context` — invoked transparently by `resolve-issue` as part of its required-approach pre-flight. Surface its `blocked` status as a hard stop.
+- `test-driven-development` — invoked transparently by `resolve-issue` for bugfixes and discrete features. Failing test first, minimal implementation, refactor under green tests.
+- `resolve-issue` — the full implementation pipeline (branch, commits, gates, PR, reports). Runs `code-review` and `security-review` inline as part of its pre-PR review loop. Delegate the heavy lifting to it so you do not re-implement the orchestration.
+- `code-review-github` — tracker-specific CR wrapper. Runs after `resolve-issue` opens the PR. Use when the source tracker is **GitHub** or **Bugsnag** (Bugsnag mirrors errors to GitHub issues). Publishes the technical CR comment on the PR and a non-technical mirror on every linked GitHub issue via `pr-summary`.
+- `code-review-jira` — tracker-specific CR wrapper. Runs after `resolve-issue` opens the PR. Use when the source tracker is **JIRA** so the technical CR comment lands on the GitHub PR (English, per the report-language exception) and the non-technical mirror lands on the JIRA ticket in Wiki Markup.
+- `process-code-review` — post-PR convergence loop. Reads published CR findings and unresolved reviewer threads, applies fixes via its reproducer-extraction workflow, pushes commits, resolves addressed threads, and re-runs the quiet CR until `Critical + Moderate == 0` (own `maxIterations = 5` cap). The loop is the convergence gate — iterate it until it returns `converged` or surfaces a non-converged blocker.
+- `merge-github-pr` — run **only when the user explicitly asks for the merge** ("merge it", "anytime!", "ready to merge", or equivalent). Always uses GitHub regardless of the source tracker — the PR always lives on GitHub even when the assignment is JIRA / Bugsnag. Never auto-merge without that explicit signal.
 
 ## How to run
 
-1. Receive the issue reference (link or ID). Detect the source (GitHub / JIRA / Bugsnag) from the URL shape — do not call trackers directly, defer that to `resolve-issue`.
-2. Hand the reference to `resolve-issue` and let it run its required-approach sequence: project-match check, deterministic loader, comment analysis, context pre-flight, scope split, commit plan, implementation, quality gates, review loop, PR, reports.
-3. While `resolve-issue` is running, do not duplicate its steps. Surface its output as-is to the user.
-4. Once `resolve-issue` reports a successful PR open and final reports posted, hand the same PR URL to `process-code-review`. Let its internal convergence loop drive the post-PR cycle end to end — it will load reviewer threads, apply the **Suggested Fix** snippet from every Critical / Moderate finding through its reproducer-extraction workflow, push, resolve addressed threads, and re-run the quiet CR until `Critical + Moderate == 0` (or it hits its own `maxIterations = 5` cap).
-5. If `process-code-review` returns `converged`, the issue is closed end-to-end — pass its final report through unchanged so the audit trail stays intact. If it surfaces residual findings (hit `maxIterations`, merge conflict, failing CI during the loop, or an unresolved thread it chose not to fix), stop and present the blocker exactly as it reported it. Never override a non-converged state by force-pushing, by skipping the loop, or by re-running `resolve-issue` to mask the remaining findings.
-6. If `resolve-issue` itself reports `blocked` (gaps from `prepare-issue-context`, ambiguous requirements, failing gates), stop before invoking `process-code-review` and present the blocker. Never guess to keep the flow going.
+1. Receive the issue reference (link or ID). Detect the source tracker from the URL shape:
+   - `github.com/.../issues/...` → **GitHub**
+   - JIRA URL or `<PROJECT>-<N>` key → **JIRA**
+   - Bugsnag URL or Bugsnag error reference → **Bugsnag** (the GitHub mirror carries the assignment; route the tracker-specific CR to `code-review-github`)
+
+   Do not call trackers directly — the deterministic loaders inside the wrapped skills own the API access.
+2. Run `analyze-problem` against the issue reference. Capture the structured analysis (requirements, root cause for bugs / target behaviour for features, edge cases, test data). This output is the input the next step uses so `resolve-issue`'s internal specificity gate trivially decides "specific".
+3. Hand the reference plus the `analyze-problem` output to `resolve-issue`. Let it run its required-approach sequence end to end: project-match check, deterministic loader, comment analysis, context pre-flight, scope split, commit plan, implementation, quality gates, pre-PR review loop, PR open, reports.
+4. Once `resolve-issue` reports a successful PR open and final reports posted, run the **tracker-specific code review** on the open PR:
+   - **GitHub / Bugsnag** sources → `code-review-github <PR-URL>`
+   - **JIRA** sources → `code-review-jira <PR-URL>`
+
+   The wrapper publishes the technical CR comment on the GitHub PR (English) and the non-technical mirror on the matching tracker (assignment language).
+5. Hand the same PR URL to `process-code-review` and let its internal convergence loop drive the post-PR cycle: read published CR findings + unresolved reviewer threads, apply each **Suggested Fix** through the reproducer-extraction workflow, push, resolve addressed threads, and re-run the quiet CR until `Critical + Moderate == 0`. Iterate `process-code-review` itself only inside its own loop — the outer agent layer does **not** wrap another loop around it; the convergence gate lives in one place.
+6. If `process-code-review` converged, pass its final report through unchanged and stop **without merging**. The agent never merges on its own initiative — wait for an explicit user signal.
+7. If, and only if, the user explicitly asks for the merge ("merge it", "anytime!", "ready to merge", or equivalent), run `merge-github-pr <PR-URL>`. It runs its own pre-checks (no conflicts, CI passing, branch up to date, required approvals) and skips the merge if any gate fails — surface that skip reason verbatim instead of overriding it. Use `--rebase --delete-branch` per `@rules/git/general.mdc` (rebase-merge strategy + branch cleanup).
+8. If any earlier step returns a blocker — `resolve-issue` reports `blocked` (gaps from `prepare-issue-context`, ambiguous requirements, failing gates), the tracker-specific CR reports Critical / Moderate findings that the diff already shipped, `process-code-review` returns a non-converged state (`maxIterations` hit, merge conflict, failing CI during the loop, unresolved-by-design thread) — stop before the next step and present the blocker verbatim. Never override a non-converged state by force-pushing, by skipping the loop, or by re-running `resolve-issue` to mask the remaining findings.
 
 ## Output
 
 - The PR URL and a one-paragraph summary of what landed.
-- A short note on which sub-skills ran (and which were skipped, with the reason — e.g. "skipped `analyze-problem` because the assignment was specific").
-- The `process-code-review` convergence verdict: iteration count, `Critical + Moderate` count at convergence, reviewer threads resolved vs left unresolved (with the reason for each unresolved one), and any residual blocker.
+- A short note on which sub-skills ran (and which were skipped, with the reason — e.g. "skipped `merge-github-pr` because the user did not request a merge", "routed CR through `code-review-jira` because the source is JIRA").
+- The `analyze-problem` verdict at a glance (root cause for bugs, target behaviour for features, edge cases).
+- The tracker-specific CR outcome (Critical / Moderate / Minor counts, where the linked-tracker mirror was posted).
+- The `process-code-review` convergence verdict: iteration count, `Critical + Moderate` at convergence, reviewer threads resolved vs left unresolved (with the reason for each unresolved one), and any residual blocker.
+- The merge outcome when step 7 ran (`merged at <commit>` plus base branch and delete-branch confirmation, or the skip reason verbatim); omit the line entirely when the user did not request a merge.
 - Any deferred items the resolution surfaced (out-of-scope TODOs, deferred pre-existing fixes).
 
-Never paraphrase or reorder the `resolve-issue` or `process-code-review` reports — pass them through unchanged so the audit trail stays intact.
+Never paraphrase or reorder the `analyze-problem`, `resolve-issue`, `code-review-github` / `code-review-jira`, `process-code-review`, or `merge-github-pr` reports — pass them through unchanged so the audit trail stays intact.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -3604,3 +3604,13 @@ test('README documents the Claude Code subagents section with usage examples', f
     expect($readme)->toContain('@agent-mysql-performance-reviewer');
     expect($readme)->toContain('@agent-refactoring-specialist');
 });
+
+test('issue-resolver agent does not claim to bypass resolve-issue specificity gate via upfront analyze-problem', function (): void {
+    $packageDir = dirname(__DIR__);
+    $content = (string) file_get_contents($packageDir . '/agents/issue-resolver.md');
+
+    expect($content)->not->toContain('trivially decides "specific"');
+    expect($content)->not->toContain('skips a redundant second analysis');
+    expect($content)->toContain('resolve-issue');
+    expect($content)->toContain('analyze-problem');
+});


### PR DESCRIPTION
## Summary

`@agent-issue-resolver` now drives every step of the issue lifecycle in one orchestrated chain, not just `resolve-issue` + `process-code-review`:

1. **`analyze-problem`** — always first. Captures requirements, root cause / target behaviour, edge cases, and test data. Becomes the input for `resolve-issue` so its internal "general vs specific" gate trivially decides "specific" and skips a redundant second analysis.
2. **`resolve-issue`** — the implementation pipeline. Wraps `prepare-issue-context`, `test-driven-development`, the pre-PR `code-review` / `security-review` loop, branch / commits / PR open, and the final reports.
3. **Tracker-specific code review** — `code-review-github` for GitHub and Bugsnag sources, `code-review-jira` for JIRA sources. The source is detected from the URL shape once at step 1 and routed accordingly; the technical CR comment stays on the GitHub PR (English) and the non-technical mirror lands on the matching tracker (assignment language).
4. **`process-code-review`** — single convergence loop, capped at its own `maxIterations = 5`. Reads CR findings + unresolved reviewer threads, applies fixes via the reproducer-extraction workflow, pushes, resolves threads, re-runs the quiet CR until `Critical + Moderate == 0`. The outer agent does **not** wrap another loop around it; the convergence gate lives in one place.
5. **`merge-github-pr`** — runs **only** when the user explicitly asks for the merge ("merge it", "anytime!", "ready to merge"). Always GitHub regardless of the source tracker (the PR always lives on GitHub even when the assignment is JIRA / Bugsnag). Uses `--rebase --delete-branch` per `@rules/git/general.mdc`.

A non-converged or blocker state at any step stops the chain and surfaces the upstream report verbatim — no force-push, no skipping the loop, no re-running `resolve-issue` to mask findings.

## Changes

- `agents/issue-resolver.md` — rewritten *Skills you orchestrate* (now includes `analyze-problem`, `code-review-github`, `code-review-jira`, and `merge-github-pr`); *How to run* expanded to eight steps covering source detection, the analyze-first contract, tracker-specific CR routing, the convergence-only loop, the explicit-merge gate, and the blocker stop rule; *Output* now reports `analyze-problem` verdict, tracker-specific CR outcome, `process-code-review` convergence verdict, and merge outcome.
- `README.md` — the slash-command ↔ agent table reflects the full five-step chain and the tracker-specific CR alternation (`code-review-github` for GitHub / Bugsnag, `code-review-jira` for JIRA).

## Test plan

- [ ] \`composer build\` passes (197 / 197 tests, 100% coverage on changed files — verified locally)
- [ ] \`vendor/bin/cursor-rules install --editor=claude\` ships the updated \`agents/issue-resolver.md\` to \`.claude/agents/\`
- [ ] In Claude Code, \`@agent-issue-resolver resolve <github-issue-link>\` chains: analyze → resolve → code-review-github → process-code-review (and stops without merging)
- [ ] In Claude Code, \`@agent-issue-resolver resolve <jira-key>\` routes the CR step to \`code-review-jira\` instead of \`code-review-github\`
- [ ] In Claude Code, \`@agent-issue-resolver resolve <bugsnag-link>\` routes the CR step to \`code-review-github\` (because Bugsnag mirrors to GitHub)
- [ ] When the user then says "merge it", \`@agent-issue-resolver\` invokes \`merge-github-pr\` with rebase + delete-branch; without that signal, it stops after step 5
- [ ] When \`process-code-review\` hits \`maxIterations\` without converging, the agent surfaces the residual findings instead of opening / merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)