### PR TITLE
feat: compound engineering — easier-future-work rule, per-project compound memory, and a plan-first analyze-problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Rules included in this package:
 | File                          | Description                                                | Scope    |
 |-------------------------------|------------------------------------------------------------|----------|
 | `php/core-standards.mdc`      | Project context, AI behavior, and unified PHP/Laravel coding standards | Always   |
+| `compound-engineering/general.mdc` | Compound engineering — make future work easier and build durable per-project compound memory | Always   |
 | `git/general.mdc`             | Unified git workflow, commits, and pull request rules       | Always   |
 | `code-review/general.mdc`     | Code review conventions and output rules                   | Always   |
 | `code-testing/general.mdc`    | Testing conventions and quality standards                  | Always   |

--- a/rules/compound-engineering/general.mdc
+++ b/rules/compound-engineering/general.mdc
@@ -1,0 +1,33 @@
+---
+description: Compound engineering — every change must make future work easier, and every mistake, insight, or decision becomes durable per-project memory the next agent can reuse.
+alwaysApply: true
+globs: ["*"]
+---
+
+## Compound Engineering
+
+Compound engineering is **not** "let the AI write the code". It is a system where AI agents plan, implement, and review the work, while the human directs the direction, decides on quality, and curates what was learned so the next task is easier. Every loop is supposed to compound: each feature, fix, and review should lower the cost of the next change, never raise it.
+
+- **Every change must make future work easier, not harder.** A change that adds hidden coupling, ships an undocumented decision, or introduces a new abstraction where an existing part of the system already fit is a defect to correct — not something to ship and move on from.
+- **Every mistake, insight, or decision worth more than this one task gets written down** where the next agent *and* the next human will find it. Knowledge that lives only in someone's head, a chat thread, or a closed PR does not compound.
+- The human stays in the loop on direction and quality; the agents do the planning, implementing, and reviewing against that direction.
+
+## Compound Memory (per project)
+
+Turn one-off lessons into reusable rules by maintaining a **per-project memory**. This memory is project-specific by definition — it lives **in the project being worked on, never in this shared rules package**. A lesson learned on one project does not become a global rule shipped to every project; it stays in that project's own memory.
+
+- **Where to store it (use what the project already has, in this order):** the project's `CLAUDE.md`, `.cursor/rules/project.mdc`, or a dedicated learnings / decision-log file (e.g. `docs/decisions/`). The installer never overwrites `CLAUDE.md` or `.cursor/rules/project.mdc`, so they are safe, durable homes for accumulated memory.
+- **When to record an entry:** whenever a review comment, a bug, or a design decision reveals a lesson that will recur. The canonical trigger: it is discovered that a certain *kind* of change belongs in an **existing part of the system rather than in a new abstraction** — capture that as a rule or a worked example so the next agent reaches for the existing part first instead of re-deriving (or re-mistaking) it.
+- **What each entry contains:** the situation that triggered it, the rule or decision, and a short concrete example. Keep entries short and greppable — prefer one rule per lesson over a long essay.
+- **Review comments and post-mortems are inputs to this memory, not throwaway chat.** When a code-review finding or a human correction generalizes beyond the current PR, promote it into the per-project memory so it stops recurring. That is how mistakes and review comments become the team's collective memory.
+
+## What Not To Do
+
+- Do not let a durable lesson live only in a commit message or a closed PR thread — promote the reusable part into the project's memory file.
+- Do not write a project-specific lesson into this shared rules package as a new global rule. Per-project lessons stay in the project's own memory; only genuinely universal standards belong here.
+- Do not record secrets, credentials, or PII in the memory file.
+
+## Code Review Application
+
+- Treat a change that makes future work harder — new abstraction where an existing part fit, undocumented non-obvious decision, hidden coupling — as a finding, with the concrete existing part it should have used.
+- When the same code-review finding recurs across PRs, require it to be promoted into the project's compound memory so the next agent does not repeat it.

--- a/skills/analyze-problem/SKILL.md
+++ b/skills/analyze-problem/SKILL.md
@@ -22,6 +22,7 @@ Focus on:
 
 ## Constraints
 - Apply @rules/php/core-standards.mdc
+- Apply @rules/compound-engineering/general.mdc — the pre-implementation research and the plan artifact below exist so the analysis compounds: it grounds the work in what already exists and leaves a reusable plan behind.
 - Never modify code
 - Output Markdown only
 - Use one language only
@@ -57,6 +58,30 @@ Apply these 10 steps in order. Each step feeds the next — never jump ahead to 
 8. **Alternatives rejected** — competing solutions considered and why they were not chosen.
 9. **Verification plan** — manual checks, automated tests, edge cases, and regression checks.
 10. **Non-technical summary** — plain-language explanation for PM, support, or business stakeholders.
+
+---
+
+## Pre-Implementation Research & Plan
+
+Before proposing or implementing anything, do the research that grounds the analysis in what already exists — then leave a reusable plan behind. This runs after the Analysis Framework settles the root cause and feeds the **Recommended Solution** (step 7) and **Implementation Outline** (step 8).
+
+### Research (do all three before planning)
+
+1. **Codebase** — read the actual files, layers, and conventions the change will touch. Find the existing part of the system the work belongs to; per `@rules/compound-engineering/general.mdc`, reach for an existing home before inventing a new abstraction.
+2. **Commit history** — walk `git log` / `git blame` for the affected area to learn how it evolved, which past changes touched it, and which approaches were already tried or reverted. Past decisions are context you must not re-derive blindly.
+3. **Internet best practices (when relevant)** — for an unfamiliar pattern, library, protocol, or security-sensitive surface, consult current authoritative references. Cite every source you rely on; skip this step for routine, well-understood changes.
+
+### Plan artifact (the deliverable)
+
+Capture the result as a **written plan** — a text file in the repo (e.g. under `docs/plans/` or alongside the issue) **or** a GitHub issue — not only inline prose. The plan must contain exactly these five parts:
+
+- **Goal** — the outcome in one or two sentences: what will be true when this is done.
+- **Architecture** — where the change lives in the existing system (files, layers, the existing part it extends), and why that home over a new abstraction.
+- **Implementation steps** — concrete, ordered, independently reviewable steps a following agent can execute without re-deriving the analysis.
+- **Sources** — links to the codebase locations, commits, and any external references the plan relies on.
+- **Success criteria** — observable, verifiable conditions (tests, behavior, metrics) that prove the work is complete and correct.
+
+State where the plan artifact was written (file path or issue URL) in the analysis output so the next agent can pick it up. A durable plan that the next agent reuses is the compounding payoff — see `@rules/compound-engineering/general.mdc`.
 
 ---
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -3719,3 +3719,29 @@ test('code-generation skills enforce a Read, Map & Verify pre-flight before impl
         expect($content)->toContain('Only after Read, Map, and Verify are complete');
     }
 });
+
+test('compound-engineering rule codifies easier-future-work and per-project compound memory (issue #564)', function (): void {
+    $packageDir = dirname(__DIR__);
+    $rulePath = $packageDir . '/rules/compound-engineering/general.mdc';
+
+    expect(is_file($rulePath))->toBeTrue();
+
+    $content = (string) file_get_contents($rulePath);
+
+    // Frontmatter: always-applied cross-cutting rule.
+    expect($content)->toContain('alwaysApply: true');
+
+    // Pillar 1 — every change must make future work easier, and lessons are recorded.
+    expect($content)->toContain('## Compound Engineering');
+    expect($content)->toContain('make future work easier');
+
+    // Pillar 2 — per-project compound memory, stored in the project, not this package.
+    expect($content)->toContain('## Compound Memory (per project)');
+    expect($content)->toContain('in the project being worked on, never in this shared rules package');
+    expect($content)->toContain('existing part of the system rather than in a new abstraction');
+    expect($content)->toContain('collective memory');
+
+    // The rule is listed in the README Rules Overview table.
+    $readme = (string) file_get_contents($packageDir . '/README.md');
+    expect($readme)->toContain('`compound-engineering/general.mdc`');
+});

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -3745,3 +3745,27 @@ test('compound-engineering rule codifies easier-future-work and per-project comp
     $readme = (string) file_get_contents($packageDir . '/README.md');
     expect($readme)->toContain('`compound-engineering/general.mdc`');
 });
+
+test('analyze-problem skill requires pre-implementation research and a plan artifact (issue #564)', function (): void {
+    $packageDir = dirname(__DIR__);
+    $content = (string) file_get_contents($packageDir . '/skills/analyze-problem/SKILL.md');
+
+    expect($content)->toContain('@rules/compound-engineering/general.mdc');
+    expect($content)->toContain('## Pre-Implementation Research & Plan');
+
+    // The three research inputs.
+    expect($content)->toContain('**Codebase**');
+    expect($content)->toContain('**Commit history**');
+    expect($content)->toContain('**Internet best practices');
+
+    // The plan artifact is a text file or a GitHub issue.
+    expect($content)->toContain('text file in the repo');
+    expect($content)->toContain('GitHub issue');
+
+    // The five mandatory parts of the plan.
+    expect($content)->toContain('**Goal**');
+    expect($content)->toContain('**Architecture**');
+    expect($content)->toContain('**Implementation steps**');
+    expect($content)->toContain('**Sources**');
+    expect($content)->toContain('**Success criteria**');
+});


### PR DESCRIPTION
Resolves #564.

## Summary

Implements the three compound-engineering asks from the issue as durable, distributable rules and skill content (this repo ships `rules/` and `skills/`; both are mirrored into consuming projects by the installer).

1. **New rule `rules/compound-engineering/general.mdc`** (`alwaysApply: true`) — codifies the operating model: every change must make future work *easier, not harder*, and every mistake / insight / decision worth more than one task gets written down for the next agent and human.
2. **Compound memory, per project** — the same rule defines compound memory as a *per-project* mechanism: lessons (canonically "this kind of change belongs in an existing part of the system, not a new abstraction") are recorded in the project's own `CLAUDE.md` / `.cursor/rules/project.mdc` (which the installer never overwrites), turning review comments and mistakes into the team's collective memory — never into a global rule in this shared package.
3. **`analyze-problem` skill — research-and-plan-first** — before proposing a solution the skill now mandates a research pass (codebase, commit history, and internet best practices when relevant) and a written **plan artifact** (a text file in the repo or a GitHub issue) carrying **Goal · Architecture · Implementation steps · Sources · Success criteria**.

## Files

- `rules/compound-engineering/general.mdc` — new rule (auto-distributed; the installer mirrors `rules/` recursively, no registry change needed).
- `skills/analyze-problem/SKILL.md` — new `## Pre-Implementation Research & Plan` section + constraint reference.
- `README.md` — Rules Overview row for the new rule.
- `tests/InstallerTest.php` — two contract tests locking the rule content + the skill additions.

## Testing

- `composer build` passes — **211 tests, 0 errors** (the one warning is a pre-existing deprecated Rector rule, unrelated).

## Technical report

- **Code review (inline, pre-PR):** Critical 0 · Moderate 0 · Minor 0. Diff is markdown rule/skill content plus two Pest tests; tests are deterministic, Pest-style, no `covers()`, descriptions match assertions. Non-Laravel project, so the architecture/API/DB walks do not apply.
- **Security review (inline, pre-PR):** 0 findings. No application code, no user-facing strings, no shell/network/DB surface; the rule explicitly forbids recording secrets/PII in the memory file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)