### PR TITLE
feat(agents): propagate assignment language through daidalos delegation

### DIFF
--- a/agents/apollon.md
+++ b/agents/apollon.md
@@ -41,7 +41,7 @@ When the caller passes a **shared brief path** (`.claude/run/<source-slug>.md`),
 
 Your final message is returned to the caller as the result, so make it a clean handoff.
 
-**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, scenario statuses, test paths, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). **When the caller passed a shared brief, its recorded `## Language` field is the authoritative source — reply in that language** rather than re-guessing it from the prompt. Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, scenario statuses, test paths, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
 
 - **Status:** `Tests done` (suite green, coverage gate held) or `Blocked` (suite red, coverage gate missed, or a flow cannot be reached) with the reason.
 - **Source:** link to the originating tracker item (GitHub issue / JIRA ticket / Bugsnag error), or `none`.

--- a/agents/argos.md
+++ b/agents/argos.md
@@ -35,7 +35,7 @@ When the caller passes a **shared brief path** (`.claude/run/<source-slug>.md`),
 
 Your final message is returned to the caller as the result, so make it a clean handoff:
 
-**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). **When the caller passed a shared brief, its recorded `## Language` field is the authoritative source — reply in that language** rather than re-guessing it from the prompt. Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
 
 - **Status:** `CR done`.
 - **PR:** link to the pull request where the review was posted. When the no-source fallback ran the base `code-review` skill, there is no PR — state `no tracker — local diff review` and include the returned findings markdown inline in the handoff instead of a link.

--- a/agents/daidalos.md
+++ b/agents/daidalos.md
@@ -25,10 +25,11 @@ The iteration loop's **state lives in the skill that `talos` / `argos` drive** (
 Before dispatching any specialist, you **gather once** and write a single shared brief that every dispatched agent reads, so the data is collected one time instead of re-derived by each agent. This is the run's shared memory and the efficient channel for passing information between agents.
 
 - **When.** Right after you resolve the source (step 1) and **before the first dispatch** — the gather phase. Assemble everything the task needs *before* any specialist starts.
-- **What to gather.** The resolved source link; the tracker payload (title, description, acceptance criteria, comments) via the deterministic loaders; the relevant files / symbols / reproduction; known constraints and prior decisions; and your **work-breakdown plan** — which specialist does what, in what order, and the success gate for each. Use your read-only tools (`Read`, `Glob`, `Grep`, `Bash` with `gh` / the deterministic loaders) to collect what already exists — you do **not** analyse or implement, you assemble.
+- **What to gather.** The resolved source link; the tracker payload (title, description, acceptance criteria, comments) via the deterministic loaders; the relevant files / symbols / reproduction; known constraints and prior decisions; the **assignment's natural language** (the language the user wrote the request in — record it explicitly so every specialist inherits it and replies in it, never re-guesses it); and your **work-breakdown plan** — which specialist does what, in what order, and the success gate for each. Use your read-only tools (`Read`, `Glob`, `Grep`, `Bash` with `gh` / the deterministic loaders) to collect what already exists — you do **not** analyse or implement, you assemble.
 - **Where.** A single Markdown file at `.claude/run/<source-slug>.md` (e.g. `.claude/run/gh-617.md`, `.claude/run/jira-ABC-123.md`). `.claude/` is git-ignored, so the brief is **ephemeral and never committed**. Derive `<source-slug>` deterministically from the resolved source.
 - **How you write it.** You have no `Write` tool — author and update the brief through `Bash` redirection to that path (`cat > "$BRIEF" <<'EOF' … EOF` to create, `cat >> "$BRIEF" <<'EOF' … EOF` to append). The brief is the **only** thing you write — never source, tests, or config; your read-only-codebase property is unchanged.
-- **Pass it on.** Include the brief's **absolute path** in every `Task` dispatch prompt, instructing the specialist to **read it first** as the authoritative shared context and to **append its own handoff section** when done (`### <agent> — <status>` plus its result, via `cat >> "$BRIEF"`). The next specialist in the chain inherits the full history — source, plan, and every prior handoff — without you re-passing it.
+- **Pass it on.** Include the brief's **absolute path** in every `Task` dispatch prompt, instructing the specialist to **read it first** as the authoritative shared context and to **append its own handoff section** when done (`### <agent> — <status>` plus its result, via `cat >> "$BRIEF"`). The next specialist in the chain inherits the full history — source, plan, the recorded assignment language, and every prior handoff — without you re-passing it.
+- **Language of the dispatch.** Write each `Task` dispatch prompt in the **assignment's natural language** (the one recorded in the brief), and state in the prompt that the specialist must produce its handoff and any end-user output in that same language. This is how the language propagates through delegation: the brief records it, your dispatch carries it, and every specialist replies in it. Identifiers (branch names, ticket / issue keys, links, severity labels, CLI commands, skill / agent names) stay verbatim regardless of that language.
 - **Cleanup.** After your final report (or a `Blocked` stop), remove the brief (`rm -f "$BRIEF"`). It is scratch memory for the run, not a kept artifact.
 
 Brief layout:
@@ -36,6 +37,7 @@ Brief layout:
 ```text
 # Task brief — <source>
 ## Source            <link / restatement>
+## Language          <the assignment's natural language — every specialist replies in it>
 ## Gathered context  <tracker payload, acceptance criteria, relevant files/symbols, reproduction, constraints>
 ## Plan & work breakdown   <metis? → talos → argos / apollon, each with its success gate>
 ## Handoff log       (each specialist appends its section as it finishes)
@@ -66,7 +68,7 @@ Brief layout:
 
 Your final message is returned to the caller as the result, so make it a clean, plain-language report.
 
-**Language:** write this report — and every routing handoff — in the **same natural language the request was given in**; if the user wrote in Czech, report in Czech. Identifiers stay verbatim regardless of the report language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single report.
+**Language:** write this report — every routing handoff, **and every `Task` dispatch prompt you send to a specialist** — in the **same natural language the request was given in**; if the user wrote in Czech, report and dispatch in Czech, and record that language in the shared brief so the whole `metis → talos → argos` chain replies in it (see *Shared task brief* → *Language of the dispatch*). Identifiers stay verbatim regardless of the report language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single report.
 
 - **Status:** `Done` (converged: 0 Critical / 0 Moderate) — `Analysis done` when the run was analysis-only and stopped at the plan artifact — or `Blocked` with the reason when the run stopped short.
 - **Source:** link to the resolved tracker item, or a one-line restatement of the described task.

--- a/agents/metis.md
+++ b/agents/metis.md
@@ -30,7 +30,7 @@ When the caller passes a **shared brief path** (`.claude/run/<source-slug>.md`),
 
 Your final message is returned to the caller as the result, so make it a clean handoff:
 
-**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). **When the caller passed a shared brief, its recorded `## Language` field is the authoritative source — reply in that language** rather than re-guessing it from the prompt. Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
 
 - **Status:** `Analysis done`.
 - **Plan:** link to the published plan-artifact issue.

--- a/agents/talos.md
+++ b/agents/talos.md
@@ -29,7 +29,7 @@ When the caller passes a **shared brief path** (`.claude/run/<source-slug>.md`),
 
 Your final message is returned to the caller as the result, so make it a clean handoff:
 
-**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
+**Language:** write this handoff — and any end-user report — in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). **When the caller passed a shared brief, its recorded `## Language` field is the authoritative source — reply in that language** rather than re-guessing it from the prompt. Identifiers stay verbatim regardless of that language: branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated. Never mix two natural languages inside a single handoff.
 
 - **Status:** `Impl done` — or `Blocked: sandbox denied file write` when the environment refused your `Write` / `Edit` (see *How to run* step 2).
 - **PR:** link to the pull request that was opened.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -100,6 +100,8 @@ An agent's final message is returned to the caller as the tool result, so it mus
 
 **Language of the handoff / report.** Every agent writes the human-facing prose of its handoff and any end-user report in the **same natural language the assignment was given in** (if the request came in Czech, the handoff is in Czech). Identifiers stay verbatim regardless of that language — branch names, ticket / issue keys, links, severity labels, CLI commands, and skill / agent names are never translated, and two natural languages are never mixed inside a single handoff.
 
+**How the language survives delegation.** When `daidalos` orchestrates, the assignment's natural language is not re-guessed at each hop — `daidalos` records it once in the shared brief's `## Language` field, writes every `Task` dispatch prompt in that language, and each specialist takes the brief's `## Language` field as the authoritative source for its reply. So a Czech request produces Czech output through the whole `metis → talos → argos` chain, not just in `daidalos`'s own final report.
+
 ## Shared task brief (inter-agent memory)
 
 The handoff above is the *return* channel. For the *forward* channel — passing context **into** each agent efficiently — `daidalos` writes a **shared task brief** that every dispatched specialist reads, so the run's data is gathered once instead of re-derived by each agent.


### PR DESCRIPTION
## Proč

Každý agent už psal svůj handoff/report v jazyce zadání, ale při orchestraci přes `daidalos` se jazyk nikam nepředával — specialista (`metis`/`talos`/`argos`) ho musel pokaždé odhadovat z dispatch promptu. Zadání: výstup v Claude Code CLI má být **vždy** v jazyce zadání, **včetně delegace úkolu od daidalose**.

## Co se změnilo

- **daidalos** — během gather fáze zaznamená jazyk zadání do shared briefu (`## Language`), každý `Task` dispatch prompt píše v tomto jazyce a specialistovi řekne, ať v něm odpovídá. Language sekce výstupu nově pokrývá i dispatch prompty.
- **metis / talos / argos / apollon** — pole `## Language` ve shared briefu berou jako **autoritativní zdroj** jazyka odpovědi místo odhadu z promptu.
- **docs/agents.md** — popsáno, jak jazyk přežije delegaci skrz celý řetězec `metis → talos → argos`.

Identifikátory (branch names, ticket/issue keys, odkazy, severity labels, CLI příkazy, názvy skillů/agentů) zůstávají beze změny bez ohledu na jazyk.

## Ověření

`composer build` — 267 passed (1427 assertions), coverage 100 %.