### PR TITLE
feat(git): hide AI co-author attribution in commits

### DIFF
--- a/rules/git/general.mdc
+++ b/rules/git/general.mdc
@@ -31,7 +31,7 @@ globs: ["*"]
 - Keep messages concise and specific.
 - Use lowercase for `type` and `scope`.
 - Do not end with a period.
-- Never include signatures or attribution (e.g. "Made with Cursor").
+- Never include signatures or attribution. This covers AI co-author trailers: no `Co-Authored-By:` lines and no "Generated with"/"Made with" notes (e.g. "Made with Cursor", "Generated with Claude Code").
 
 ### Allowed Types
 - feat: New feature

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -93,8 +93,9 @@ final class Installer
         $claudeMdSource = InstallerPath::isClaudeMdEditor($editor) ? InstallerPath::resolveClaudeMdSource() : null;
         $copied += self::installSingleFile($claudeMdSource, InstallerPath::resolveClaudeMdTarget($root));
         $permissionsAdded = InstallerClaudeSettings::applyIfRequested($allowBundledScripts, $editor);
+        $coAuthoredByDisabled = InstallerClaudeSettings::applyCoAuthoredByPreference($editor);
 
-        self::reportInstallSummary($copied, $pruned, $permissionsAdded);
+        self::reportInstallSummary($copied, $pruned, $permissionsAdded, $coAuthoredByDisabled);
 
         return 0;
     }
@@ -135,12 +136,16 @@ final class Installer
         return [$totalCopied, $totalPruned];
     }
 
-    private static function reportInstallSummary(int $copied, int $pruned, int $permissionsAdded): void
+    private static function reportInstallSummary(int $copied, int $pruned, int $permissionsAdded, bool $coAuthoredByDisabled): void
     {
         echo sprintf('Cursor rules installed (%d files, %d pruned).%s', $copied, $pruned, PHP_EOL);
 
         if ($permissionsAdded > 0) {
             echo sprintf('Allowed %d bundled-script permission(s) in ~/.claude/settings.json.%s', $permissionsAdded, PHP_EOL);
+        }
+
+        if ($coAuthoredByDisabled) {
+            echo sprintf('Disabled AI co-author attribution (includeCoAuthoredBy: false) in ~/.claude/settings.json.%s', PHP_EOL);
         }
     }
 

--- a/src/InstallerClaudeSettings.php
+++ b/src/InstallerClaudeSettings.php
@@ -51,6 +51,49 @@ final class InstallerClaudeSettings
     }
 
     /**
+     * Disables AI co-author attribution in Claude Code commits/PRs by writing
+     * `includeCoAuthoredBy: false` into the user's settings, but only for the
+     * `claude`/`all` editors and when a usable home directory is available.
+     * Returns true when the setting was newly written; false in every other case.
+     */
+    public static function applyCoAuthoredByPreference(string $editor): bool
+    {
+        if (!InstallerPath::isClaudeMdEditor($editor)) {
+            return false;
+        }
+
+        $home = InstallerPath::resolveHomeDirectoryOrNull();
+
+        if ($home === null) {
+            return false;
+        }
+
+        return self::ensureCoAuthoredByDisabled($home);
+    }
+
+    /**
+     * Sets `includeCoAuthoredBy: false` in `<home>/.claude/settings.json` idempotently.
+     * Leaves an existing value untouched so a user who opted back in keeps their choice.
+     * Returns true only when the key was absent and is now written.
+     */
+    public static function ensureCoAuthoredByDisabled(string $home): bool
+    {
+        $settingsPath = self::resolveSettingsPath($home);
+        $existing = self::readSettings($settingsPath);
+
+        if (array_key_exists('includeCoAuthoredBy', $existing)) {
+            return false;
+        }
+
+        $existing['includeCoAuthoredBy'] = false;
+
+        InstallerPath::ensureDirectory(dirname($settingsPath));
+        self::writeSettings($settingsPath, $existing);
+
+        return true;
+    }
+
+    /**
      * Reads the `permissions.allow` list from `<home>/.claude/settings.json`,
      * sanitised to strings only. Returns an empty list when the file does not
      * exist or the section is missing.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -3066,7 +3066,7 @@ test('install --editor=cursor --allow-bundled-scripts does not write settings.js
     }
 });
 
-test('install --editor=claude without --allow-bundled-scripts leaves settings.json untouched', function (): void {
+test('install --editor=claude without --allow-bundled-scripts still disables AI co-author attribution', function (): void {
     $root = installerCreateProjectRoot();
     $homeEnv = getenv('HOME');
     $homeBefore = $homeEnv !== false && $homeEnv !== '' ? $homeEnv : getenv('USERPROFILE');
@@ -3086,7 +3086,14 @@ test('install --editor=claude without --allow-bundled-scripts leaves settings.js
         $output = (string) ob_get_clean();
 
         expect($output)->not->toContain('Allowed');
-        expect(is_file($root . '/.claude/settings.json'))->toBeFalse();
+        expect($output)->toContain('Disabled AI co-author attribution (includeCoAuthoredBy: false) in ~/.claude/settings.json.');
+
+        $settingsPath = $root . '/.claude/settings.json';
+        expect(is_file($settingsPath))->toBeTrue();
+
+        $data = json_decode((string) file_get_contents($settingsPath), true, 512, JSON_THROW_ON_ERROR);
+        assert(is_array($data));
+        expect($data['includeCoAuthoredBy'])->toBeFalse();
     } finally {
         installerRestoreEnvAndCleanup($homeBefore, $originalCwd, $root);
     }
@@ -3155,6 +3162,69 @@ test('install --editor=claude --allow-bundled-scripts is idempotent across two c
     } finally {
         installerRestoreEnvAndCleanup($homeBefore, $originalCwd, $root);
     }
+});
+
+test('ensureCoAuthoredByDisabled writes includeCoAuthoredBy false into a fresh settings.json', function (): void {
+    $home = sys_get_temp_dir() . '/claude-settings-' . bin2hex(random_bytes(4));
+
+    try {
+        $written = InstallerClaudeSettings::ensureCoAuthoredByDisabled($home);
+
+        expect($written)->toBeTrue();
+
+        $settingsPath = $home . '/.claude/settings.json';
+        expect(is_file($settingsPath))->toBeTrue();
+
+        $data = json_decode((string) file_get_contents($settingsPath), true, 512, JSON_THROW_ON_ERROR);
+        assert(is_array($data));
+        expect($data['includeCoAuthoredBy'])->toBeFalse();
+    } finally {
+        installerRemoveDirectory($home);
+    }
+});
+
+test('ensureCoAuthoredByDisabled respects an existing includeCoAuthoredBy value', function (): void {
+    $home = sys_get_temp_dir() . '/claude-settings-' . bin2hex(random_bytes(4));
+    $settingsPath = $home . '/.claude/settings.json';
+    installerWriteFile($settingsPath, (string) json_encode(['includeCoAuthoredBy' => true]));
+
+    try {
+        $written = InstallerClaudeSettings::ensureCoAuthoredByDisabled($home);
+
+        expect($written)->toBeFalse();
+
+        $data = json_decode((string) file_get_contents($settingsPath), true, 512, JSON_THROW_ON_ERROR);
+        assert(is_array($data));
+        expect($data['includeCoAuthoredBy'])->toBeTrue();
+    } finally {
+        installerRemoveDirectory($home);
+    }
+});
+
+test('ensureCoAuthoredByDisabled merges into existing settings.json without dropping unrelated keys', function (): void {
+    $home = sys_get_temp_dir() . '/claude-settings-' . bin2hex(random_bytes(4));
+    $settingsPath = $home . '/.claude/settings.json';
+    installerWriteFile($settingsPath, (string) json_encode([
+        'theme' => 'dark',
+        'permissions' => ['allow' => ['Bash(git status:*)']],
+    ], JSON_PRETTY_PRINT));
+
+    try {
+        $written = InstallerClaudeSettings::ensureCoAuthoredByDisabled($home);
+
+        expect($written)->toBeTrue();
+
+        $raw = (string) file_get_contents($settingsPath);
+        expect($raw)->toContain('"theme": "dark"');
+        expect($raw)->toContain('"Bash(git status:*)"');
+        expect($raw)->toContain('"includeCoAuthoredBy": false');
+    } finally {
+        installerRemoveDirectory($home);
+    }
+});
+
+test('applyCoAuthoredByPreference skips non-claude editors', function (): void {
+    expect(InstallerClaudeSettings::applyCoAuthoredByPreference('cursor'))->toBeFalse();
 });
 
 test('dependency-selection rule gates every new Composer package on activity and compatibility', function (): void {


### PR DESCRIPTION
## Proč

Commity vytvořené AI agentem (hlavně Claude Code) ve výsledku nesmí ukazovat, že je AI spoluautorem — žádný `Co-Authored-By: Claude …` ani „Generated with Claude Code".

## Co se mění

**Git pravidlo** (`rules/git/general.mdc`)
- Řádek o zákazu attribution nově explicitně pokrývá AI co-author trailery: `Co-Authored-By:` a „Generated with"/„Made with" poznámky. Distribuuje se do všech projektů, takže každý agent řídící se pravidly to dodrží.

**Instalátor** (`src/InstallerClaudeSettings.php`, `src/Installer.php`)
- Nová metoda `ensureCoAuthoredByDisabled()` zapíše `includeCoAuthoredBy: false` do `~/.claude/settings.json` — tím se trailer vypne přímo na úrovni harnesu Claude Code (skutečné vynucení, ne jen doporučení).
- Aplikuje se při každé instalaci s `--editor=claude` nebo `--editor=all` (na rozdíl od bundled-scripts to není opt-in, protože jde o neškodnou policy preferenci a chceme záruku).
- Zápis je **idempotentní** a **respektuje existující hodnotu** — pokud si uživatel vědomě nastavil `true`, nepřepíšeme to. Ostatní klíče v `settings.json` zůstávají nedotčené.
- Instalace pro `cursor`/`codex` se nemění.

## Jak otestovat

```bash
composer build
```

- Přidány unit testy pro `ensureCoAuthoredByDisabled` (čerstvý zápis, respekt existující hodnoty, merge bez ztráty klíčů) a integrační test `--editor=claude` bez `--allow-bundled-scripts`.
- Aktualizován dřívější test, který předpokládal, že claude instalace bez flagu `settings.json` nezapisuje (chování se záměrně změnilo).
- Testy existují: **yes**. Pokrytí `InstallerClaudeSettings` 100 %, celý `composer build` zelený (231 testů).