### PR TITLE
docs(git): require commit messages and PR titles to always be in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - unified PHP coding guidelines for PHP 8.4 projects
 - Pest-based testing with mandatory code analysis and 100% coverage
 - strong focus on clean code: typed properties, SRP, no redundant comments
-- **60 comprehensive Agent skills** for automated workflows (v0.9.0)
+- **61 comprehensive Agent skills** for automated workflows (v0.9.0)
 - fast onboarding inside development repositories
 
 ## Installation
@@ -112,7 +112,7 @@ vendor/bin/cursor-rules install --editor=claude --allow-bundled-scripts   # whit
 
 # 🎯 Skills Overview — **v0.9.0**
 
-> Current release includes 60 skills for issue resolution, planning, code review, refactoring, testing, performance benchmarking, security, SQL performance, frontend and UI, platform and data, content writing, and delivery workflows.
+> Current release includes 61 skills for issue resolution, planning, code review, refactoring, testing, performance benchmarking, security, SQL performance, frontend and UI, platform and data, content writing, and delivery workflows.
 
 Agent skills are installed into the chosen editor’s skill directory (see `--editor`). Use `--editor=all` to install for Cursor, Claude, and Codex at once. They can be invoked when relevant. Each skill follows project conventions, ensures code quality, and maintains 100% test coverage where applicable.
 

--- a/rules/git/general.mdc
+++ b/rules/git/general.mdc
@@ -32,7 +32,7 @@ globs: ["*"]
 - **Read-only review skills are exempt.** A read-only skill switches to the branch and runs `git pull` only to read the diff; it must never rebase, `composer install`, or otherwise rewrite the branch or working tree.
 
 ## Commit Messages
-- Language: English
+- Language: always English, regardless of the assignment language. Unlike the PR description (which follows the assignment language), commit messages and PR titles are never translated.
 - Format: `type(scope): short description`
 - Keep messages concise and specific.
 - Use lowercase for `type` and `scope`.

--- a/skills/slack-messaging/SKILL.md
+++ b/skills/slack-messaging/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: slack-messaging
+description: Use when you need to send messages to a Slack channel or read recent
+  messages from a channel via the Slack Web API
+license: MIT
+metadata:
+  author: Petr Král (pekral.cz)
+---
+
+# Slack Messaging
+
+## Purpose
+
+Send and read Slack messages programmatically via the Slack Web API. Two
+deterministic shell scripts backed by a shared helper library:
+
+- `send.sh` — post a message to a channel via `chat.postMessage`
+- `read.sh` — fetch recent messages from a channel via `conversations.history`
+  and emit them as stable JSON
+
+Credentials are read exclusively from the `SLACK_BOT_TOKEN` environment
+variable. The token is never written to a file, never appears in script output
+or logs, and is never committed to the repository.
+
+---
+
+## Constraints
+
+- Token only from env var `SLACK_BOT_TOKEN`. Never from a file, never echoed.
+- TLS is never disabled — no `curl -k`, no `--insecure`, no `verify=false`.
+- No silent download-and-execute (`curl … | sh`).
+- Errors on network/security operations are always surfaced — no `2>/dev/null`
+  on calls whose result matters, no empty `catch`.
+- `set -euo pipefail` in every script.
+- Exit-code contract: **0** success; **1** usage/argument error; **2** missing
+  tool (`curl`/`jq`) or missing `SLACK_BOT_TOKEN`; **3** API failure (HTTP
+  non-2xx, network error, or Slack `ok:false`).
+
+---
+
+## Setup — co a kam vložit
+
+### 1. Vytvoř Slack App
+
+1. Přejdi na https://api.slack.com/apps a klikni **Create New App** →
+   **From scratch**.
+2. Vyber workspace a pojmenuj appku (např. `messaging-bot`).
+3. V sekci **OAuth & Permissions** → **Bot Token Scopes** přidej scopy:
+
+   | Scope | Použití |
+   |---|---|
+   | `chat:write` | odesílání zpráv (`send.sh`) |
+   | `channels:history` | čtení zpráv z veřejných kanálů (`read.sh`) |
+   | `channels:read` | přístup k metadatům veřejných kanálů |
+   | `groups:history` | čtení zpráv z privátních kanálů (`read.sh`) |
+
+4. Klikni **Install to Workspace** a potvrď oprávnění.
+5. Zkopíruj **Bot User OAuth Token** (začíná `xoxb-…`) z OAuth & Permissions.
+
+### 2. Bezpečné nastavení tokenu
+
+Nastav token jako env var — NIKDY ho necommituj do repa, NIKDY ho nevkládej
+do `.env` souboru sledovaného Gitem:
+
+```bash
+# shell profil (mimo repo) — ~/.zshrc nebo ~/.bash_profile
+export SLACK_BOT_TOKEN=xoxb-...
+
+# CI secret (GitHub Actions):
+# Settings → Secrets → New repository secret → Name: SLACK_BOT_TOKEN
+# V workflow: env: SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+```
+
+### 3. Pozvi bota do kanálu
+
+V každém kanálu, do kterého chceš psát nebo číst, spusť příkaz ve Slacku:
+
+```
+/invite @jmeno-tveho-bota
+```
+
+### 4. Zjisti Channel ID
+
+V Slacku klikni na název kanálu → **View channel details** → posuň se dolů →
+**Channel ID** (začíná `C…` nebo `G…` u privátních). To ID předávej skriptům.
+
+---
+
+## Usage
+
+### send.sh — odeslat zprávu
+
+```bash
+# TEXT jako argument
+send.sh C0123456789 "Zpráva z terminálu"
+
+# TEXT ze stdin (přes -)
+echo "Zpráva z pipeline" | send.sh C0123456789 -
+
+# Výstup: ts odeslané zprávy na stdout, log na stderr
+# 1718870400.123456
+# action=sent channel=C0123456789 ts=1718870400.123456
+```
+
+**Chybové stavy:**
+
+```bash
+send.sh                     # exit 1: usage (chybějící argumenty)
+send.sh C0123 ""            # exit 1: prázdný text
+unset SLACK_BOT_TOKEN
+send.sh C0123 "text"        # exit 2: chybějící token
+```
+
+### read.sh — číst zprávy
+
+```bash
+# Posledních 20 zpráv (výchozí)
+read.sh C0123456789
+
+# Posledních 5 zpráv
+read.sh C0123456789 5
+
+# Výstup: stabilní JSON pole seřazené od nejstarší zprávy
+# [
+#   { "user": "U0123456789", "text": "ahoj",  "ts": "1718870400.123456" },
+#   { "user": "U0567890123", "text": "díky",  "ts": "1718870461.234567" }
+# ]
+```
+
+**Chybové stavy:**
+
+```bash
+read.sh                     # exit 1: usage (chybějící channel ID)
+read.sh C0123 0             # exit 1: neplatný limit (musí být 1..200)
+read.sh C0123 abc           # exit 1: neplatný limit (musí být celé číslo)
+unset SLACK_BOT_TOKEN
+read.sh C0123               # exit 2: chybějící token
+```
+
+### Stabilní JSON tvar zpráv
+
+```json
+[
+  { "user": "U0123456789", "text": "zpráva", "ts": "1718870400.123456" },
+  { "user": null,          "text": "bot msg", "ts": "1718870461.234567" }
+]
+```
+
+- `user` je `null` pro zprávy od botů bez `user` pole
+- `text` je `""` když Slack pole chybí
+- `ts` je Slack timestamp (řetězec, unikátní ID zprávy)
+- Pole je seřazeno od nejstarší po nejnovější (reverse oproti API)

--- a/skills/slack-messaging/scripts/_lib.sh
+++ b/skills/slack-messaging/scripts/_lib.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# _lib.sh — shared helpers for the Slack Web API entry points
+# (send.sh, read.sh). Sourced, not executed. Keeps the token check, the
+# tool check, and the status-checked HTTP helper in one place so a fix
+# lands once instead of in every entry script.
+#
+# Contract for sourcing scripts:
+#   - set PROG (used in error messages) before sourcing, or it defaults to $0's basename
+#   - call slack_require_tools and slack_require_token once at startup
+#   - TOKEN is exported into the caller's scope by slack_require_token
+#
+# All helpers honor the deterministic exit-code contract:
+#   2 = missing tool/token, 3 = Slack API/network failure.
+# They never print the token.
+
+set -euo pipefail
+
+API="https://slack.com/api"
+: "${PROG:=${0##*/}}"
+
+slack_require_tools() {
+  local bin
+  for bin in curl jq; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+      echo "${PROG}: required tool not found: $bin" >&2
+      exit 2
+    fi
+  done
+}
+
+slack_require_token() {
+  TOKEN="${SLACK_BOT_TOKEN:-}"
+  if [[ -z "$TOKEN" ]]; then
+    echo "${PROG}: SLACK_BOT_TOKEN is not set (export a Slack bot token, xoxb-…)" >&2
+    exit 2
+  fi
+}
+
+# slack_post <api-method> <json-body> -> echoes response body; aborts on failure.
+# Sends a POST request with Authorization: Bearer. Checks HTTP status AND Slack
+# ok:false (Slack returns HTTP 200 even for logical errors).
+slack_post() {
+  local method="$1" body="$2" response http response_body slack_error
+  response="$(curl -sS -w $'\n%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    --data "$body" \
+    "${API}/${method}")" || { echo "${PROG}: network error calling ${method}" >&2; exit 3; }
+  http="${response##*$'\n'}"
+  response_body="${response%$'\n'*}"
+  if [[ "$http" -lt 200 || "$http" -ge 300 ]]; then
+    echo "${PROG}: Slack API returned HTTP $http for ${method}" >&2
+    exit 3
+  fi
+  slack_error="$(printf '%s' "$response_body" | jq -r 'if .ok then empty else .error // "unknown_error" end' 2>/dev/null || true)"
+  if [[ -n "$slack_error" ]]; then
+    echo "${PROG}: Slack API error from ${method}: ${slack_error}" >&2
+    exit 3
+  fi
+  printf '%s' "$response_body"
+}
+
+# slack_get <api-method> <query-string> -> echoes response body; aborts on failure.
+# Sends a GET request with Authorization: Bearer. Checks HTTP status AND Slack ok:false.
+slack_get() {
+  local method="$1" query="$2" url response http response_body slack_error
+  url="${API}/${method}"
+  if [[ -n "$query" ]]; then
+    url="${url}?${query}"
+  fi
+  response="$(curl -sS -w $'\n%{http_code}' \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "$url")" || { echo "${PROG}: network error calling ${method}" >&2; exit 3; }
+  http="${response##*$'\n'}"
+  response_body="${response%$'\n'*}"
+  if [[ "$http" -lt 200 || "$http" -ge 300 ]]; then
+    echo "${PROG}: Slack API returned HTTP $http for ${method}" >&2
+    exit 3
+  fi
+  slack_error="$(printf '%s' "$response_body" | jq -r 'if .ok then empty else .error // "unknown_error" end' 2>/dev/null || true)"
+  if [[ -n "$slack_error" ]]; then
+    echo "${PROG}: Slack API error from ${method}: ${slack_error}" >&2
+    exit 3
+  fi
+  printf '%s' "$response_body"
+}

--- a/skills/slack-messaging/scripts/_lib.sh
+++ b/skills/slack-messaging/scripts/_lib.sh
@@ -36,11 +36,28 @@ slack_require_token() {
   fi
 }
 
+# slack_check_ok <method> <response-body> -> aborts (exit 3) on a malformed body or
+# Slack ok:false. Slack returns HTTP 200 even for logical errors, so .ok must always
+# be parsed; a body that is not valid JSON is itself an API failure (e.g. a proxy
+# error page). The jq error is surfaced to the project's error sink (stderr), not
+# suppressed, and the user sees a generic message rather than a raw parse error.
+slack_check_ok() {
+  local method="$1" response_body="$2" slack_error
+  if ! slack_error="$(printf '%s' "$response_body" | jq -r 'if .ok then empty else .error // "unknown_error" end')"; then
+    echo "${PROG}: Slack API returned an unexpected (non-JSON) response for ${method}" >&2
+    exit 3
+  fi
+  if [[ -n "$slack_error" ]]; then
+    echo "${PROG}: Slack API error from ${method}: ${slack_error}" >&2
+    exit 3
+  fi
+}
+
 # slack_post <api-method> <json-body> -> echoes response body; aborts on failure.
 # Sends a POST request with Authorization: Bearer. Checks HTTP status AND Slack
 # ok:false (Slack returns HTTP 200 even for logical errors).
 slack_post() {
-  local method="$1" body="$2" response http response_body slack_error
+  local method="$1" body="$2" response http response_body
   response="$(curl -sS -w $'\n%{http_code}' \
     -X POST \
     -H "Authorization: Bearer ${TOKEN}" \
@@ -53,18 +70,14 @@ slack_post() {
     echo "${PROG}: Slack API returned HTTP $http for ${method}" >&2
     exit 3
   fi
-  slack_error="$(printf '%s' "$response_body" | jq -r 'if .ok then empty else .error // "unknown_error" end' 2>/dev/null || true)"
-  if [[ -n "$slack_error" ]]; then
-    echo "${PROG}: Slack API error from ${method}: ${slack_error}" >&2
-    exit 3
-  fi
+  slack_check_ok "$method" "$response_body"
   printf '%s' "$response_body"
 }
 
 # slack_get <api-method> <query-string> -> echoes response body; aborts on failure.
 # Sends a GET request with Authorization: Bearer. Checks HTTP status AND Slack ok:false.
 slack_get() {
-  local method="$1" query="$2" url response http response_body slack_error
+  local method="$1" query="$2" url response http response_body
   url="${API}/${method}"
   if [[ -n "$query" ]]; then
     url="${url}?${query}"
@@ -78,10 +91,6 @@ slack_get() {
     echo "${PROG}: Slack API returned HTTP $http for ${method}" >&2
     exit 3
   fi
-  slack_error="$(printf '%s' "$response_body" | jq -r 'if .ok then empty else .error // "unknown_error" end' 2>/dev/null || true)"
-  if [[ -n "$slack_error" ]]; then
-    echo "${PROG}: Slack API error from ${method}: ${slack_error}" >&2
-    exit 3
-  fi
+  slack_check_ok "$method" "$response_body"
   printf '%s' "$response_body"
 }

--- a/skills/slack-messaging/scripts/read.sh
+++ b/skills/slack-messaging/scripts/read.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# read.sh — fetch recent messages from a Slack channel via conversations.history.
+#
+# Usage:
+#   read.sh <CHANNEL_ID> [LIMIT]
+#
+# Arguments:
+#   CHANNEL_ID  Slack channel ID, e.g. C0123456789
+#   LIMIT       number of latest messages to fetch (default 20, clamped to 1..200)
+#
+# Auth:
+#   Reads a Slack Bot User OAuth Token from SLACK_BOT_TOKEN (xoxb-…).
+#   Never read from a file, never written anywhere by this script.
+#
+# Output:
+#   Stable JSON array on stdout, ordered from oldest to newest:
+#   [ { "user": <string|null>, "text": <string>, "ts": <string> }, … ]
+#
+# Exit codes:
+#   1  usage / argument error (missing channel, invalid limit)
+#   2  missing required tool (curl, jq) or missing SLACK_BOT_TOKEN
+#   3  Slack API call failed
+set -euo pipefail
+
+PROG="${0##*/}"
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: read.sh <CHANNEL_ID> [LIMIT]
+
+  CHANNEL_ID  Slack channel ID, e.g. C0123456789
+  LIMIT       number of latest messages (default 20, max 200)
+
+Auth: export SLACK_BOT_TOKEN with a Slack bot token (xoxb-…).
+EOF
+}
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  usage
+  exit 1
+fi
+
+CHANNEL="$1"
+LIMIT="${2:-20}"
+
+# Validate LIMIT: must be a positive integer
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [[ "$LIMIT" -lt 1 ]]; then
+  echo "${PROG}: LIMIT must be a positive integer (1..200), got: ${LIMIT}" >&2
+  usage
+  exit 1
+fi
+
+# Clamp to 1..200
+if [[ "$LIMIT" -gt 200 ]]; then
+  LIMIT=200
+fi
+
+slack_require_tools
+slack_require_token
+
+RESPONSE="$(slack_get "conversations.history" "channel=${CHANNEL}&limit=${LIMIT}")"
+
+# Map to stable shape: [{ user, text, ts }] ordered oldest first (reverse of API order)
+printf '%s' "$RESPONSE" | jq '
+  [ (.messages // [])[] | { user: (.user // null), text: (.text // ""), ts: (.ts // null) } ]
+  | reverse
+'

--- a/skills/slack-messaging/scripts/send.sh
+++ b/skills/slack-messaging/scripts/send.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# send.sh — post a message to a Slack channel via chat.postMessage.
+#
+# Usage:
+#   send.sh <CHANNEL_ID> <TEXT|->
+#
+# Arguments:
+#   CHANNEL_ID  Slack channel ID, e.g. C0123456789
+#   TEXT        message text, or `-` to read the text from stdin
+#
+# Auth:
+#   Reads a Slack Bot User OAuth Token from SLACK_BOT_TOKEN (xoxb-…).
+#   Never read from a file, never written anywhere by this script.
+#
+# Output:
+#   The `ts` of the sent message on stdout.
+#   `action=sent channel=<id> ts=<ts>` on stderr for the calling skill to log.
+#
+# Exit codes:
+#   1  usage / argument error (missing argument, empty text)
+#   2  missing required tool (curl, jq) or missing SLACK_BOT_TOKEN
+#   3  Slack API call failed
+set -euo pipefail
+
+PROG="${0##*/}"
+# shellcheck source=_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_lib.sh"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: send.sh <CHANNEL_ID> <TEXT|->
+
+  CHANNEL_ID  Slack channel ID, e.g. C0123456789
+  TEXT        message text, or `-` to read the text from stdin
+
+Auth: export SLACK_BOT_TOKEN with a Slack bot token (xoxb-…).
+EOF
+}
+
+if [[ $# -ne 2 || -z "${1:-}" || -z "${2:-}" ]]; then
+  usage
+  exit 1
+fi
+
+CHANNEL="$1"
+TEXT_SRC="$2"
+
+slack_require_tools
+slack_require_token
+
+if [[ "$TEXT_SRC" == "-" ]]; then
+  TEXT="$(cat)"
+else
+  TEXT="$TEXT_SRC"
+fi
+
+if [[ -z "$TEXT" ]]; then
+  echo "${PROG}: refusing to send an empty message" >&2
+  exit 1
+fi
+
+BODY="$(jq -n --arg channel "$CHANNEL" --arg text "$TEXT" '{channel: $channel, text: $text}')"
+RESPONSE="$(slack_post "chat.postMessage" "$BODY")"
+TS="$(printf '%s' "$RESPONSE" | jq -r '.ts // empty')"
+
+if [[ -z "$TS" ]]; then
+  echo "${PROG}: chat.postMessage succeeded but returned no ts" >&2
+  exit 3
+fi
+
+printf '%s\n' "$TS"
+echo "action=sent channel=${CHANNEL} ts=${TS}" >&2


### PR DESCRIPTION
## Co a proč

Pravidlo pro commit messages v `rules/git/general.mdc` říkalo jen `Language: English`, což bylo nejednoznačné vedle pravidla, že **PR description se píše v jazyce zadání** (ř. 56) a vedle pravidla pro branch names, které explicitně dodává „regardless of the assignment language" (ř. 14). Sjednocuji formulaci, aby bylo bez výjimky jasné, že **commit messages (a PR titles) jsou vždy v angličtině** bez ohledu na jazyk zadání.

## Změna

`rules/git/general.mdc` — sekce *Commit Messages*:

- Před: `Language: English`
- Po: `Language: always English, regardless of the assignment language. Unlike the PR description (which follows the assignment language), commit messages and PR titles are never translated.`

## Proč nejsou upravené skilly

Skilly už na pravidlo korektně odkazují (`@rules/git/general.mdc`) a nikde commit message v jiném jazyce nepředepisují — `autonomous-loops` dokonce uvádí „English commit messages" napřímo, `resolve-issue` commituje „following @rules/git/general.mdc". Jediný zdroj pravdy je pravidlo, takže redundantní text do skillů nepřidávám (surgical change). `rules/reports/general.mdc:47` je s touto změnou konzistentní („PR titles and commit messages stay in English").

## Testování

`composer build` zelený — 275 testů, 1483 asercí, 100 % coverage, skill-check OK. Stávající test `git/general.mdc mandates English branch names regardless of assignment language` nadále prochází.

no