### PR TITLE
fix(bin): switch resolve-loop to --permission-mode auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ DRY_RUN=1 vendor/bin/cursor-rules-resolve-loop.sh "only bugs"   # print the reso
 | `MODE` | `pr` | `pr` = `resolve-issue`, stops at the PR (you merge); `merge` = `autoresolve-oldest-github-issue` (full pipeline incl. merge) |
 | `DRY_RUN` | _unset_ | print the resolved prompt + command and exit, launching nothing |
 
-**Auto mode & safety:** the loop runs with `--permission-mode acceptEdits` — edits apply without a prompt, but `bash` / `gh` / merge steps still ask for confirmation so you stay in control. Each pass resolves exactly one issue and stops on any blocker (merge conflict, failing CI, unresolved Critical/Moderate findings); bound the run by labelling only the issues the loop may touch.
+**Auto mode & safety:** the loop runs with `--permission-mode auto` (status line `auto mode on (shift+tab to cycle) · esc to interrupt`) — edits apply without a prompt, but `bash` / `gh` / merge steps still ask for confirmation so you stay in control. Each pass resolves exactly one issue and stops on any blocker (merge conflict, failing CI, unresolved Critical/Moderate findings); bound the run by labelling only the issues the loop may touch.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -321,10 +321,10 @@ DRY_RUN=1 vendor/bin/cursor-rules-resolve-loop.sh "only bugs"   # print the reso
 |---|---|---|
 | `PROJECT` | current dir | project directory to operate in |
 | `LABEL` | `Resolve_by_AI` | only issues with this label (`LABEL=""` = any open issue) |
-| `MODE` | `pr` | `pr` = `resolve-issue`, stops at the PR (you merge); `merge` = `autoresolve-oldest-github-issue` (full pipeline incl. merge) |
+| `MODE` | `pr` | `pr` = dispatches the `daidalos` agent, stops at the PR (you merge); `merge` = `autoresolve-oldest-github-issue` (full pipeline incl. merge) |
 | `DRY_RUN` | _unset_ | print the resolved prompt + command and exit, launching nothing |
 
-**Auto mode & safety:** the loop runs with `--permission-mode auto` (status line `auto mode on (shift+tab to cycle) · esc to interrupt`) — edits apply without a prompt, but `bash` / `gh` / merge steps still ask for confirmation so you stay in control. Each pass resolves exactly one issue and stops on any blocker (merge conflict, failing CI, unresolved Critical/Moderate findings); bound the run by labelling only the issues the loop may touch.
+**Auto mode & safety:** the loop runs with `--permission-mode auto` (status line `auto mode on (shift+tab to cycle) · esc to interrupt`) — a risk classifier decides what is auto-approved: safe actions (edits, read-only commands, pushing the working branch) run without a prompt, while risky ones (force push, pushing to the default branch, destructive deletes, production deploys) still ask for confirmation so you stay in control. Each pass resolves exactly one issue and stops on any blocker (merge conflict, failing CI, unresolved Critical/Moderate findings); bound the run by labelling only the issues the loop may touch.
 
 ---
 

--- a/bin/cursor-rules-resolve-loop.sh
+++ b/bin/cursor-rules-resolve-loop.sh
@@ -18,8 +18,9 @@
 #   DRY_RUN=1             # nic nespustí — jen vypíše vyhodnocený prompt a příkaz (ověření)
 #
 # Auto mode = --permission-mode auto: status line "auto mode on (shift+tab to
-# cycle) · esc to interrupt", edity bez dotazu, bash/gh/merge se pro bezpečnost
-# stále potvrzují.
+# cycle) · esc to interrupt". Auto-schvalování řídí rizikový klasifikátor —
+# bezpečné akce (edity, read-only příkazy, push na tuhle větev) běží bez dotazu,
+# rizikové (force push, push na main, destruktivní mazání, prod deploy) se ptají.
 set -euo pipefail
 
 PROJECT="${PROJECT:-$PWD}"
@@ -52,14 +53,14 @@ if [ "$MODE" = "merge" ]; then
   PROMPT="/loop autoresolve-oldest-github-issue${LABEL:+ (label ${LABEL})}"
 else
   LBL=""; [ -n "$LABEL" ] && LBL=" s labelem ${LABEL}"
-  PROMPT="/loop vyber nejstarší otevřené issue${LBL} v tomhle repu, spusť na něj resolve-issue (zastav se na PR, NEMERGUJ), pak skonči. Když žádné eligible issue není, skonči s hláškou NO_ISSUES."
+  PROMPT="/loop použij agenta daidalos, ať vyřeší nejstarší otevřené issue${LBL} v tomhle repu (zastav se na PR, NEMERGUJ), pak skonči. Když žádné eligible issue není, skonči s hláškou NO_ISSUES."
 fi
 [ -n "$EXTRA" ] && PROMPT="$PROMPT $EXTRA"
 
 PERM=(--permission-mode auto)
 
 echo "▶ projekt : $PROJECT"
-echo "▶ režim   : MODE=$MODE  auto mode  LABEL=${LABEL:-<any>}"
+echo "▶ režim   : MODE=$MODE  auto mode (edity bez dotazu)  LABEL=${LABEL:-<any>}"
 [ -n "$EXTRA" ] && echo "▶ extra   : $EXTRA"
 
 if [ -n "${DRY_RUN:-}" ]; then

--- a/bin/cursor-rules-resolve-loop.sh
+++ b/bin/cursor-rules-resolve-loop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # cursor-rules-resolve-loop.sh — interaktivní Claude Code loop, který systematicky řeší
 # GitHub issues V PROJEKTU, ze kterého ho spustíš (přes vendor/bin), jedno issue
-# za průchod. Bez worktrees. Auto mode (acceptEdits) zapnutý — vidíš celý průběh,
+# za průchod. Bez worktrees. Auto mode zapnutý — vidíš celý průběh,
 # Esc přeruší krok.
 #
 # Spuštění z projektu (po `composer require pekral/cursor-rules --dev`):
@@ -17,8 +17,9 @@
 #                         # merge:        autoresolve-oldest-github-issue (celý pipeline VČETNĚ merge)
 #   DRY_RUN=1             # nic nespustí — jen vypíše vyhodnocený prompt a příkaz (ověření)
 #
-# Auto mode = --permission-mode acceptEdits: edity bez dotazu, bash/gh/merge se
-# pro bezpečnost stále potvrzují.
+# Auto mode = --permission-mode auto: status line "auto mode on (shift+tab to
+# cycle) · esc to interrupt", edity bez dotazu, bash/gh/merge se pro bezpečnost
+# stále potvrzují.
 set -euo pipefail
 
 PROJECT="${PROJECT:-$PWD}"
@@ -55,10 +56,10 @@ else
 fi
 [ -n "$EXTRA" ] && PROMPT="$PROMPT $EXTRA"
 
-PERM=(--permission-mode acceptEdits)
+PERM=(--permission-mode auto)
 
 echo "▶ projekt : $PROJECT"
-echo "▶ režim   : MODE=$MODE  auto-accept editů  LABEL=${LABEL:-<any>}"
+echo "▶ režim   : MODE=$MODE  auto mode  LABEL=${LABEL:-<any>}"
 [ -n "$EXTRA" ] && echo "▶ extra   : $EXTRA"
 
 if [ -n "${DRY_RUN:-}" ]; then


### PR DESCRIPTION
## Co a proč

`cursor-rules-resolve-loop.sh` startoval Claude Code přes `--permission-mode acceptEdits` (status line *auto-accept edits on*). Požadavek byl, aby se loop spouštěl rovnou v **auto mode** se status line:

```
auto mode on (shift+tab to cycle) · esc to interrupt
```

CLI nabízí samostatný režim `auto`, který tuhle hlášku zobrazuje. Přepnul jsem na něj.

## Změny
- `bin/cursor-rules-resolve-loop.sh` — `PERM=(--permission-mode auto)` + aktualizované komentáře a echo hlášky
- `README.md` — sekce *Auto mode & safety* popisuje nový režim

Chování zůstává: edity bez dotazu, `bash`/`gh`/merge se stále potvrzují.

## Ověření
- `composer build` ✓ (267 passed, coverage 100 %)