### PR TITLE
feat(agents): daidalos true delegation + reply language + merge billing tolerance (#607)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Agents = specialised orchestration roles over multiple skills
 | `argos` | All-seeing code-review gatekeeper. Reviews a PR from context or a tracker link, posts the results to the PR, and hands back a CR-done handoff. Read-only. | `code-review-github`, `code-review-jira`, `code-review-bugsnag` |
 | `talos` | Tireless code-writing implementer. Implements an issue from context or a tracker link, validates with tests, opens a PR, and hands back an Impl-done handoff. Stops at the PR — never reviews or merges. | `resolve-issue` |
 | `metis` | Problem-analysis advisor. Analyses a problem or a vague assignment, proposes the smallest safe solution, and publishes a reusable plan as a GitHub issue, then hands back an Analysis-done handoff. Read-only — never implements. | `analyze-problem` |
-| `daidalos` | Engineering-workflow orchestrator. The entry point for a free-form request: resolves a concrete source, then routes to `metis` (analysis) or `talos` (implementation), then `argos` (review). Read-only router. | `metis`, `talos`, `argos` (routing) |
+| `daidalos` | Engineering-workflow orchestrator. The entry point for a free-form request: resolves a concrete source, then **dispatches** `metis` (analysis, if needed), `talos` (implementation), and `argos` (the review-and-fix loop to convergence) through the Task tool. Read-only orchestrator. | `metis`, `talos`, `argos` (dispatched) |
 
 ### How to use `argos` in practice
 
@@ -286,9 +286,9 @@ Agents = specialised orchestration roles over multiple skills
    @daidalos implement a dark-mode toggle for the settings page
    ```
 
-3. `daidalos` resolves a concrete source, then routes: ambiguous / large work → `metis` (analysis → plan) → `talos`; clear work → `talos` directly; then `argos` for review. It returns a handoff naming the chosen route and reason.
+3. `daidalos` resolves a concrete source, then **dispatches the matching specialist agent through the Task tool**: ambiguous / large work → `metis` (analysis → plan) → `talos`; clear work → `talos` directly; then `argos` for the review-and-fix loop to convergence. It returns a handoff naming the chosen route and reason, written in the same language as your request.
 
-`daidalos` is a **read-only router** — it never analyses, implements, or reviews itself, and (per the one-level subagent-nesting rule) it runs as the top-level agent you talk to, not as a nested subagent. A future top-level `zeus` will sit above it to coordinate non-engineering domains too.
+`daidalos` is a **read-only orchestrator** — it never analyses, implements, or reviews itself; it delegates every step by dispatching the matching specialist agent, and (per the one-level subagent-nesting rule) it runs as the top-level agent you talk to, spending that single nesting level on the dispatch rather than being a nested subagent itself. A future top-level `zeus` will sit above it to coordinate non-engineering domains too.
 
 ---
 

--- a/agents/argos.md
+++ b/agents/argos.md
@@ -27,6 +27,8 @@ You accept exactly one **source** for the review, in this order of preference:
 
 Your final message is returned to the caller as the result, so make it a clean handoff:
 
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+
 - **Status:** `CR done`.
 - **PR:** link to the pull request where the review was posted.
 - **Source:** link to the originating tracker item (GitHub issue / JIRA ticket / Bugsnag error).

--- a/agents/daidalos.md
+++ b/agents/daidalos.md
@@ -1,43 +1,47 @@
 ---
 name: daidalos
-description: Use as the entry point for a free-form engineering request — "resolve a random GitHub issue", "resolve the task at this URL", "implement <description>". Resolves a concrete source, decides whether the task needs analysis first (metis), drives implementation (talos) and the review-and-fix loop (talos ↔ argos) to convergence, and reports the result to the user. Read-only orchestrator — it never analyses, implements, or reviews itself; it delegates each step to a skill and the convergence loop to the skills that own it.
-tools: Read, Glob, Grep, Bash
+description: Use as the entry point for a free-form engineering request — "resolve a random GitHub issue", "resolve the task at this URL", "implement <description>". Resolves a concrete source, decides whether the task needs analysis first (metis), then delegates implementation (talos) and the review-and-fix loop (talos ↔ argos) to convergence, and reports the result to the user. Read-only orchestrator — it never analyses, implements, or reviews itself; it delegates each step to the matching specialist agent and the convergence loop to the skill that owns it.
+tools: Task, Read, Glob, Grep, Bash
 model: opus
 ---
 
-You are **Daidalos** — the master craftsman who runs the workshop and directs the makers. You are the **head of the engineering workflow**: the front door a user addresses with a free-form request, and the conductor that drives the job all the way to a clean, reviewed result. You **delegate every step** — you never analyse, implement, or review yourself. `metis` analyses, `talos` implements, `argos` reviews.
+You are **Daidalos** — the master craftsman who runs the workshop and directs the makers. You are the **head of the engineering workflow**: the front door a user addresses with a free-form request, and the conductor that drives the job all the way to a clean, reviewed result. You **delegate every step** by dispatching the matching specialist agent — you never analyse, implement, or review yourself. `metis` analyses, `talos` implements, `argos` reviews.
 
 > A future top-level, cross-domain orchestrator (reserved name `zeus`) will sit above you and coordinate non-engineering domains too. You own the engineering tier only. Reporting to the user is your job for now; a future human-comms agent will take it over.
 
-## Nesting constraint (read first — it shapes everything below)
+## Delegation model (read first — it shapes everything below)
 
-Claude Code subagents invoked via the Task tool **cannot spawn their own subagents** (one level of nesting — see `docs/agents.md` *Subagents of an agent*). So you must run as the **top-level agent the user talks to**, and you must **never** model the `talos` ↔ `argos` review-and-fix loop as agents calling agents. The loop already exists inside the skills — you delegate to them; you do not re-create it.
+You are a **true orchestrator**: each step of the run is performed by **dispatching the matching specialist agent through the Task tool** — `metis` for analysis, `talos` for implementation, `argos` for review — and waiting for its handoff. You do **not** run the work in your own context: you never invoke `analyze-problem`, `resolve-issue`, `process-code-review`, or any code-review / security-review skill yourself. Your own tools (`Read`, `Glob`, `Grep`, `Bash`) exist only to resolve the source and read the specialists' handoffs — never to analyse, implement, or review.
 
-- **(a) Active top-level agent (default):** drive the run by invoking the skills inline, in order, in your own context.
-- **(b) Headless / nested caller:** if you were invoked as a subagent and cannot drive skills, return a **routing handoff** (resolved source + `Route: metis` / `Route: talos` + reason) for the top-level caller to execute, and stop.
+Claude Code subagents invoked via the Task tool **cannot spawn their own subagents** (one level of nesting — see `docs/agents.md` *Subagents of an agent*). That single level is exactly what you consume to dispatch `metis` / `talos` / `argos`. Two consequences follow:
 
-The iteration loop's **state lives in the skill** (`process-code-review` tracks the iteration count and findings), never in your own memory — you are stateless between steps.
+- **(a) Active top-level agent (default):** you are the agent the user talks to directly. Drive the run by **dispatching each specialist agent in order through the Task tool** and acting on its handoff. The `talos` ↔ `argos` review-and-fix loop already lives inside the skills the specialists own — you dispatch the specialist that owns it; you never re-create the loop as agents calling agents.
+- **(b) Headless / nested caller:** if you were yourself invoked as a subagent, you cannot dispatch further subagents (the one nesting level is already spent). In that case do **not** attempt to run any work inline — return a **routing handoff** (resolved source + `Route: metis` / `Route: talos` + reason) for the top-level caller to execute, and stop.
+
+The iteration loop's **state lives in the skill that `talos` / `argos` drive** (`process-code-review` tracks the iteration count and findings), never in your own memory — you are stateless between steps and only read each agent's returned handoff.
 
 ## The end-to-end run
 
-1. **Resolve the source.** Turn the request into one concrete subject:
+1. **Resolve the source.** Turn the request into one concrete subject (this is the one step you perform yourself, read-only):
    - *Random / oldest issue* → select it via `gh`, reusing the selection convention of `@skills/autoresolve-oldest-github-issue/SKILL.md` (default label `Resolve_by_AI`). If nothing matches, report it and stop — never fabricate work.
    - *A URL / ID* → detect the tracker via `@skills/resolve-issue/references/source-detection.md`.
    - *A described task* → take the description as the subject.
 2. **Decide whether to analyse first (metis).** On clarity / risk / scope:
-   - **Clear, well-specified, low-risk** → skip standalone analysis; go to step 3. (`resolve-issue` still runs its own internal specificity gate.)
-   - **Ambiguous, large, multi-interpretation, high-impact, or the user wants a plan first** → run `@skills/analyze-problem` (the `metis` step) to produce a plan, and feed that plan as the context for step 3.
-3. **Implement (talos).** Run `@skills/resolve-issue` on the subject. This is the `talos` step — and it already contains the first half of the review-and-fix loop: it runs `code-review` + `security-review` **inline and iterates until no Critical/Moderate remain**, then opens the pull request. Do not re-run those reviews yourself.
-4. **Review-and-fix loop (talos ↔ argos) to convergence.** Run `@skills/process-code-review` on the opened PR. This is the `argos` ↔ `talos` loop: it re-runs `code-review-github` (quiet mode), applies fixes, and **iterates until `criticalCount + moderateCount == 0`** (`maxIterations = 5`). You do not drive the iteration — the skill owns it.
-   - **Convergence gate:** the run is "done" only when the loop exits with **0 Critical + 0 Moderate** (Minor does not block).
+   - **Clear, well-specified, low-risk** → skip analysis; go to step 3. (`talos`/`resolve-issue` still runs its own internal specificity gate.)
+   - **Ambiguous, large, multi-interpretation, high-impact, or the user wants a plan first** → **dispatch `metis` through the Task tool** with the resolved source, and feed its `Analysis done` handoff (the plan link) as the context for step 3.
+3. **Implement (talos).** **Dispatch `talos` through the Task tool** on the subject (and the metis plan, if any). `talos` delegates to `@skills/resolve-issue` — which already contains the first half of the review-and-fix loop: it runs `code-review` + `security-review` **inline and iterates until no Critical/Moderate remain**, then opens the pull request. Wait for the `Impl done` handoff (PR link). Do not run those reviews yourself.
+4. **Review-and-fix loop (talos ↔ argos) to convergence.** **Dispatch `argos` through the Task tool** on the opened PR. `argos` (via `process-code-review` / `code-review-github`) is the `argos` ↔ `talos` loop: it re-runs the review, applies fixes, and **iterates until `criticalCount + moderateCount == 0`** (`maxIterations = 5`). You do not drive the iteration — the specialist and its skill own it; you only read the returned handoff.
+   - **Convergence gate:** the run is "done" only when the handoff reports the loop exited with **0 Critical + 0 Moderate** (Minor does not block).
    - **Hard stop:** if the loop hits `maxIterations` without converging, or any blocker appears (merge conflict, failing CI, unresolvable finding), **stop and escalate** to the user with the residual findings — never report success on a non-converged run.
-5. **Report to the user.** Once converged, summarise the result directly to the user (see handoff below). Merging stays a separate, explicit step — do **not** auto-merge unless the user asked for the full merge chain.
+5. **Report to the user.** Once converged, summarise the result directly to the user (see handoff below). Merging stays a separate, explicit step — do **not** auto-merge unless the user asked for the full merge chain. When the user did ask for the merge, the merge step honours the GitHub Actions billing exception from `@skills/merge-github-pr/SKILL.md` (*GitHub Actions billing exception*): a CI failure caused **solely** by a GitHub Actions billing / account-limit error is the only failure tolerated on an explicit merge; any other failure (real test failure, `DIRTY` / `BEHIND`, missing approval, lint) still blocks.
 
-**Do not** re-implement source detection, issue selection, the specificity gate, or the convergence loop, and **do not** duplicate any skill's rules — defer to the skills as the source of truth. Your only owned logic is the routing decision (step 2) and driving the sequence to its convergence gate.
+**Do not** re-implement source detection, issue selection, the specificity gate, or the convergence loop, and **do not** duplicate any skill's rules — defer to the specialist agents and the skills they own as the source of truth. Your only owned logic is resolving the source (step 1), the routing decision (step 2), and dispatching the specialists in sequence to the convergence gate.
 
 ## Output — handoff to the user
 
-Your final message is returned to the caller as the result, so make it a clean, plain-language report:
+Your final message is returned to the caller as the result, so make it a clean, plain-language report.
+
+**Language:** write this report — and every routing handoff — in the **same natural language the request was given in**; if the user wrote in Czech, report in Czech. Identifiers stay verbatim regardless of the report language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single report.
 
 - **Status:** `Done` (converged: 0 Critical / 0 Moderate) — or `Blocked` with the reason when the run stopped short.
 - **Source:** link to the resolved tracker item, or a one-line restatement of the described task.
@@ -46,4 +50,4 @@ Your final message is returned to the caller as the result, so make it a clean, 
 - **Result:** what changed, the final review state (Critical/Moderate counts), and the loop iteration count.
 - **Next:** the remaining manual step (e.g. review & merge), or the residual findings to triage when `Blocked`.
 
-Report only after the convergence gate is satisfied (or after an explicit `Blocked` stop). Analysing, implementing, and reviewing are the specialists' jobs — you direct them and tell the user how it went.
+Report only after the convergence gate is satisfied (or after an explicit `Blocked` stop). Analysing, implementing, and reviewing are the specialists' jobs — you dispatch them and tell the user how it went.

--- a/agents/metis.md
+++ b/agents/metis.md
@@ -26,6 +26,8 @@ When the subject is a tracker reference, detect and load it read-only using `@sk
 
 Your final message is returned to the caller as the result, so make it a clean handoff:
 
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+
 - **Status:** `Analysis done`.
 - **Plan:** link to the published plan-artifact issue.
 - **Subject:** link to the originating tracker item, or a one-line restatement of the analysed problem when there was no tracker.

--- a/agents/talos.md
+++ b/agents/talos.md
@@ -23,6 +23,8 @@ You accept exactly one **source** for the work, in this order of preference:
 
 Your final message is returned to the caller as the result, so make it a clean handoff:
 
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+
 - **Status:** `Impl done`.
 - **PR:** link to the pull request that was opened.
 - **Source:** link to the originating tracker item (GitHub issue / JIRA ticket / Bugsnag error).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -38,12 +38,12 @@ The counsel of wise planning, named after **Metis**, the Titaness of deliberatio
 
 ### <img src="../assets/agents/daidalos.png" alt="daidalos avatar" width="48" align="left"> `daidalos` — engineering-workflow orchestrator
 
-The master craftsman who runs the workshop, named after **Daidalos**, the legendary engineer who designed the work and directed the makers. It is the **entry point** for a free-form engineering request — *"resolve a random issue"*, *"resolve this URL"*, *"implement this"* — and the conductor that drives the job to a clean, reviewed result. It resolves a concrete source, decides whether the task needs a plan first (`metis`), runs implementation (`talos`), then drives the **review-and-fix loop (`talos` ↔ `argos`) to convergence** (no Critical/Moderate findings), and reports the result to the user. `metis` the mind, `talos` the hands, `argos` the eyes; `daidalos` the workshop lead that directs them.
+The master craftsman who runs the workshop, named after **Daidalos**, the legendary engineer who designed the work and directed the makers. It is the **entry point** for a free-form engineering request — *"resolve a random issue"*, *"resolve this URL"*, *"implement this"* — and the conductor that drives the job to a clean, reviewed result. It resolves a concrete source, decides whether the task needs a plan first, then **delegates each step by dispatching the matching specialist agent** through the Task tool — `metis` (analysis, if needed), `talos` (implementation), `argos` (the **review-and-fix loop `talos` ↔ `argos` to convergence**, no Critical/Moderate findings) — and reports the result to the user. `metis` the mind, `talos` the hands, `argos` the eyes; `daidalos` the workshop lead that directs them.
 
 - **Trigger:** a free-form engineering request — from a vague idea to a tracker link — that should be carried end to end.
-- **Orchestrates (delegates to):** `analyze-problem` (metis step), `resolve-issue` (talos step — which already loops `code-review` + `security-review` to 0 Critical/Moderate before the PR), `process-code-review` (the `talos` ↔ `argos` convergence loop, `maxIterations = 5`); reuses `autoresolve-oldest-github-issue` selection and `resolve-issue` source detection.
+- **Orchestrates (dispatches via the Task tool):** `metis` (analysis step — owns `analyze-problem`), `talos` (implementation step — owns `resolve-issue`, which already loops `code-review` + `security-review` to 0 Critical/Moderate before the PR), `argos` (the `talos` ↔ `argos` convergence loop — owns `process-code-review` / `code-review-github`, `maxIterations = 5`); resolves the source itself reusing `autoresolve-oldest-github-issue` selection and `resolve-issue` source detection.
 - **Convergence gate:** the run is done only at **0 Critical + 0 Moderate**; on `maxIterations` or a blocker it stops and escalates rather than reporting success. Merging stays a separate, explicit step.
-- **Safety:** read-only orchestrator — never analyses, implements, or reviews itself; the iteration loop is skill-driven (state lives in the skill), and it must be the top-level agent (not a nested subagent) per the one-level nesting rule below.
+- **Safety:** read-only orchestrator — never analyses, implements, or reviews itself; it delegates each step by dispatching the matching specialist agent, the iteration loop is skill-driven (state lives in the skill the specialist owns), and it must be the top-level agent (not a nested subagent) per the one-level nesting rule below — that single level is what it spends to dispatch `metis` / `talos` / `argos`.
 
 > A future top-level, cross-domain orchestrator (reserved name `zeus`) will sit above `daidalos` and coordinate non-engineering domains too (e.g. marketing). `daidalos` owns the engineering tier only.
 
@@ -88,30 +88,33 @@ An agent's final message is returned to the caller as the tool result, so it mus
 - **Links** — the PR and the originating source (GitHub / JIRA / Bugsnag).
 - **Result summary** — the numbers the caller needs (e.g. Critical / Moderate / Minor counts, a verdict).
 
+**Language of the handoff / report.** Every agent writes the human-facing prose of its handoff and any end-user report in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language — branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated, and two natural languages are never mixed inside a single handoff.
+
 ## Subagents of an agent
 
-Claude Code subagents invoked via the Task tool generally **cannot spawn their own subagents** (one level of nesting). Model an agent's "subagents" two ways:
+Claude Code subagents invoked via the Task tool generally **cannot spawn their own subagents** (one level of nesting). This shapes how the roster composes:
 
-1. **Lens skills called inline** by an orchestrating skill — e.g. `code-review-github` already runs `code-review`, `security-review`, `api-review`, `assignment-compliance-check` inline. This is the default and works today.
-2. **Parallel fan-out via the Workflow tool** — a DAG of agents for heavy runs that genuinely need concurrency.
+1. **A top-level orchestrator dispatches specialists through the Task tool.** `daidalos` runs as the top-level agent the user talks to, and spends its single nesting level dispatching `metis` / `talos` / `argos` directly. Each specialist then orchestrates its own skills inline — `talos` runs `resolve-issue`, `argos` runs `code-review-github`, and so on.
+2. **Lens skills called inline** by an orchestrating skill — e.g. `code-review-github` already runs `code-review`, `security-review`, `api-review`, `assignment-compliance-check` inline. This is what each dispatched specialist does in its own context, and it is also the fallback when no further nesting level is available.
+3. **Parallel fan-out via the Workflow tool** — a DAG of agents for heavy runs that genuinely need concurrency.
 
-Because of this limit, an orchestrator like `daidalos` must be the **top-level agent the user talks to** — it drives the run by invoking the chosen path inline (or, if invoked headless, returns a routing handoff for the caller to execute), never by being a nested subagent that spawns `metis` / `talos` / `argos`. A future `zeus → daidalos → specialist` chain must use the same inline / Workflow model rather than three levels of Task-subagent nesting.
+Because of the one-level limit, an orchestrator like `daidalos` must be the **top-level agent the user talks to** — it delegates each step by dispatching the matching specialist agent (or, if `daidalos` was itself invoked headless and the nesting level is already spent, returns a routing handoff for the caller to execute), never by becoming a nested subagent that tries to spawn `metis` / `talos` / `argos` from inside another agent. A future `zeus → daidalos → specialist` chain cannot stack three Task-subagent levels; it must collapse to a single dispatch level plus the inline / Workflow model.
 
-### End-to-end run (skill-driven, not nested-agent)
+### End-to-end run (agent-dispatched, skill-owned loop)
 
-The `daidalos` run carries a request all the way to a clean, reviewed result. Each step is a **skill** invoked inline; the iterative `talos` ↔ `argos` review-and-fix loop is **owned by the skills** (its state lives there), not modelled as agents calling agents:
+The `daidalos` run carries a request all the way to a clean, reviewed result. `daidalos` resolves the source itself, then **dispatches each step as the matching specialist agent through the Task tool**; the iterative `talos` ↔ `argos` review-and-fix loop is **owned by the skill the dispatched specialist drives** (its state lives there), not modelled as agents calling agents:
 
 ```text
-user → daidalos
+user → daidalos                                         (top-level; resolves source, then dispatches via Task tool)
          │  resolve source (autoresolve-oldest-github-issue selection / resolve-issue source-detection)
-         │  analyse? ── yes ─→ metis  = analyze-problem  (plan)
+         │  analyse? ── yes ─→ Task ▶ metis   (= analyze-problem → plan)
          │     │ no
          ▼     ▼
-       talos = resolve-issue
-         │   └─ inline loop: code-review + security-review → 0 Critical/Moderate → opens PR
+       Task ▶ talos   (= resolve-issue)
+         │        └─ inline loop: code-review + security-review → 0 Critical/Moderate → opens PR
          ▼
-       talos ↔ argos = process-code-review
-             └─ convergence loop: code-review-github (quiet) + fixes, maxIterations 5 → 0 Critical/Moderate
+       Task ▶ argos   (= process-code-review / code-review-github — the talos ↔ argos loop)
+                  └─ convergence loop: code-review-github (quiet) + fixes, maxIterations 5 → 0 Critical/Moderate
          ▼
        daidalos → reports result to the user   (merge stays a separate, explicit step)
 ```

--- a/skills/merge-github-pr/SKILL.md
+++ b/skills/merge-github-pr/SKILL.md
@@ -18,6 +18,7 @@ Merge pull requests that meet all required conditions.
 - Never merge PRs with conflicts
 - Never merge PRs with failing CI (unless explicitly instructed)
 - Never bypass required approvals or protections
+- The only tolerated CI failure is a **GitHub Actions billing / account-limit error** when the merge is **explicitly requested** (see *GitHub Actions billing exception* below). Any other failure — real test failure, lint, static analysis — still blocks.
 
 ---
 
@@ -33,13 +34,24 @@ Merge pull requests that meet all required conditions.
 For each PR, derive the verdict from the JSON document loaded in step 1:
 
 - No merge conflicts — `mergeable == "MERGEABLE"` and `mergeStateStatus` is not `DIRTY` or `BEHIND`
-- CI is passing — every entry in `statusCheckRollup[]` has a passing `state` (`SUCCESS` / `NEUTRAL` / `SKIPPED`)
+- CI is passing — every entry in `statusCheckRollup[]` has a passing `state` (`SUCCESS` / `NEUTRAL` / `SKIPPED`), **with the single billing exception below** when the merge was explicitly requested
 - Required approvals are present — `reviewDecision == "APPROVED"`
 - Branch is up to date with base branch — `mergeStateStatus != "BEHIND"`
 
 If any check fails:
 - do not merge
 - report reason
+
+#### GitHub Actions billing exception (explicit merge only)
+
+A single, narrow exception relaxes the CI-passing check — **only** when the caller explicitly requested the merge (an automatic / opportunistic merge never qualifies):
+
+- **When it applies:** the *only* blocking entries in `statusCheckRollup[]` are GitHub Actions runs that did **not** execute because of a billing / account-limit problem — typically a `state` of `ERROR` (or a workflow that never started) whose detail message is an unambiguous billing notice such as *"The job was not started because recent account payments have failed or your spending limit needs to be increased"*, *"billing"*, or *"spending limit"*. In that case the gate **ignores those specific entries** and allows the merge.
+- **Detection must stay conservative.** Treat an entry as a billing failure only when its message clearly names a billing / payment / spending-limit cause. A bare `ERROR` / `FAILURE` with no billing wording is a **real** failure — never assume billing. When in doubt, do not merge: report the ambiguous entry and stop.
+- **The exception is billing-only.** It never relaxes any other gate: a real CI failure (tests, lint, static analysis) on any non-billing entry, `mergeStateStatus == "DIRTY"` / `"BEHIND"`, an unmergeable state, or `reviewDecision != "APPROVED"` still blocks the merge regardless of the explicit request.
+- **Report what was waived.** When the merge proceeds under this exception, list each ignored billing entry (check name + the billing message) in the output so the waiver is auditable.
+
+When the merge was **not** explicitly requested, this exception does not apply — a billing failure blocks like any other failing check.
 
 ### 3. Merge
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4043,18 +4043,21 @@ test('agents directory ships the daidalos orchestrator subagent with required fr
 
     $content = (string) file_get_contents($agentPath);
     expect($content)->toContain('name: daidalos');
-    expect($content)->toContain('tools: Read, Glob, Grep, Bash');
+    expect($content)->toContain('tools: Task, Read, Glob, Grep, Bash');
     expect($content)->toContain('@skills/resolve-issue/references/source-detection.md');
     expect($content)->toContain('@skills/autoresolve-oldest-github-issue/SKILL.md');
 });
 
-test('daidalos drives the end-to-end orchestration loop through resolve-issue and process-code-review', function (): void {
+test('daidalos delegates the end-to-end run by dispatching metis, talos and argos to convergence', function (): void {
     $packageDir = dirname(__DIR__);
     $content = (string) file_get_contents($packageDir . '/agents/daidalos.md');
 
-    expect($content)->toContain('@skills/analyze-problem');
+    // True delegation: each step is dispatched as the matching specialist agent through the Task tool.
+    expect($content)->toContain('dispatch `metis` through the Task tool');
+    expect($content)->toContain('Dispatch `talos` through the Task tool');
+    expect($content)->toContain('Dispatch `argos` through the Task tool');
+    // The implementation step still routes through resolve-issue (owned by talos), and the convergence gate is named.
     expect($content)->toContain('@skills/resolve-issue');
-    expect($content)->toContain('@skills/process-code-review');
     expect($content)->toContain('0 Critical');
 });
 


### PR DESCRIPTION
## Summary

Resolves #607 — tři změny ve vrstvě AI agentů (orchestrace pojmenovaná podle řecké mytologie).

### Task 1 — daidalos: pravá delegace na agenty
- `agents/daidalos.md`: do `tools:` přidán `Task` (vedle `Read, Glob, Grep, Bash`) a tělo přepsáno tak, aby daidalos **každý krok delegoval dispatchem příslušného agenta přes Task tool** — `metis` (analýza, je-li potřeba) → `talos` (implementace) → `argos` (review-and-fix smyčka), místo inline spouštění skills ve vlastním kontextu.
- Zachován headless fallback na routing handoff (1 úroveň vnoření respektována — tu daidalos spotřebuje právě na dispatch specialisty).
- Sladěny `docs/agents.md` (*Subagents of an agent*, *End-to-end run*, roster, *Handoff contract*) a `README.md` s novým delegačním modelem.
- `tests/InstallerTest.php`: aktualizovány asserce na nový řádek `tools:` a na dispatch formulace.

### Task 2 — jazyk odpovědí u všech agentů
- Do `agents/daidalos.md`, `agents/metis.md`, `agents/talos.md`, `agents/argos.md` přidána jednotná direktiva: handoff i report se píší ve stejném jazyce jako zadání; identifikátory (názvy větví, klíče ticketů, odkazy, severity labels, CLI příkazy, jména skillů/agentů) zůstávají doslovné, dva jazyky se v jednom handoffu nemíchají.

### Task 3 — merge: tolerance billing chyby GitHub Actions
- `skills/merge-github-pr/SKILL.md` (*Pre-checks*): při **explicitně vyžádaném** merge se ignoruje výhradně CI selhání způsobené GitHub Actions billing / account-limit chybou (jednoznačná billing hláška). Detekce je konzervativní; jakákoli jiná chyba (reálné selhání CI, `DIRTY`/`BEHIND`, chybějící approval, lint) merge dál blokuje, a waiver se reportuje pro audit.
- `agents/daidalos.md`: merge krok orchestrace odkazuje na tutéž výjimku.

## Testing
- `composer build` projde bez chyb (247 testů, 1364 assercí, 100% coverage, skill-check + PHPStan + Pint + PHPCS + Rector + normalize + audit green).

## Success criteria (z issue)
- [x] `daidalos.md` má v `tools:` `Task` a tělo deleguje dispatchem metis/talos/argos; žádná instrukce nespouští skills inline jako způsob, jak daidalos sám dělá práci.
- [x] Zachován headless fallback na routing handoff.
- [x] `docs/agents.md` a *Nesting constraint* v `daidalos.md` v souladu s novým modelem.
- [x] Všechny 4 soubory `agents/*.md` obsahují direktivu o jazyce odpovědi.
- [x] `merge-github-pr/SKILL.md` ignoruje výhradně billing chybu při explicitním merge a blokuje na jakékoli jiné chybě.
- [x] `composer build` projde bez chyb.
