### PR TITLE
test(agents): assert every agent definition declares model in frontmatter (#620)

### DIFF
--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4359,6 +4359,19 @@ test('every dispatched agent reads and appends to the shared task brief', functi
     }
 });
 
+test('every agent definition declares a model in frontmatter', function (): void {
+    $packageDir = dirname(__DIR__);
+    $globResult = glob($packageDir . '/agents/*.md');
+    $agentFiles = $globResult !== false ? $globResult : [];
+
+    expect($agentFiles)->not->toBeEmpty();
+
+    foreach ($agentFiles as $agentFile) {
+        $content = (string) file_get_contents($agentFile);
+        expect($content)->toContain('model:');
+    }
+});
+
 test('daidalos delegates the end-to-end run by dispatching metis, talos and argos to convergence', function (): void {
     $packageDir = dirname(__DIR__);
     $content = (string) file_get_contents($packageDir . '/agents/daidalos.md');

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4368,7 +4368,9 @@ test('every agent definition declares a model in frontmatter', function (): void
 
     foreach ($agentFiles as $agentFile) {
         $content = (string) file_get_contents($agentFile);
-        expect($content)->toContain('model:');
+        // Anchor to a frontmatter line starting with `model:` so a stray substring
+        // (e.g. the prose "## Delegation model") cannot satisfy the assertion.
+        expect($content)->toMatch('/^model:\s*\S+/m');
     }
 });
 


### PR DESCRIPTION
## Summary

- Adds a dynamic Pest test that globs `agents/*.md` and asserts each file contains a `model:` line in its frontmatter
- No agent definitions were modified — all five already carry the `model:` field
- Test uses `glob()` result with a `!== false` guard (PHPStan-compliant) and asserts the result is non-empty so the test self-destructs if the directory disappears

## Test plan

- [ ] `composer build` passes: 267 tests, 1427 assertions, 100% coverage
- [ ] New test `every agent definition declares a model in frontmatter` is visible in the output
- [ ] No changes to any file in `agents/`

Closes #620