### PR TITLE
feat(git): require one commit per phase for phased issues

### DIFF
--- a/rules/git/general.mdc
+++ b/rules/git/general.mdc
@@ -10,6 +10,7 @@ globs: ["*"]
 ## Git Rules
 - Never push directly to `main` branch. NEVER.
 - Use small, focused commits (one logical change per commit).
+- **One phase = one commit.** When the issue is complex and split into phases — explicit `Phase N` headings, numbered milestones, ordered acceptance-criteria blocks, or a step-by-step plan written by the reporter — resolve each phase as **exactly one commit** in the PR, in the original phase order. Never merge, reorder, or re-scope phases into a single commit. When no phases are marked but the work covers multiple distinct concerns, split it into independently reviewable phases the same way and map one phase per commit; keep a small atomic change as a single commit (do not invent artificial phases).
 - Use meaningful branch names, always written in English regardless of the assignment language.
 
 ## Pull Policy

--- a/skills/resolve-issue/SKILL.md
+++ b/skills/resolve-issue/SKILL.md
@@ -89,7 +89,7 @@ Only after Read, Map, and Verify are complete may phase planning and implementat
 
 ### Phase planning (commit plan)
 
-Before writing any code, decide how the in-scope work will be split into commits within the PR.
+Before writing any code, decide how the in-scope work will be split into commits within the PR, applying the **one phase = one commit** rule from `@rules/git/general.mdc` *Git Rules*.
 
 1. **Detect existing phases** in the issue description and the kept comments. Phase markers include explicit headings such as `Phase 1`, numbered milestones, ordered acceptance-criteria blocks, or a step-by-step plan written by the reporter.
 2. **If phases exist:** treat each phase as exactly **one commit**. Keep the original phase order as commit order. Do not merge, reorder, or re-scope phases.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4059,3 +4059,19 @@ test('resolve-issue skill requires the created branch name to be in English', fu
 
     expect($content)->toContain('name always in English, regardless of the assignment language');
 });
+
+test('git/general.mdc mandates one commit per phase for phased issues', function (): void {
+    $packageDir = dirname(__DIR__);
+    $content = (string) file_get_contents($packageDir . '/rules/git/general.mdc');
+
+    expect($content)->toContain('One phase = one commit.');
+    expect($content)->toContain('exactly one commit');
+});
+
+test('resolve-issue skill anchors phase planning on the one-phase-one-commit git rule', function (): void {
+    $packageDir = dirname(__DIR__);
+    $content = (string) file_get_contents($packageDir . '/skills/resolve-issue/SKILL.md');
+
+    expect($content)->toContain('one phase = one commit');
+    expect($content)->toContain('@rules/git/general.mdc');
+});


### PR DESCRIPTION
## Proč

Když je issue komplexní a rozdělené do fází, mají se fáze řešit tak, aby **jedna fáze = jeden commit** v PR. Tato logika dosud žila jen ve skillu `resolve-issue`; teď je povýšená na globální git pravidlo, takže ji dědí každý skill produkující commity.

## Co se mění

**Git pravidlo** (`rules/git/general.mdc`)
- Do sekce *Git Rules* přidán bod **„One phase = one commit"**: komplexní issue rozdělené do fází (explicitní `Phase N` nadpisy, číslované milníky, seřazené akceptační kritéria nebo krokový plán reportéra) se řeší jako **právě jeden commit na fázi**, v původním pořadí. Fáze se nikdy neslučují, nepřeskupují ani nepřeskopávají do jednoho commitu. Bez vyznačených fází, ale s více odlišnými oblastmi → rozdělit na nezávisle reviewovatelné fáze stejně; malá atomická změna zůstává jedním commitem (žádné umělé fáze).
- `alwaysApply: true`, takže pravidlo platí napříč všemi skilly.

**Skill** (`skills/resolve-issue/SKILL.md`)
- Sekce *Phase planning (commit plan)* nově ukotvuje na globální pravidlo místo jeho opakování (DRY). Detailní postup (detekce fází, pořadí, commit na konci fáze) zůstává.

## Jak otestovat

```bash
composer build
```

- Přidány testy ověřující znění pravidla v `git/general.mdc` a odkaz v `resolve-issue`.
- Testy existují: **yes**. Celý `composer build` zelený (232 testů, 100 % pokrytí změněných tříd).