### PR TITLE
fix(code-review-jira): align upsert-comment.sh with current acli build

### DIFF
--- a/skills/code-review-jira/scripts/upsert-comment.sh
+++ b/skills/code-review-jira/scripts/upsert-comment.sh
@@ -21,9 +21,8 @@
 #               runs instead of stacking on top of the CR comment.
 #
 # Behavior:
-#   1. Detect the actor identity via `acli jira me --json` (account id),
-#      falling back to a slug of the display name when the account id is not
-#      available.
+#   1. Detect the actor identity from `acli jira auth status` (the
+#      authenticated account email), normalised to a slug.
 #   2. Append a hidden marker `{anchor:<MARKER_KEY>-actor-<slug>}` to the body
 #      (only when the body does not already carry the marker). The marker is
 #      placed at the **bottom** of the body so the JIRA UI keeps the comment's
@@ -33,10 +32,10 @@
 #      grep-able in the raw body returned by the REST API.
 #   3. List the issue comments and find the most recent one carrying the same
 #      marker — that is the actor's prior comment in this namespace.
-#   4. If found, edit it (`acli jira workitem comment edit`). Otherwise add a
-#      fresh one (`acli jira workitem comment add`).
+#   4. If found, edit it (`acli jira workitem comment update`). Otherwise add a
+#      fresh one (`acli jira workitem comment create`).
 #
-# When acli is unavailable or the comment-edit command is missing in the
+# When acli is unavailable or the `comment update` command is missing in the
 # installed acli build, the script exits with code 4 so the calling skill can
 # fall back to the JIRA MCP server (`editJiraIssue` / `addCommentToJiraIssue`).
 #
@@ -114,15 +113,18 @@ if [[ -z "$BODY" ]]; then
   exit 1
 fi
 
-ACTOR_JSON="$(acli jira me --json 2>/dev/null || true)"
-ACTOR_ID=""
-if [[ -n "$ACTOR_JSON" ]]; then
-  ACTOR_ID="$(printf '%s' "$ACTOR_JSON" | jq -r '.accountId // .emailAddress // .name // .displayName // empty' 2>/dev/null || true)"
-fi
+# Resolve the actor identity and site from `acli jira auth status`. The
+# installed acli build prints them as human-readable lines:
+#   ✓ Authenticated
+#     Site: your-org.atlassian.net
+#     Email: someone@example.com
+AUTH_STATUS="$(acli jira auth status 2>/dev/null || true)"
+ACTOR_ID="$(printf '%s' "$AUTH_STATUS" | awk -F': *' 'tolower($0) ~ /email:/ { gsub(/[[:space:]]+$/, "", $2); print $2; exit }')"
 if [[ -z "$ACTOR_ID" ]]; then
-  echo "upsert-comment.sh: failed to resolve current JIRA actor — is acli authenticated?" >&2
+  echo "upsert-comment.sh: failed to resolve current JIRA actor — is acli authenticated? (run: acli jira auth status)" >&2
   exit 3
 fi
+SITE="$(printf '%s' "$AUTH_STATUS" | awk -F': *' 'tolower($0) ~ /site:/ { gsub(/[[:space:]]+$/, "", $2); print $2; exit }')"
 
 # Normalise to an anchor-safe slug (lowercase alnum + dashes).
 ACTOR_SLUG="$(printf '%s' "$ACTOR_ID" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed -E 's#-+#-#g; s#^-|-$##g')"
@@ -138,38 +140,58 @@ if ! grep -Fq "$MARKER" <<<"$BODY"; then
 ${MARKER}"
 fi
 
-COMMENTS_JSON="$(acli jira workitem view "$KEY" --fields comment --json 2>/dev/null || true)"
+# `comment list --json --paginate` emits one JSON object per page, each with a
+# `.comments` array; `jq -s` slurps the pages into a single list. Comment
+# bodies come back as Atlassian Document Format (ADF) objects, so the marker is
+# matched against the stringified body rather than a raw string.
+list_comments() {
+  acli jira workitem comment list --key "$KEY" --json --paginate 2>/dev/null \
+    | jq -s '{ comments: ([ .[].comments // [] ] | add // []) }' 2>/dev/null || true
+}
+
+find_marked_id() {
+  printf '%s' "$1" \
+    | jq -r --arg marker "$MARKER" '
+        (.comments // [])
+        | map(select((.body | tostring) | contains($marker)))
+        | sort_by(.updated // .created)
+        | last
+        | (.id // empty)
+      ' 2>/dev/null || true
+}
+
+COMMENTS_JSON="$(list_comments)"
 if [[ -z "$COMMENTS_JSON" ]]; then
   echo "upsert-comment.sh: failed to list comments on $KEY" >&2
   exit 3
 fi
 
-EXISTING_ID="$(printf '%s' "$COMMENTS_JSON" \
-  | jq -r --arg marker "$MARKER" '
-      ((.fields.comment.comments // .comments // []) // [])
-      | map(select((.body // "") | contains($marker)))
-      | sort_by(.updated // .created)
-      | last
-      | (.id // empty)
-    ' 2>/dev/null || true)"
+EXISTING_ID="$(find_marked_id "$COMMENTS_JSON")"
+
+# acli reads the comment body from a file (no stdin flag in the current build).
+BODY_FILE_TMP="$(mktemp)"
+trap 'rm -f "$BODY_FILE_TMP"' EXIT
+printf '%s' "$BODY" > "$BODY_FILE_TMP"
 
 if [[ -n "$EXISTING_ID" ]]; then
-  if ! acli jira workitem comment edit --help 2>/dev/null | grep -qiE 'edit|update'; then
-    echo "upsert-comment.sh: installed acli build does not support comment edit — fall back to MCP" >&2
+  if ! acli jira workitem comment update --help >/dev/null 2>&1; then
+    echo "upsert-comment.sh: installed acli build does not support 'comment update' — fall back to MCP" >&2
     exit 4
   fi
-  if ! printf '%s' "$BODY" | acli jira workitem comment edit "$KEY" --id "$EXISTING_ID" --body-stdin >/dev/null 2>&1; then
-    echo "upsert-comment.sh: acli edit failed for comment $EXISTING_ID on $KEY" >&2
+  if ! acli jira workitem comment update --key "$KEY" --id "$EXISTING_ID" --body-file "$BODY_FILE_TMP" >/dev/null 2>&1; then
+    echo "upsert-comment.sh: acli comment update failed for comment $EXISTING_ID on $KEY" >&2
     exit 3
   fi
-  echo "https://$(acli jira config get --json 2>/dev/null | jq -r '.site // .baseUrl // empty')/browse/${KEY}?focusedCommentId=${EXISTING_ID}"
+  echo "https://${SITE}/browse/${KEY}?focusedCommentId=${EXISTING_ID}"
   echo "action=updated id=${EXISTING_ID}" >&2
 else
-  if ! NEW_RESPONSE="$(printf '%s' "$BODY" | acli jira workitem comment add "$KEY" --body-stdin --json 2>/dev/null)"; then
-    echo "upsert-comment.sh: acli add failed on $KEY" >&2
+  if ! acli jira workitem comment create --key "$KEY" --body-file "$BODY_FILE_TMP" --json >/dev/null 2>&1; then
+    echo "upsert-comment.sh: acli comment create failed on $KEY" >&2
     exit 3
   fi
-  NEW_ID="$(printf '%s' "$NEW_RESPONSE" | jq -r '.id // empty')"
-  echo "https://$(acli jira config get --json 2>/dev/null | jq -r '.site // .baseUrl // empty')/browse/${KEY}?focusedCommentId=${NEW_ID}"
+  # The `create --json` shape varies across acli builds, so re-list and match
+  # the just-written marker to resolve the new comment id deterministically.
+  NEW_ID="$(find_marked_id "$(list_comments)")"
+  echo "https://${SITE}/browse/${KEY}?focusedCommentId=${NEW_ID}"
   echo "action=created id=${NEW_ID}" >&2
 fi

--- a/skills/code-review-jira/scripts/upsert-comment.sh
+++ b/skills/code-review-jira/scripts/upsert-comment.sh
@@ -144,9 +144,16 @@ fi
 # `.comments` array; `jq -s` slurps the pages into a single list. Comment
 # bodies come back as Atlassian Document Format (ADF) objects, so the marker is
 # matched against the stringified body rather than a raw string.
+#
+# The acli call and the jq transform are kept separate so a failed list call
+# (non-zero acli exit) returns 1 instead of being silently flattened to
+# `{"comments":[]}` by jq -s — that distinction is what lets the caller exit 3
+# rather than mistake an API failure for an empty comment set and post a
+# duplicate comment.
 list_comments() {
-  acli jira workitem comment list --key "$KEY" --json --paginate 2>/dev/null \
-    | jq -s '{ comments: ([ .[].comments // [] ] | add // []) }' 2>/dev/null || true
+  local raw
+  raw="$(acli jira workitem comment list --key "$KEY" --json --paginate 2>/dev/null)" || return 1
+  printf '%s' "$raw" | jq -s '{ comments: ([ .[].comments // [] ] | add // []) }' 2>/dev/null
 }
 
 find_marked_id() {
@@ -160,8 +167,7 @@ find_marked_id() {
       ' 2>/dev/null || true
 }
 
-COMMENTS_JSON="$(list_comments)"
-if [[ -z "$COMMENTS_JSON" ]]; then
+if ! COMMENTS_JSON="$(list_comments)"; then
   echo "upsert-comment.sh: failed to list comments on $KEY" >&2
   exit 3
 fi
@@ -192,6 +198,12 @@ else
   # The `create --json` shape varies across acli builds, so re-list and match
   # the just-written marker to resolve the new comment id deterministically.
   NEW_ID="$(find_marked_id "$(list_comments)")"
-  echo "https://${SITE}/browse/${KEY}?focusedCommentId=${NEW_ID}"
+  # The comment is already created; only drop the deep-link fragment when the
+  # re-list could not resolve the id, so stdout stays a valid issue URL.
+  if [[ -n "$NEW_ID" ]]; then
+    echo "https://${SITE}/browse/${KEY}?focusedCommentId=${NEW_ID}"
+  else
+    echo "https://${SITE}/browse/${KEY}"
+  fi
   echo "action=created id=${NEW_ID}" >&2
 fi

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1527,6 +1527,12 @@ test('CR skills publish through the publish helper — GitHub always-new, JIRA s
     expect($jiraScriptBody)->not->toContain('acli jira workitem comment add');
     expect($jiraScriptBody)->not->toContain('acli jira config get');
     expect($jiraScriptBody)->toContain('acli jira workitem comment list --key "$KEY" --json --paginate');
+    // Issue #569 CR: a failed `comment list` call must exit 3, not be flattened
+    // to `{"comments":[]}` by `jq -s` (which would skip the upsert lookup and
+    // post a duplicate comment). The acli exit status is captured separately so
+    // failure returns 1, and the caller turns that into exit 3.
+    expect($jiraScriptBody)->toContain('raw="$(acli jira workitem comment list --key "$KEY" --json --paginate 2>/dev/null)" || return 1');
+    expect($jiraScriptBody)->toContain('if ! COMMENTS_JSON="$(list_comments)"; then');
     expect($jiraScriptBody)->toMatch('/if ! grep -Fq "\$MARKER" <<<"\$BODY"; then\s+BODY="\$\{BODY\}\s+\$\{MARKER\}"/');
 
     $github = (string) file_get_contents($packageDir . '/skills/code-review-github/SKILL.md');

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -1515,9 +1515,18 @@ test('CR skills publish through the publish helper — GitHub always-new, JIRA s
     $jiraScriptBody = (string) file_get_contents($jiraScript);
     expect($jiraScriptBody)->toContain('MARKER_KEY="${3:-cr-comment}"');
     expect($jiraScriptBody)->toContain('{anchor:${MARKER_KEY}-actor-${ACTOR_SLUG}}');
-    expect($jiraScriptBody)->toContain('acli jira me --json');
-    expect($jiraScriptBody)->toContain('acli jira workitem comment edit');
-    expect($jiraScriptBody)->toContain('acli jira workitem comment add');
+    // Issue #569: the helper was written against an acli build that no longer
+    // matches the installed one. Actor/site come from `acli jira auth status`
+    // (no `acli jira me --json`), and comments are upserted via the current
+    // `comment create` / `comment update` subcommands (not `add` / `edit`).
+    expect($jiraScriptBody)->toContain('acli jira auth status');
+    expect($jiraScriptBody)->not->toContain('acli jira me --json');
+    expect($jiraScriptBody)->toContain('acli jira workitem comment update');
+    expect($jiraScriptBody)->toContain('acli jira workitem comment create');
+    expect($jiraScriptBody)->not->toContain('acli jira workitem comment edit');
+    expect($jiraScriptBody)->not->toContain('acli jira workitem comment add');
+    expect($jiraScriptBody)->not->toContain('acli jira config get');
+    expect($jiraScriptBody)->toContain('acli jira workitem comment list --key "$KEY" --json --paginate');
     expect($jiraScriptBody)->toMatch('/if ! grep -Fq "\$MARKER" <<<"\$BODY"; then\s+BODY="\$\{BODY\}\s+\$\{MARKER\}"/');
 
     $github = (string) file_get_contents($packageDir . '/skills/code-review-github/SKILL.md');


### PR DESCRIPTION
## Proč

Helper `skills/code-review-jira/scripts/upsert-comment.sh` byl psaný proti starší/jiné verzi `acli`, než jaká je nainstalovaná. Při běhu selhal už ve fázi rozpoznání aktéra (exit 3), protože:

- `acli jira me --json` v nainstalovaném buildu neexistuje (`unknown flag: --json`),
- komentářové příkazy `comment add` / `comment edit` byly přejmenovány na `comment create` / `comment update`,
- `--body-stdin` nahradil `--body-file`,
- `acli jira config get` (pro URL) neexistuje — site se čte z `acli jira auth status`.

Closes #569.

## Co se mění

`skills/code-review-jira/scripts/upsert-comment.sh`:
- **Aktér + site** se čtou z `acli jira auth status` (parsování řádků `Email:` / `Site:`) místo `acli jira me --json` a `acli jira config get`.
- **Výpis komentářů** přes `acli jira workitem comment list --key … --json --paginate` (stejně jako už používá `load-issue.sh`). Těla komentářů chodí jako ADF objekty, takže se marker hledá proti `(.body | tostring)`, ne proti syrovému stringu.
- **Upsert** používá `comment update --key … --id … --body-file` a `comment create --key … --body-file … --json`. Nové ID se po vytvoření dohledá znovuvýpisem podle markeru (tvar `create --json` se mezi buildy liší).
- Fallback `exit 4` na MCP zůstává — nově se testuje dostupnost `comment update`.

Kontrakt helperu (argumenty, marker namespace `cr-comment` / `cr-status`, exit kódy 1–4) zůstává beze změny, takže navazující skilly není třeba upravovat.

## Mimo rozsah

Reportér zmínil i druhý problém — `acli` ukládá JIRA Wiki Markup doslovně (nerenderuje `h2.`, `*…*` ani `{anchor:}`). To je širší téma formátu těla (Wiki → ADF) napříč `pr-summary` šablonami a `code-review-jira`, ne selhání tohoto helperu. Tady řeším konkrétní požadavek z issue — kompatibilitu helperu s aktuálním buildem `acli`.

## Test

- `composer build` — 211 passed, 100% coverage.
- `InstallerTest` rozšířen, aby zamknul nový command surface (přítomnost `auth status`, `comment create/update`, `comment list … --paginate`; absence `acli jira me --json`, `comment add/edit`, `config get`).
- Read-only smoke test parsování `auth status` a hledání markeru proti ADF tělu ověřen lokálně.

🤖 Generated with [Claude Code](https://claude.com/claude-code)