### PR TITLE
feat(agents): add argus code-review subagent with installer distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,44 @@ Agent skills are installed into the chosen editor’s skill directory (see `--ed
 
 ---
 
+## Claude Code Subagents
+
+Agents are a thin orchestration layer over the existing skills — they don't replace them and they don't duplicate their prompts. The roster is named after **Greek mythology** by function (see [`docs/agents.md`](docs/agents.md)).
+
+```text
+Rules  = long-lived project standards
+Skills = reusable workflows
+Agents = specialised orchestration roles over multiple skills
+```
+
+| Agent | Role | Orchestrated skills |
+|---|---|---|
+| `argus` | All-seeing code-review gatekeeper. Reviews a PR from context or a tracker link, posts the results to the PR, and hands back a CR-done handoff. Read-only. | `code-review-github`, `code-review-jira`, `code-review-bugsnag` |
+
+### How to use `argus` in practice
+
+1. Install for Claude Code (or every editor):
+
+   ```bash
+   vendor/bin/cursor-rules install --editor=claude   # or --editor=all
+   ```
+
+   Agents land in `.claude/agents/`. They are **not** installed for `--editor=cursor` or `--editor=codex`.
+
+2. Invoke it with a **source** — a GitHub PR/issue, a JIRA key, a Bugsnag error, or just the current branch/PR:
+
+   ```text
+   @argus review PR #123
+   @argus review https://your.atlassian.net/browse/PROJ-42
+   @argus review the current diff
+   ```
+
+3. `argus` detects the tracker, runs the matching `code-review-*` skill, lets it **post the review to the PR**, then returns a handoff: `CR done` + PR link + source link + Critical/Moderate/Minor counts + assignment-conformance verdict.
+
+`argus` is **read-only** — it never applies fixes, commits, pushes, or merges. Those belong to separate agents.
+
+---
+
 ## Rules Overview
 
 Rules included in this package:

--- a/agents/argus.md
+++ b/agents/argus.md
@@ -1,0 +1,36 @@
+---
+name: argus
+description: Use when a pull request needs a code review driven from context or a tracker link (GitHub, JIRA, Bugsnag). Loads the source, runs the matching code-review wrapper skill, posts the results to the PR, and hands back a "CR done" handoff with links. Read-only — never applies fixes, commits, pushes, or merges.
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+You are **Argus** — the all-seeing code-review gatekeeper. Your single job is to run a code review and publish it. You are **read-only**: never edit the working tree, never commit, push, or merge, and never apply fixes.
+
+## Input
+
+You accept exactly one **source** for the review, in this order of preference:
+
+1. An explicit tracker reference passed by the caller — a **GitHub** PR/issue number or URL, a **JIRA** key/URL, or a **Bugsnag** error URL/triple.
+2. The **current context** — the checked-out branch or the PR the conversation is about — when no tracker reference is given.
+
+## How to run
+
+1. **Detect the source** using `@skills/resolve-issue/references/source-detection.md`. Load context only through the deterministic loaders (`skills/code-review-github/scripts/load-issue.sh`, `gather-issue-context.sh`, and the JIRA / Bugsnag equivalents) — never call `gh pr view`, `acli`, or `api.bugsnag.com` directly.
+2. **Pick the matching code-review wrapper** and run it to completion, letting it publish the results to the PR:
+   - GitHub source (or plain context / local branch) → `@skills/code-review-github/SKILL.md`
+   - JIRA source → `@skills/code-review-jira/SKILL.md`
+   - Bugsnag source → `@skills/code-review-bugsnag/SKILL.md`
+3. The wrapper owns the whole review pipeline (assignment compliance, code-review, security-review, api-review, refactoring lens, coverage gate) and the publishing contract (technical PR comment + non-technical tracker summary). **Do not re-implement any of it and do not duplicate its rules** — defer to the skills as the source of truth.
+
+## Output — handoff to the caller
+
+Your final message is returned to the caller as the result, so make it a clean handoff:
+
+- **Status:** `CR done`.
+- **PR:** link to the pull request where the review was posted.
+- **Source:** link to the originating tracker item (GitHub issue / JIRA ticket / Bugsnag error).
+- **Counts:** Critical / Moderate / Minor.
+- **Assignment conformance:** `conformant` / `N gap(s)` / `no linked issue`.
+
+Hand the next agent everything it needs to act (apply fixes, merge) without re-deriving where the review lives. Stop after the handoff — applying fixes or merging is a different agent's job.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,66 @@
+# Agents
+
+Agents are **Claude Code subagents** that act as a thin orchestration layer over the existing skills. They run in their own context window, delegate the real work to skills, and hand a clean result back to the caller.
+
+```text
+Rules  = long-lived project standards
+Skills = reusable workflows
+Agents = specialised orchestration roles over multiple skills
+```
+
+## Naming convention — Greek mythology
+
+Every agent is named after a figure from **Greek mythology**, chosen so the figure's role matches the agent's function. Use the lowercase name as the agent `name:` and file id (`agents/<name>.md`).
+
+| Agent | Greek figure | Why it fits |
+|---|---|---|
+| `argus` | Argus Panoptes, the hundred-eyed all-seeing watcher | nothing escapes his gaze → thorough PR inspection |
+
+Naming ideas for future agents: `themis` (order / verdict), `rhadamanthys` (fair judge), `athena` (wisdom / architecture), `hermes` (delivery / merge).
+
+## Anatomy of an agent
+
+An agent is a Markdown file with frontmatter + a system prompt:
+
+```markdown
+---
+name: argus
+description: When to auto-delegate to this agent (the trigger sentence).
+tools: Read, Glob, Grep, Bash
+model: sonnet
+---
+
+System prompt: what the agent does, which skills it orchestrates, and the handoff it returns.
+```
+
+- **`name`** — lowercase, the id used as `subagent_type` / `@name`.
+- **`description`** — drives auto-delegation; phrase it as the situation that should trigger the agent.
+- **`tools`** — restrict to what the agent needs. A read-only reviewer needs `Read, Glob, Grep, Bash` only.
+- **System prompt** — orchestration only. Delegate to skills via `@skills/<name>/SKILL.md`; **never duplicate a skill's rules** — defer to the skill as the source of truth.
+
+## Handoff contract
+
+An agent's final message is returned to the caller as the tool result, so it must be a self-contained handoff the next agent can act on without re-deriving context:
+
+- **Status** — e.g. `CR done`.
+- **Links** — the PR and the originating source (GitHub / JIRA / Bugsnag).
+- **Result summary** — the numbers the caller needs (e.g. Critical / Moderate / Minor counts, a verdict).
+
+## Subagents of an agent
+
+Claude Code subagents invoked via the Task tool generally **cannot spawn their own subagents** (one level of nesting). Model an agent's "subagents" two ways:
+
+1. **Lens skills called inline** by an orchestrating skill — e.g. `code-review-github` already runs `code-review`, `security-review`, `api-review`, `assignment-compliance-check` inline. This is the default and works today.
+2. **Parallel fan-out via the Workflow tool** — a DAG of agents for heavy runs that genuinely need concurrency.
+
+## Distribution
+
+The installer copies `agents/` to `.claude/agents/` for `--editor=claude` and `--editor=all` only — Claude Code is the only editor with a native subagent format, so `--editor=cursor` and `--editor=codex` skip agents.
+
+## Adding a new agent
+
+1. Pick a Greek figure whose myth matches the job; use the lowercase name.
+2. Create `agents/<name>.md` with the frontmatter + an orchestration-only system prompt that delegates to skills and returns a handoff.
+3. Add it to the README *Claude Code Subagents* table.
+4. Add a test asserting the file ships with its required frontmatter (mirror the `argus` test in `tests/InstallerTest.php`).
+5. Run `composer build` — the installer file-count tests pick up the new agent automatically.

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -115,6 +115,13 @@ final class Installer
             $payloads[] = [$skillsSource, InstallerPath::resolveSkillsTargetDirectories($root, $editor)];
         }
 
+        $agentsSource = InstallerPath::resolveAgentsSource();
+        $agentsTargets = InstallerPath::resolveAgentsTargetDirectories($root, $editor);
+
+        if ($agentsSource !== null && $agentsTargets !== []) {
+            $payloads[] = [$agentsSource, $agentsTargets];
+        }
+
         return $payloads;
     }
 

--- a/src/InstallerPath.php
+++ b/src/InstallerPath.php
@@ -110,6 +110,44 @@ final class InstallerPath
         return is_file($source) ? $source : null;
     }
 
+    public static function resolveAgentsSource(): ?string
+    {
+        $packageSource = self::getPackageDirectory() . '/agents';
+
+        if (is_dir($packageSource)) {
+            return $packageSource;
+        }
+
+        // @codeCoverageIgnoreStart
+        return null;
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Agent target directories for the given editor.
+     * Claude Code subagents only install for editor=claude or editor=all.
+     *
+     * @return array<int, string>
+     */
+    public static function resolveAgentsTargetDirectories(string $root, string $editor): array
+    {
+        if (!self::isAgentsEditor($editor)) {
+            return [];
+        }
+
+        return [$root . '/.claude/agents'];
+    }
+
+    /**
+     * Whether Claude Code subagents should be installed for the given editor.
+     */
+    public static function isAgentsEditor(string $editor): bool
+    {
+        $editor = strtolower($editor);
+
+        return $editor === self::EDITOR_CLAUDE || $editor === self::EDITOR_ALL;
+    }
+
     /**
      * Target path for CLAUDE.md in the project root.
      */

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -407,9 +407,12 @@ test('install with editor=all copies all files to all rule and skill directories
 
     $rulesTargets = InstallerPath::resolveRulesTargetDirectories($root, InstallerPath::EDITOR_ALL);
     $skillTargets = InstallerPath::resolveSkillsTargetDirectories($root, InstallerPath::EDITOR_ALL);
+    $agentTargets = InstallerPath::resolveAgentsTargetDirectories($root, InstallerPath::EDITOR_ALL);
+    $expectedAgentsCount = installerCountFiles($packageDir . '/agents');
     $claudeMdCount = InstallerPath::resolveClaudeMdSource() !== null ? 1 : 0;
     $expectedTotalFiles = $expectedRulesCount * count($rulesTargets)
         + $expectedSkillsCount * count($skillTargets)
+        + $expectedAgentsCount * count($agentTargets)
         + $claudeMdCount;
     $cwd = getcwd();
     $originalCwd = $cwd !== false ? $cwd : '';
@@ -430,6 +433,11 @@ test('install with editor=all copies all files to all rule and skill directories
         foreach ($skillTargets as $skillsTarget) {
             $actualSkillsCount = installerCountFiles($skillsTarget);
             expect($actualSkillsCount)->toBe($expectedSkillsCount, 'Skills: all source files in ' . $skillsTarget);
+        }
+
+        foreach ($agentTargets as $agentsTarget) {
+            $actualAgentsCount = installerCountFiles($agentsTarget);
+            expect($actualAgentsCount)->toBe($expectedAgentsCount, 'Agents: all source files in ' . $agentsTarget);
         }
 
         expect($output)->toContain(sprintf('(%d files,', $expectedTotalFiles));
@@ -3987,19 +3995,103 @@ test('duplicate and unsupported ECC skills were intentionally not ported', funct
     expect(is_dir($packageDir . '/skills/test-driven-development'))->toBeTrue();
 });
 
-test('bundled Claude Code subagents feature is fully removed from package and installer', function (): void {
+test('agents directory ships the argus code-review subagent with required frontmatter', function (): void {
+    $packageDir = dirname(__DIR__);
+    $agentPath = $packageDir . '/agents/argus.md';
+
+    expect(is_file($agentPath))->toBeTrue();
+
+    $content = (string) file_get_contents($agentPath);
+    expect($content)->toContain('name: argus');
+    expect($content)->toContain('tools: Read, Glob, Grep, Bash');
+    expect($content)->toContain('@skills/code-review-github/SKILL.md');
+    expect($content)->toContain('@skills/code-review-jira/SKILL.md');
+    expect($content)->toContain('@skills/code-review-bugsnag/SKILL.md');
+    expect($content)->toContain('@skills/resolve-issue/references/source-detection.md');
+});
+
+test('resolveAgentsSource returns the package agents directory when it exists', function (): void {
     $packageDir = dirname(__DIR__);
 
-    expect(is_dir($packageDir . '/agents'))->toBeFalse();
+    expect(InstallerPath::resolveAgentsSource())->toBe($packageDir . '/agents');
+});
 
-    $installerPath = (string) file_get_contents($packageDir . '/src/InstallerPath.php');
-    expect($installerPath)->not->toContain('resolveAgentsSource');
-    expect($installerPath)->not->toContain('resolveAgentsTargetDirectories');
-    expect($installerPath)->not->toContain('isAgentsEditor');
+test('isAgentsEditor matches only claude and all', function (): void {
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_CLAUDE))->toBeTrue();
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_ALL))->toBeTrue();
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_CURSOR))->toBeFalse();
+    expect(InstallerPath::isAgentsEditor(InstallerPath::EDITOR_CODEX))->toBeFalse();
+});
 
-    $readme = (string) file_get_contents($packageDir . '/README.md');
-    expect($readme)->not->toContain('## Claude Code Subagents');
-    expect($readme)->not->toContain('@agent-');
+test('resolveAgentsTargetDirectories returns .claude/agents for editor=claude', function (): void {
+    expect(InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_CLAUDE))
+        ->toBe(['/project/.claude/agents']);
+});
+
+test('resolveAgentsTargetDirectories returns .claude/agents for editor=all', function (): void {
+    expect(InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_ALL))
+        ->toBe(['/project/.claude/agents']);
+});
+
+test('resolveAgentsTargetDirectories returns empty list for editor=cursor', function (): void {
+    expect(InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_CURSOR))->toBe([]);
+});
+
+test('resolveAgentsTargetDirectories returns empty list for editor=codex', function (): void {
+    expect(InstallerPath::resolveAgentsTargetDirectories('/project', InstallerPath::EDITOR_CODEX))->toBe([]);
+});
+
+test('install with editor=claude copies the argus agent to .claude/agents', function (): void {
+    $root = installerCreateProjectRoot();
+    $homeEnv = getenv('HOME');
+    $homeBefore = $homeEnv !== false && $homeEnv !== '' ? $homeEnv : getenv('USERPROFILE');
+    putenv('HOME=' . $root);
+
+    if (getenv('USERPROFILE') !== false) {
+        putenv('USERPROFILE=' . $root);
+    }
+
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=claude']);
+        ob_end_clean();
+
+        expect(is_file($root . '/.claude/agents/argus.md'))->toBeTrue();
+        expect(is_dir($root . '/.cursor/agents'))->toBeFalse();
+        expect(is_dir($root . '/.codex/agents'))->toBeFalse();
+    } finally {
+        installerRestoreEnvAndCleanup($homeBefore, $originalCwd, $root);
+    }
+});
+
+test('install with editor=cursor does not copy agents', function (): void {
+    $root = installerCreateProjectRoot();
+    $homeEnv = getenv('HOME');
+    $homeBefore = $homeEnv !== false && $homeEnv !== '' ? $homeEnv : getenv('USERPROFILE');
+    putenv('HOME=' . $root);
+
+    if (getenv('USERPROFILE') !== false) {
+        putenv('USERPROFILE=' . $root);
+    }
+
+    $cwd = getcwd();
+    $originalCwd = $cwd !== false ? $cwd : '';
+
+    try {
+        chdir($root);
+        ob_start();
+        Installer::run(['cursor-rules', 'install', '--editor=cursor']);
+        ob_end_clean();
+
+        expect(is_dir($root . '/.cursor/agents'))->toBeFalse();
+        expect(is_dir($root . '/.claude/agents'))->toBeFalse();
+    } finally {
+        installerRestoreEnvAndCleanup($homeBefore, $originalCwd, $root);
+    }
 });
 
 test('code-generation skills enforce a Read, Map & Verify pre-flight before implementing', function (): void {


### PR DESCRIPTION
Closes #587

## Summary

Zavádí **vrstvu agentů** (Claude Code subagents) jako tenké orchestrátory nad existujícími skilly. První agent: **`argus`** — read-only code-review gatekeeper.

Pozn.: feature subagentů už v balíčku jednou byla (#546) a byla záměrně odstraněna (`00034c8`, zamčeno guard testem). Na základě rozhodnutí uživatele se **pravidlo o zákazu ruší** a vrstva se znovu zavádí — vychází z dříve ověřené implementace.

## Co se mění

- **`agents/argus.md`** — agent: detekuje zdroj (kontext nebo GitHub/JIRA/Bugsnag odkaz), spustí odpovídající `code-review-*` wrapper, nechá ho **zapsat výsledky k PR**, a vrátí **handoff** (`CR done` + odkazy + počty + verdikt). Read-only — neaplikuje opravy, necommituje, nemerguje.
- **Instalátor** (`InstallerPath`, `Installer`) — distribuuje `agents/ → .claude/agents/` jen pro `--editor=claude` / `--editor=all` (Cursor/Codex agent formát nemají → přeskočí). Smazán guard test „subagents fully removed", nahrazen pokrytím nové cesty.
- **`docs/agents.md`** — konvence pojmenování (**řecká mytologie** podle funkce), anatomie agenta, handoff kontrakt, jak přidat dalšího agenta.
- **README** — sekce *Claude Code Subagents* s praktickým návodem na `argus`.

## Jak otestovat

```bash
composer build
vendor/bin/cursor-rules install --editor=claude   # → vznikne .claude/agents/argus.md
```

- `--editor=cursor` / `--editor=codex` agenta **nekopíruje**.
- Testy existují: **yes** — frontmatter agenta, editor targeting (claude/all vs cursor/codex), install kopíruje argus, `--editor=all` file-count zahrnuje agenty.
- `composer build` zelený — 242 testů, `InstallerPath`/`Installer` 100 % pokrytí, phpstan max.

## Technical report (CR + security)

- **Code review:** 0 Critical / 0 Moderate. Nové metody mají návratové typy, kryté testy, styl mirrorová existující `isClaudeMdEditor` / `resolveSkillsSource`.
- **Security review:** beze změny rizik — instalátor jen kopíruje soubory, agent prompt je read-only, žádné secrets / síťové volání / injection surface.

## TODO (mimo rozsah, do budoucna)
- Další agenti (`themis` verdikt, `hermes` merge, …) stejným vzorem.
- Lokální `.claude/agents/argus.md` se vygeneruje samo po `install --editor=claude`.