### PR TITLE
docs(testing): add flaky-test prevention guidance to shared testing rule

### DIFF
--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -25,7 +25,7 @@ A flaky test fails inconsistently, is hard to reproduce, and is often "fixed" by
 - **Make factory data deterministic.** Do not let random factory values decide the outcome. Explicitly set every attribute the assertion depends on (for example the user's role) instead of trusting factory defaults or random states.
 - **Test queues and async jobs deterministically.** Never wait for an asynchronous job to finish before asserting. Either assert the dispatch with `Bus::fake()` / `Queue::fake()`, or force `QUEUE_CONNECTION=sync` in the test environment so jobs run inline.
 - **Keep shared resources parallel-safe.** Parallel runs do not create flakiness — they expose existing shared state: Redis keys, files, temp directories, config cache, static properties, and singletons. Isolate per test with `Storage::fake()`, unique keys / file names, and by avoiding mutable static or singleton state.
-- **Never call external services directly.** Real HTTP requests fail on network issues, rate limits, latency, or sandbox outages. Fake every outbound call with `Http::fake()` (and the relevant SDK fakes); tests must not hit the network or perform DNS lookups.
+- **Never call external services directly.** Real HTTP requests fail on network issues, rate limits, latency, or sandbox outages — fake every outbound call with `Http::fake()` (and the relevant SDK fakes). See the *External Calls* section below for the full no-network / no-DNS contract.
 - **Guarantee order independence.** A test must pass on its own, repeatedly, and in any order. If a test passes only because another test ran before it, fix the hidden dependency — do not rely on suite ordering.
 
 ## Data Handling

--- a/rules/code-testing/general.mdc
+++ b/rules/code-testing/general.mdc
@@ -17,6 +17,17 @@ globs: []
 - Prefer local variables; avoid shared mutable state.
 - In Laravel Pest projects, define `uses(Tests\TestCase::class)` in `tests/Pest.php` instead of repeating it in every test file.
 
+## Flaky Test Prevention
+A flaky test fails inconsistently, is hard to reproduce, and is often "fixed" by simply re-running the pipeline. Flaky tests destroy trust in CI — once a team learns to re-run instead of investigate, it starts ignoring real failures too. Every new or modified test must be deterministic: it must pass repeatedly, in isolation, and in any order. Apply the following:
+
+- **Freeze time; never assert on the wall clock.** Tests that read `now()`, `time()`, `sleep()`, or the ambient timezone fail depending on environment speed and clock drift. Pin time with `Carbon::setTestNow(...)` (or `travelTo()`) and always restore it afterwards — `Carbon::setTestNow()` / `travelBack()` in `afterEach`.
+- **Isolate database state.** A test must never rely on rows created by another test. Assertions such as `assertDatabaseCount('posts', 1)` start failing the moment another test seeds the same table. Isolate with `RefreshDatabase` (or `DatabaseTransactions`) and create exactly the rows the test under assertion needs.
+- **Make factory data deterministic.** Do not let random factory values decide the outcome. Explicitly set every attribute the assertion depends on (for example the user's role) instead of trusting factory defaults or random states.
+- **Test queues and async jobs deterministically.** Never wait for an asynchronous job to finish before asserting. Either assert the dispatch with `Bus::fake()` / `Queue::fake()`, or force `QUEUE_CONNECTION=sync` in the test environment so jobs run inline.
+- **Keep shared resources parallel-safe.** Parallel runs do not create flakiness — they expose existing shared state: Redis keys, files, temp directories, config cache, static properties, and singletons. Isolate per test with `Storage::fake()`, unique keys / file names, and by avoiding mutable static or singleton state.
+- **Never call external services directly.** Real HTTP requests fail on network issues, rate limits, latency, or sandbox outages. Fake every outbound call with `Http::fake()` (and the relevant SDK fakes); tests must not hit the network or perform DNS lookups.
+- **Guarantee order independence.** A test must pass on its own, repeatedly, and in any order. If a test passes only because another test ran before it, fix the hidden dependency — do not rely on suite ordering.
+
 ## Data Handling
 - For Laravel:
     - Use `Model::factory()` for persisted data.


### PR DESCRIPTION
## Summary

Resolves #553. The issue asks that all skills dealing with application testing carry guidance to prevent the creation of flaky tests.

All four test-authoring skills — `create-test`, `create-missing-tests-in-pr`, `test-driven-development`, `rewrite-tests-pest` — already declare `Apply @rules/code-testing/general.mdc`, which is explicitly the *"Shared testing conventions for skills that generate or modify tests."* The DRY, single-source change is therefore to add the guidance to that canonical rule rather than duplicating the same prose into four skill files (which would drift over time and violate the repo's Simplicity / Surgical conventions).

A new **Flaky Test Prevention** section was added to `rules/code-testing/general.mdc` covering every point from the issue:

| Issue point | Where covered |
|---|---|
| 1. Flaky tests destroy CI trust | Section intro |
| 2. Time-dependent tests (`now()`/`sleep()`/timezone) | *Freeze time* — `Carbon::setTestNow()` + cleanup in `afterEach` |
| 3. Shared DB state (`assertDatabaseCount`) | *Isolate database state* — `RefreshDatabase` / `DatabaseTransactions` |
| 4. Random factories | *Make factory data deterministic* — explicit attributes (e.g. role) |
| 5. Queue / async jobs | *Test queues deterministically* — `Bus::fake()` / `QUEUE_CONNECTION=sync` |
| 6. Parallel testing reveals shared state | *Keep shared resources parallel-safe* — `Storage::fake()`, unique names |
| 7. External API calls | *Never call external services* — `Http::fake()`, no network/DNS |
| 8. Order independence | *Guarantee order independence* |

## Testing instructions

- `composer build` passes end-to-end (skill-check 100/100, normalize, phpcs, pint, rector, phpstan, security-audit, 198 tests at 100% coverage).
- Open `rules/code-testing/general.mdc` and confirm the new **Flaky Test Prevention** section sits between *Testing Rules* and *Data Handling*.
- Confirm each of the four test-authoring skills still references `@rules/code-testing/general.mdc` (unchanged), so the guidance is inherited.

## Notes

- No PHP/code surface, no user-facing strings, and no security surface are touched — the change is a single markdown rule file. The code-review and security-review passes had nothing actionable to flag; the new section was verified consistent with the existing rule style and non-contradictory with the existing `Jobs` / `External Calls` sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)