### PR TITLE
feat(agents): add metis problem-analysis advisor subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Agents = specialised orchestration roles over multiple skills
 |---|---|---|
 | `argos` | All-seeing code-review gatekeeper. Reviews a PR from context or a tracker link, posts the results to the PR, and hands back a CR-done handoff. Read-only. | `code-review-github`, `code-review-jira`, `code-review-bugsnag` |
 | `talos` | Tireless code-writing implementer. Implements an issue from context or a tracker link, validates with tests, opens a PR, and hands back an Impl-done handoff. Stops at the PR — never reviews or merges. | `resolve-issue` |
+| `metis` | Problem-analysis advisor. Analyses a problem or a vague assignment, proposes the smallest safe solution, and publishes a reusable plan as a GitHub issue, then hands back an Analysis-done handoff. Read-only — never implements. | `analyze-problem` |
 
 ### How to use `argos` in practice
 
@@ -251,6 +252,22 @@ Agents = specialised orchestration roles over multiple skills
 3. `talos` detects the source, runs `resolve-issue` to implement the change with tests and open a PR, then returns a handoff: `Impl done` + PR link + source link + branch + a summary of what changed and the test result.
 
 `talos` **stops at the PR** — it never reviews its own work or merges. Hand the PR to `argos` for review next.
+
+### How to use `metis` in practice
+
+1. Install for Claude Code (or every editor), exactly as for `argos` / `talos` — agents land in `.claude/agents/` and are skipped for `--editor=cursor` / `--editor=codex`.
+
+2. Invoke it with a **subject** — a GitHub issue/PR, a JIRA key, a Bugsnag error, or just a problem you want thought through:
+
+   ```text
+   @metis analyse #123
+   @metis analyse https://your.atlassian.net/browse/PROJ-42
+   @metis analyse why the nightly export job times out
+   ```
+
+3. `metis` runs `analyze-problem`, then returns a handoff: `Analysis done` + a link to the published plan-artifact issue + the subject link + a one-line root cause + the recommended solution.
+
+`metis` is **read-only** — it analyses and plans, but never edits code, commits, or implements. Hand its plan issue to `talos` to build next.
 
 ---
 

--- a/agents/metis.md
+++ b/agents/metis.md
@@ -1,0 +1,35 @@
+---
+name: metis
+description: Use when a problem needs structured analysis or an under-specified assignment needs a proposed solution before any code is written — a GitHub issue/PR number or URL, a JIRA key/URL, a Bugsnag error, a described failure, or the current task context. Runs the analyze-problem framework, proposes the smallest safe solution, and publishes a reusable plan artifact as a GitHub issue, then hands back an "Analysis done" handoff with links. Read-only — never edits, commits, pushes, or implements.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+You are **Metis** — the counsel of wise planning. Your single job is to analyse a problem or an under-specified assignment and propose a solution, then leave behind a plan the next agent can act on. You are **read-only**: never edit the working tree, never commit, push, or implement. You think and advise; `talos` implements and `argos` reviews.
+
+## Input
+
+You accept exactly one **subject** for the analysis, in this order of preference:
+
+1. An explicit tracker reference passed by the caller — a **GitHub** issue/PR number or URL, a **JIRA** key/URL, or a **Bugsnag** error URL/triple.
+2. A **described problem** or under-specified assignment stated by the caller.
+3. The **current context** — the task the conversation is about — when nothing else is given.
+
+When the subject is a tracker reference, detect and load it read-only using `@skills/resolve-issue/references/source-detection.md` and the deterministic loaders — never call `gh`, `acli`, or REST endpoints directly.
+
+## How to run
+
+1. **Delegate the entire analysis to `@skills/analyze-problem/SKILL.md`** and let it run to completion. That skill owns the whole framework — context extraction, problem statement, evidence, root-cause hypothesis, impact, the smallest safe solution, rejected alternatives, the verification plan, and the pre-implementation research. **Do not re-implement any of it and do not duplicate its rules** — defer to the skill as the source of truth.
+2. **Publish the plan artifact as a GitHub issue** (via `gh`), carrying the five mandatory parts the skill produces — Goal, Architecture, Implementation steps, Sources, Success criteria — so a following agent (`talos`) can pick it up cold. Do not write files into the repository or mutate the working tree; the plan lives on the tracker, keeping you read-only with respect to code.
+
+## Output — handoff to the caller
+
+Your final message is returned to the caller as the result, so make it a clean handoff:
+
+- **Status:** `Analysis done`.
+- **Plan:** link to the published plan-artifact issue.
+- **Subject:** link to the originating tracker item, or a one-line restatement of the analysed problem when there was no tracker.
+- **Root cause:** one line — the most probable cause (with certainty) for a bug, or the target behaviour for a feature.
+- **Recommended solution:** one line — the smallest safe solution proposed.
+
+Hand the next agent everything it needs to implement (e.g. `@talos`) without re-deriving the analysis. Stop after the handoff — implementing and reviewing are other agents' jobs.

--- a/assets/agents/metis.svg
+++ b/assets/agents/metis.svg
@@ -1,0 +1,14 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Universal agent avatar">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3b4252"/>
+      <stop offset="1" stop-color="#2e3440"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#bg)"/>
+  <!-- generic agent silhouette -->
+  <circle cx="80" cy="64" r="26" fill="#d8dee9"/>
+  <path d="M36 128c0-24 20-40 44-40s44 16 44 40v6H36z" fill="#d8dee9"/>
+  <!-- subtle ring marking it as a placeholder slot -->
+  <rect x="6" y="6" width="148" height="148" rx="28" fill="none" stroke="#4c566a" stroke-width="3" stroke-dasharray="8 8"/>
+</svg>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -28,6 +28,14 @@ The tireless bronze automaton, named after **Talos**, the forged guardian that w
 - **Orchestrates:** `resolve-issue`.
 - **Safety:** stops at the PR — never reviews its own work and never merges.
 
+### <img src="../assets/agents/metis.svg" alt="metis avatar" width="48" align="left"> `metis` — problem-analysis advisor
+
+The counsel of wise planning, named after **Metis**, the Titaness of deliberation and cunning planning (and mother of Athena). Give it a problem — a tracker link, a described failure, or an under-specified assignment — and it runs the analyze-problem framework, proposes the smallest safe solution, and publishes a reusable plan as a GitHub issue, then hands back an `Analysis done` summary. It is the thinking front-end to the roster: `metis` the mind (analysis), `talos` the hands (implementation), `argos` the eyes (review).
+
+- **Trigger:** a problem needs analysis, or a vague assignment needs a proposed solution before any code is written.
+- **Orchestrates:** `analyze-problem`.
+- **Safety:** read-only — never edits, commits, pushes, or implements; publishes its plan to the tracker.
+
 ## Naming convention — Greek mythology
 
 Every agent is named after a figure from **Greek mythology**, chosen so the figure's role matches the agent's function. Use the lowercase name as the agent `name:` and file id (`agents/<name>.md`).
@@ -36,6 +44,7 @@ Every agent is named after a figure from **Greek mythology**, chosen so the figu
 |---|---|---|
 | `argos` | Argos Panoptes, the hundred-eyed all-seeing watcher | nothing escapes his gaze → thorough PR inspection |
 | `talos` | Talos, the bronze automaton forged to work and guard without rest | tireless artificial labourer → forges working code |
+| `metis` | Metis, Titaness of wise counsel and cunning planning | deliberation before action → problem analysis & planning |
 
 Naming ideas for future agents: `themis` (order / verdict), `rhadamanthys` (fair judge), `athena` (wisdom / architecture), `hermes` (delivery / merge).
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4023,6 +4023,18 @@ test('agents directory ships the talos code-writing subagent with required front
     expect($content)->toContain('@skills/resolve-issue/references/source-detection.md');
 });
 
+test('agents directory ships the metis problem-analysis subagent with required frontmatter', function (): void {
+    $packageDir = dirname(__DIR__);
+    $agentPath = $packageDir . '/agents/metis.md';
+
+    expect(is_file($agentPath))->toBeTrue();
+
+    $content = (string) file_get_contents($agentPath);
+    expect($content)->toContain('name: metis');
+    expect($content)->toContain('tools: Read, Glob, Grep, Bash');
+    expect($content)->toContain('@skills/analyze-problem/SKILL.md');
+});
+
 test('resolveAgentsSource returns the package agents directory when it exists', function (): void {
     $packageDir = dirname(__DIR__);
 


### PR DESCRIPTION
## Summary

Adds **`metis`**, the problem-analysis advisor — the *thinking* role the agent roster was missing — resolving #591. `metis` is a thin, **read-only** orchestration wrapper over the existing `analyze-problem` skill: it analyses a problem or an under-specified assignment, proposes the smallest safe solution, and publishes a reusable plan artifact (Goal / Architecture / Implementation steps / Sources / Success criteria) as a GitHub issue, then returns an `Analysis done` handoff. It never implements or reviews. No skill logic is duplicated.

This completes the roster as a pipeline: **`metis` (analyse → plan issue) → `talos` (implement → PR) → `argos` (review)** — the mind, the hands, the eyes.

## Changes

- `agents/metis.md` — new read-only subagent (`tools: Read, Glob, Grep, Bash`, `model: opus`) delegating to `@skills/analyze-problem/SKILL.md`; publishes the plan as a GitHub issue, keeping it read-only with respect to the codebase.
- `assets/agents/metis.svg` — avatar slot (universal placeholder until custom artwork is supplied).
- `docs/agents.md` — roster profile for `metis`, naming-convention table row, and naming-ideas line.
- `README.md` — *Claude Code Subagents* table row + "How to use `metis` in practice" subsection.
- `tests/InstallerTest.php` — frontmatter test mirroring the `argos` / `talos` ones; the installer file-count tests pick up the new agent automatically.

## Testing

- `composer build` — green, 100% on all checked components; new test `agents directory ships the metis problem-analysis subagent with required frontmatter` passes.
- `metis.md` is copied for `--editor=claude` / `--editor=all`, skipped for `cursor` / `codex` (existing agent file-count + copy tests).

## Notes

The diff is additive docs/Markdown, a new agent file, a static SVG avatar, and a mirrored Pest test — no production PHP logic, no security surface. Inline code-review and security-review found nothing actionable (no Critical/Moderate).

Closes #591