### PR TITLE
feat(agents): add talos implementer subagent; run argos on opus

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Agents = specialised orchestration roles over multiple skills
 | Agent | Role | Orchestrated skills |
 |---|---|---|
 | `argos` | All-seeing code-review gatekeeper. Reviews a PR from context or a tracker link, posts the results to the PR, and hands back a CR-done handoff. Read-only. | `code-review-github`, `code-review-jira`, `code-review-bugsnag` |
+| `talos` | Tireless code-writing implementer. Implements an issue from context or a tracker link, validates with tests, opens a PR, and hands back an Impl-done handoff. Stops at the PR — never reviews or merges. | `resolve-issue` |
 
 ### How to use `argos` in practice
 
@@ -234,6 +235,22 @@ Agents = specialised orchestration roles over multiple skills
 3. `argos` detects the tracker, runs the matching `code-review-*` skill, lets it **post the review to the PR**, then returns a handoff: `CR done` + PR link + source link + Critical/Moderate/Minor counts + assignment-conformance verdict.
 
 `argos` is **read-only** — it never applies fixes, commits, pushes, or merges. Those belong to separate agents.
+
+### How to use `talos` in practice
+
+1. Install for Claude Code (or every editor), exactly as for `argos` — agents land in `.claude/agents/` and are skipped for `--editor=cursor` / `--editor=codex`.
+
+2. Invoke it with a **source** — a GitHub issue/PR, a JIRA key, a Bugsnag error, or just the task you want implemented:
+
+   ```text
+   @talos implement #123
+   @talos implement https://your.atlassian.net/browse/PROJ-42
+   @talos implement the failing upload validation
+   ```
+
+3. `talos` detects the source, runs `resolve-issue` to implement the change with tests and open a PR, then returns a handoff: `Impl done` + PR link + source link + branch + a summary of what changed and the test result.
+
+`talos` **stops at the PR** — it never reviews its own work or merges. Hand the PR to `argos` for review next.
 
 ---
 

--- a/agents/argos.md
+++ b/agents/argos.md
@@ -2,7 +2,7 @@
 name: argos
 description: Use when a pull request needs a code review driven from context or a tracker link (GitHub, JIRA, Bugsnag). Loads the source, runs the matching code-review wrapper skill, posts the results to the PR, and hands back a "CR done" handoff with links. Read-only — never applies fixes, commits, pushes, or merges.
 tools: Read, Glob, Grep, Bash
-model: sonnet
+model: opus
 ---
 
 You are **Argos** — the all-seeing code-review gatekeeper. Your single job is to run a code review and publish it. You are **read-only**: never edit the working tree, never commit, push, or merge, and never apply fixes.

--- a/agents/talos.md
+++ b/agents/talos.md
@@ -1,0 +1,32 @@
+---
+name: talos
+description: Use when a tracker issue or a described task needs to be implemented as a safe fix or feature — a GitHub issue/PR number or URL, a JIRA key/URL, a Bugsnag error, or the current task context. Detects the source, implements the change, validates it with tests, and opens a pull request, then hands back an "Impl done" handoff with links. Stops at the PR — never reviews its own work and never merges.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are **Talos** — the tireless bronze automaton that forges the implementation. Your single job is to turn one source into a finished, tested pull request. You **stop at the PR**: never review your own work (that is `argos`) and never merge.
+
+## Input
+
+You accept exactly one **source** for the work, in this order of preference:
+
+1. An explicit tracker reference passed by the caller — a **GitHub** issue/PR number or URL, a **JIRA** key/URL, or a **Bugsnag** error URL/triple.
+2. The **current context** — the task the conversation is about — when no tracker reference is given.
+
+## How to run
+
+1. **Detect the source** using `@skills/resolve-issue/references/source-detection.md`.
+2. **Delegate the entire implementation to `@skills/resolve-issue/SKILL.md`** and let it run to completion. That skill owns the whole pipeline — project-ownership and open/active checks, the deterministic context loaders, scope classification (bug vs feature), the Read-Map-Verify pre-flight, phase/commit planning, the implementation, the test + coverage gates, the inline code-review and security-review loops, and the pull request. **Do not re-implement any of it and do not duplicate its rules** — defer to the skill as the source of truth.
+
+## Output — handoff to the caller
+
+Your final message is returned to the caller as the result, so make it a clean handoff:
+
+- **Status:** `Impl done`.
+- **PR:** link to the pull request that was opened.
+- **Source:** link to the originating tracker item (GitHub issue / JIRA ticket / Bugsnag error).
+- **Branch:** the feature branch name.
+- **Summary:** what changed (files / scope) and the test result (tests added / passing, coverage).
+
+Hand the next agent everything it needs to review (e.g. `@argos`) without re-deriving where the work lives. Stop after the handoff — reviewing and merging are other agents' jobs.

--- a/assets/agents/talos.svg
+++ b/assets/agents/talos.svg
@@ -1,0 +1,14 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Universal agent avatar">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3b4252"/>
+      <stop offset="1" stop-color="#2e3440"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#bg)"/>
+  <!-- generic agent silhouette -->
+  <circle cx="80" cy="64" r="26" fill="#d8dee9"/>
+  <path d="M36 128c0-24 20-40 44-40s44 16 44 40v6H36z" fill="#d8dee9"/>
+  <!-- subtle ring marking it as a placeholder slot -->
+  <rect x="6" y="6" width="148" height="148" rx="28" fill="none" stroke="#4c566a" stroke-width="3" stroke-dasharray="8 8"/>
+</svg>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -20,6 +20,14 @@ The all-seeing code-review gatekeeper, named after **Argos Panoptes**, the hundr
 - **Orchestrates:** `code-review-github`, `code-review-jira`, `code-review-bugsnag`.
 - **Safety:** read-only — never edits, commits, pushes, or merges.
 
+### <img src="../assets/agents/talos.svg" alt="talos avatar" width="48" align="left"> `talos` — code-writing implementer
+
+The tireless bronze automaton, named after **Talos**, the forged guardian that worked without rest. Give it a source — a tracker link (GitHub, JIRA, Bugsnag) or the current task — and it implements the fix or feature, validates it with tests, opens a pull request, and hands back an `Impl done` summary with links. It is the write-side counterpart to `argos`: `argos` is the tireless eye (review), `talos` the tireless hands (implementation).
+
+- **Trigger:** an issue or task needs implementing.
+- **Orchestrates:** `resolve-issue`.
+- **Safety:** stops at the PR — never reviews its own work and never merges.
+
 ## Naming convention — Greek mythology
 
 Every agent is named after a figure from **Greek mythology**, chosen so the figure's role matches the agent's function. Use the lowercase name as the agent `name:` and file id (`agents/<name>.md`).
@@ -27,6 +35,7 @@ Every agent is named after a figure from **Greek mythology**, chosen so the figu
 | Agent | Greek figure | Why it fits |
 |---|---|---|
 | `argos` | Argos Panoptes, the hundred-eyed all-seeing watcher | nothing escapes his gaze → thorough PR inspection |
+| `talos` | Talos, the bronze automaton forged to work and guard without rest | tireless artificial labourer → forges working code |
 
 Naming ideas for future agents: `themis` (order / verdict), `rhadamanthys` (fair judge), `athena` (wisdom / architecture), `hermes` (delivery / merge).
 
@@ -39,7 +48,7 @@ An agent is a Markdown file with frontmatter + a system prompt:
 name: argos
 description: When to auto-delegate to this agent (the trigger sentence).
 tools: Read, Glob, Grep, Bash
-model: sonnet
+model: opus
 ---
 
 System prompt: what the agent does, which skills it orchestrates, and the handoff it returns.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4010,6 +4010,19 @@ test('agents directory ships the argos code-review subagent with required frontm
     expect($content)->toContain('@skills/resolve-issue/references/source-detection.md');
 });
 
+test('agents directory ships the talos code-writing subagent with required frontmatter', function (): void {
+    $packageDir = dirname(__DIR__);
+    $agentPath = $packageDir . '/agents/talos.md';
+
+    expect(is_file($agentPath))->toBeTrue();
+
+    $content = (string) file_get_contents($agentPath);
+    expect($content)->toContain('name: talos');
+    expect($content)->toContain('tools: Read, Write, Edit, Glob, Grep, Bash');
+    expect($content)->toContain('@skills/resolve-issue/SKILL.md');
+    expect($content)->toContain('@skills/resolve-issue/references/source-detection.md');
+});
+
 test('resolveAgentsSource returns the package agents directory when it exists', function (): void {
     $packageDir = dirname(__DIR__);
 


### PR DESCRIPTION
## Summary

Adds **`talos`**, the code-writing implementer counterpart to `argos`, resolving #589. `talos` is a thin orchestration wrapper over the existing `resolve-issue` skill — it detects a source (GitHub / JIRA / Bugsnag tracker reference or the current task), delegates the whole implementation pipeline to `resolve-issue`, and returns an `Impl done` handoff. It **stops at the PR**: review (`argos`) and merge stay separate roles. No `resolve-issue` logic is duplicated.

This completes the agent roster's implement → review → merge story: **`talos` (implement → PR) → `argos` (review) → future `hermes` (merge)**.

Per the maintainer's model choice, the two agents now run on different tiers:
- `argos` → `opus` (review)
- `talos` → `sonnet` (implementation)

## Changes

- `agents/talos.md` — new orchestration-only subagent (`tools: Read, Write, Edit, Glob, Grep, Bash`, `model: sonnet`) delegating to `@skills/resolve-issue/SKILL.md` via the shared source-detection reference.
- `agents/argos.md` — `model: sonnet` → `model: opus`.
- `assets/agents/talos.svg` — avatar slot (universal placeholder until custom artwork is supplied).
- `docs/agents.md` — roster profile for `talos`, naming-convention table row, and the anatomy example updated to `model: opus`.
- `README.md` — *Claude Code Subagents* table row + "How to use `talos` in practice" subsection.
- `tests/InstallerTest.php` — frontmatter test mirroring the `argos` one; the installer file-count tests pick up the new agent automatically.

## Testing

- `composer build` — green, **244 tests / 1348 assertions**, 100% on all checked components.
- New test `agents directory ships the talos code-writing subagent with required frontmatter` passes.
- The `install with editor=claude copies the argos agent` and agent file-count tests stay green (talos is copied for `claude`/`all`, skipped for `cursor`/`codex`).

## Notes

The diff is additive docs/Markdown, a static SVG avatar, one frontmatter line on `argos`, and a mirrored Pest test — no production PHP logic, no security surface. Inline code-review and security-review found nothing actionable (no Critical/Moderate).

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)