### PR TITLE
feat(agents): add momus — human-perspective PR tester (wraps test-like-human)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Agents = specialised orchestration roles over multiple skills
 | `talos` | Tireless code-writing implementer. Implements an issue from context or a tracker link, validates with tests, opens a PR, and hands back an Impl-done handoff. Stops at the PR — never reviews or merges. | `resolve-issue` |
 | `metis` | Problem-analysis advisor. Analyses a problem or a vague assignment, proposes the smallest safe solution, and publishes a reusable plan as a GitHub issue, then hands back an Analysis-done handoff. Read-only — never implements. | `analyze-problem` |
 | `daidalos` | Engineering-workflow orchestrator. The entry point for a free-form request: resolves a concrete source, then **dispatches** `metis` (analysis, if needed), `talos` (implementation), and `argos` (the review-and-fix loop to convergence) through the Task tool. Read-only orchestrator. | `metis`, `talos`, `argos` (dispatched) |
+| `momus` | Fault-finding human-perspective PR tester. Walks a PR like a real user (UI / API / CLI), runs the mandatory `curl` checks on API changes, publishes a human-readable report to the PR, and hands back a Test-done handoff with `pass / fail / blocked / unclear` counts and a readiness verdict. Read-only — dispatched on demand, outside the `daidalos` loop. | `test-like-human` |
 
 ### How to use `argos` in practice
 

--- a/agents/momus.md
+++ b/agents/momus.md
@@ -1,0 +1,56 @@
+---
+name: momus
+description: Use when a pull request needs validating from a real user's perspective — understand the assignment, exercise the app like a human (UI/API/CLI), and report what passes, fails, confuses, or is blocked. Loads the source, runs test-like-human, publishes the human-readable result to the PR, and hands back a "Test done" handoff with scenario counts and a readiness verdict. Read-only — never edits source, commits, pushes, or merges.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+You are **Momus** — the fault-finding tester who walks the app as a real user. Your single job is to run a human-perspective validation of a pull request and publish it. You are **read-only**: never edit the working tree, never commit, push, or merge, and never apply fixes.
+
+You may start the app, issue `curl` requests, open a REPL, and flip feature flags / ENV switches **only to verify** the change (through `Bash`), always with throwaway data and cleaning up after yourself — restoring the branch / working tree to its original state, exactly as `@skills/test-like-human/SKILL.md` requires. **Writing missing automated tests is out of scope** — you only record the coverage gap and recommend `talos` / `create-test`; you never author the test yourself.
+
+## Input
+
+You accept one **source** for the validation, in this order of preference:
+
+1. An explicit tracker reference passed by the caller — a **GitHub** PR/issue number or URL, a **JIRA** key/URL, or a **Bugsnag** error URL/triple.
+2. The **current context** — the checked-out branch or the PR the conversation is about — when it resolves to a concrete tracker item.
+3. **No resolvable source** — no tracker URL/reference was given and the current branch maps to no PR/tracker item. In that case the validation still runs, on the local working-tree / branch diff, but there is nowhere to publish — the results travel back in the handoff instead of a PR comment.
+
+## How to run
+
+1. **Detect the source** using `@skills/resolve-issue/references/source-detection.md`. This resolves which tracker the PR lives on (GitHub / JIRA / Bugsnag) so `test-like-human` knows where its `pr-summary` comment must land.
+2. **Run `@skills/test-like-human/SKILL.md` to completion.** That skill owns the whole pipeline and is the source of truth — **do not re-implement or duplicate any of it**:
+   - understand the assignment (load the PR, read description / comments / discussions, identify the expected final behavior),
+   - detect the project's stack and toolchain, then run the **reachability pre-check** per scenario so a "PASS" actually exercises the changed branch,
+   - execute the manual scenarios as a senior tester (UI → browser, backend → the stack's REPL, CLI → terminal),
+   - perform the **mandatory `curl` verification** whenever the PR changes the API (status code, response shape, validation errors, authorization, happy path + negative cases),
+   - validate the **triple** (positive / negative / legacy preservation) to confirm the observed behavior was caused by the changed code,
+   - publish the tracker-facing report through `@skills/pr-summary/SKILL.md` (the *Authors / Available behind / Summary of changes / How to test* contract).
+   - **No-source fallback:** when step 1 yields no tracker, the same skill still runs on the local diff, but the publishing step has nowhere to land — relay the returned report inline in the handoff instead.
+
+## Two feedback channels
+
+Both channels are produced by the run — do not add a third or restate the skill's work:
+
+- **To the source** — the tracker comment on the PR, authored by `test-like-human` via `@skills/pr-summary/SKILL.md` (*Authors / Available behind / Summary of changes / How to test*), plus the short **non-public dev-team follow-up** listing the failed / blocked / unclear scenarios with enough technical detail to act on them.
+- **To the calling agent** — your final message is the structured handoff below, so `daidalos` (or any other caller) never has to re-derive where the validation lives or what it found.
+
+## On-demand, never auto-chained
+
+`@skills/test-like-human/SKILL.md` is **never** auto-chained from the review pipeline (`code-review`, `code-review-github`, `process-code-review`, `resolve-issue`). `momus` is dispatched **explicitly**, only when a real user-perspective validation is genuinely wanted — typically **after** `argos` has converged the review-and-fix loop. That is why `momus` is **not** part of the `daidalos` convergence loop.
+
+## Output — handoff to the caller
+
+Your final message is returned to the caller as the result, so make it a clean handoff.
+
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, scenario statuses, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+
+- **Status:** `Test done` (validated) or `Blocked` (scenarios could not be run — missing environment, unreachable branch) with the reason. For the no-source fallback, state `no tracker — local diff` and include the report inline in the handoff.
+- **PR:** link to the pull request where the report was published, or `no tracker — local diff`.
+- **Source:** link to the originating tracker item (GitHub issue / JIRA ticket / Bugsnag error), or `none`.
+- **Scenarios:** counts of `pass / fail / blocked / unclear`.
+- **Verdict:** `ready` / `not ready` from the user's perspective, plus a one-line rationale.
+- **Follow-up:** link to / summary of the failed / blocked / unclear scenarios for the dev team.
+
+Stop after the handoff — applying fixes, writing missing tests, and merging are other agents' jobs.

--- a/assets/agents/momus.svg
+++ b/assets/agents/momus.svg
@@ -1,0 +1,14 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="momus agent avatar">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3b4252"/>
+      <stop offset="1" stop-color="#2e3440"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#bg)"/>
+  <!-- generic agent silhouette -->
+  <circle cx="80" cy="64" r="26" fill="#d8dee9"/>
+  <path d="M36 128c0-24 20-40 44-40s44 16 44 40v6H36z" fill="#d8dee9"/>
+  <!-- subtle ring marking it as a placeholder slot -->
+  <rect x="6" y="6" width="148" height="148" rx="28" fill="none" stroke="#4c566a" stroke-width="3" stroke-dasharray="8 8"/>
+</svg>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -45,6 +45,15 @@ The master craftsman who runs the workshop, named after **Daidalos**, the legend
 - **Convergence gate:** the run is done only at **0 Critical + 0 Moderate**; on `maxIterations` or a blocker it stops and escalates rather than reporting success. Merging stays a separate, explicit step.
 - **Safety:** read-only orchestrator — never analyses, implements, or reviews itself; it delegates each step by dispatching the matching specialist agent, the iteration loop is skill-driven (state lives in the skill the specialist owns), and it must be the top-level agent (not a nested subagent) per the one-level nesting rule below — that single level is what it spends to dispatch `metis` / `talos` / `argos`.
 
+### <img src="../assets/agents/momus.svg" alt="momus avatar" width="48" align="left"> `momus` — human-perspective PR tester
+
+The fault-finding tester, named after **Momus**, the god of criticism, satire, and fault-finding who found a flaw in every work the gods made. Give it a pull request — from the current context or a tracker link (GitHub, JIRA, Bugsnag) — and it walks the change like a real user: it understands the assignment, exercises the app (UI / API / CLI), runs the mandatory `curl` checks on API changes, publishes a human-readable report to the PR via `pr-summary`, and hands back a `Test done` summary with `pass / fail / blocked / unclear` scenario counts and a readiness verdict. It is a thin wrapper over `test-like-human` — the same read-only-wrapper-plus-handoff shape as `argos`.
+
+- **Trigger:** a pull request needs validating from a real user's perspective — typically **on demand after `argos` has converged the review-and-fix loop**, not as part of it.
+- **Orchestrates:** `test-like-human` (which itself publishes through `pr-summary`).
+- **Safety:** read-only — never edits, commits, pushes, or merges; writing missing automated tests is out of scope (it records the gap and recommends `talos` / `create-test`).
+- **On-demand, outside the loop:** `test-like-human` is never auto-chained from the review pipeline, so `momus` is dispatched explicitly and is **not** part of the `daidalos` convergence loop.
+
 > A future top-level, cross-domain orchestrator (reserved name `zeus`) will sit above `daidalos` and coordinate non-engineering domains too (e.g. marketing). `daidalos` owns the engineering tier only.
 
 ## Naming convention — Greek mythology
@@ -57,6 +66,7 @@ Every agent is named after a figure from **Greek mythology**, chosen so the figu
 | `talos` | Talos, the bronze automaton forged to work and guard without rest | tireless artificial labourer → forges working code |
 | `metis` | Metis, Titaness of wise counsel and cunning planning | deliberation before action → problem analysis & planning |
 | `daidalos` | Daidalos, the master craftsman who runs the workshop and directs the makers | head of production → routes engineering work to the right specialist |
+| `momus` | Momus, the god of criticism, satire, and fault-finding | finds the flaw in every work → user-perspective testing |
 
 Naming ideas for future agents: `themis` (order / verdict), `rhadamanthys` (fair judge), `athena` (wisdom / architecture), `hermes` (delivery / merge), `zeus` (top-level cross-domain orchestrator above `daidalos`).
 

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4359,6 +4359,22 @@ test('daidalos delegates the end-to-end run by dispatching metis, talos and argo
     expect($content)->toContain('0 Critical');
 });
 
+test('agents directory ships the momus human-perspective tester subagent with required frontmatter', function (): void {
+    $packageDir = dirname(__DIR__);
+    $agentPath = $packageDir . '/agents/momus.md';
+
+    expect(is_file($agentPath))->toBeTrue();
+
+    $content = (string) file_get_contents($agentPath);
+    expect($content)->toContain('name: momus');
+    expect($content)->toContain('tools: Read, Glob, Grep, Bash');
+    expect($content)->toContain('@skills/test-like-human/SKILL.md');
+    expect($content)->toContain('@skills/resolve-issue/references/source-detection.md');
+    // Read-only wrapper: the tools line must not grant Write or Edit.
+    expect($content)->not->toContain('tools: Read, Write');
+    expect($content)->not->toContain('Edit, Glob');
+});
+
 test('resolveAgentsSource returns the package agents directory when it exists', function (): void {
     $packageDir = dirname(__DIR__);
 


### PR DESCRIPTION
## Summary

Adds **`momus`** — a thin, read-only Claude Code subagent that validates a pull request **from a real user's perspective** by orchestrating `@skills/test-like-human/SKILL.md`. Same wrapper-plus-handoff shape as `argos` (read-only wrapper over a skill): `momus` adds no rules of its own, it drives the skill and returns a clean handoff.

`momus` understands the assignment, exercises the app like a human (UI / API / CLI) with the mandatory `curl` checks on API changes, validates the positive / negative / legacy triple, publishes the human-readable report to the PR via `pr-summary`, and hands back a `Test done` handoff with `pass / fail / blocked / unclear` scenario counts and a readiness verdict. It is dispatched **on demand** (typically after `argos` converges) and is deliberately **not** part of the `daidalos` convergence loop.

Resolves #617.

## What changed

- **`agents/momus.md`** — frontmatter (`name: momus`, the spec `description` verbatim, `tools: Read, Glob, Grep, Bash`, `model: opus`) + an orchestration-only system prompt: identity & read-only safety, single-source input precedence, `source-detection` + delegate-to-`test-like-human`, the two feedback channels (tracker comment + dev-team follow-up; handoff to the caller), the on-demand-not-auto-chained note, and the handoff contract (Status / PR / Source / Scenarios / Verdict / Follow-up). Missing-test authoring is explicitly out of scope (recommends `talos` / `create-test`).
- **`docs/agents.md`** — roster block for `momus`, a row in the *Naming convention* table (Momus → god of criticism / fault-finding → user-perspective testing), and the note that it is an on-demand step outside the `daidalos` convergence loop.
- **`README.md`** — `momus` row in the *Claude Code Subagents* table.
- **`tests/InstallerTest.php`** — a frontmatter/distribution test mirroring the `argos` test (asserts `name: momus`, the read-only tools line, delegation to `test-like-human` + `source-detection`, and no `Write`/`Edit` grant). The installer file-count tests pick up the new agent automatically.
- **`assets/agents/momus.svg`** — placeholder avatar slot (custom artwork is out of scope per the issue).

## How to test

- `composer build` — passes clean (skill-check 0 errors, 265 tests / 1410 assertions including the new `momus` test, 100% coverage).
- Confirm the new agent ships and is read-only: `agents/momus.md` declares `tools: Read, Glob, Grep, Bash` (no `Write` / `Edit`) and delegates to `@skills/test-like-human/SKILL.md`.

## Out of scope (per the issue)

- Wiring `momus` into the automatic `daidalos` loop (stays on demand).
- Custom avatar artwork (placeholder only).
- Any behavior change to `test-like-human` or `pr-summary`.

## Technical report

- **Code review:** ran `@skills/code-review/SKILL.md` inline on the local diff — documentation / agent-definition / test-only change, surgical, no application code or API surface; **0 Critical / 0 Moderate / 0 Minor**.
- **Security review:** ran `@skills/security-review/SKILL.md` inline — no user-facing strings, no remote-fetch / TLS / process-execution constructs, no secrets; nothing flagged.