### PR TITLE
docs(memory): record agent-file-vs-registration lesson from #628

### DIFF
--- a/docs/memory/PROJECT_MEMORY.md
+++ b/docs/memory/PROJECT_MEMORY.md
@@ -1,0 +1,8 @@
+# Project memory — cursor-rules
+
+### agent-file-vs-registration — Adding agents/<name>.md does not make the agent dispatchable
+
+- Trigger: a daidalos run tries to dispatch a newly documented agent (e.g. `apollon`) via the Task tool, or any orchestrator step assumes a new `agents/<name>.md` entry is immediately executable as a subagent.
+- Rule:    An `agents/<name>.md` file is documentation only. For an agent to be dispatchable in Claude tooling the agent type must also be installed/registered (the installer syncs copies into `.claude/`). Until that happens, the agent cannot be spawned and the orchestrator must fall back to available registered agents or treat the step as blocked. Document the dependency explicitly in the agent's own file and in the issue that introduces the agent.
+- Example: `agents/apollon.md` was added in #628; daidalos correctly noted "agent type `apollon` is not registered in this environment" and continued with `metis / talos / argos`. The push-level gate becomes effective only after `apollon` is installed.
+- Source:  https://github.com/pekral/cursor-rules/pull/633   Added: 2026-06-20


### PR DESCRIPTION
## Summary

- Creates `docs/memory/PROJECT_MEMORY.md` (first entry in the project compound memory).
- Records the non-obvious lesson that adding `agents/<name>.md` is documentation only — the agent is not dispatchable until installed/registered via the installer.
- Surfaced in the #628 daidalos run when `apollon` could not be dispatched despite its definition existing in `agents/apollon.md`.

## Why a separate PR

The memory file is a write-only artifact (`record-project-memory` skill constraint). Keeping it separate from PR #633 (which introduced `apollon`) keeps the diff scopes clean and lets this entry serve future runs independent of that feature PR's merge status.

## Build gate

- `composer build`: 273 tests passed, 100% coverage, PHPStan 0 errors.
- `composer skill-check`: 0 errors, 4 pre-existing warnings (unrelated to this diff).

## Related

- Issue: https://github.com/pekral/cursor-rules/issues/628
- Feature PR: https://github.com/pekral/cursor-rules/pull/633