### PR TITLE
feat(agents): athena uses the Claude Fable 5 model

### DIFF
--- a/agents/athena.md
+++ b/agents/athena.md
@@ -2,7 +2,7 @@
 name: athena
 description: Use when security needs a dedicated specialist in one of two modes — a pre-implementation **security-risk analysis** of a security-focused task (dispatched on demand by daidalos when the task carries a cyber-security question, before talos implements) or a post-implementation **security review** of a pull request or diff (dispatched after talos, in parallel with argos). Runs all security skills (security-review, laravel-security, security-bounty-hunter, security-threat-analysis) and applies all security rules, marks Critical/Moderate/Minor findings, and hands back a "Security analysis done" or "Security CR done" handoff with counts to the caller (typically daidalos or argos), which passes the findings to the agents that need them. Read-only — never edits, commits, pushes, or merges.
 tools: Read, Glob, Grep, Bash
-model: opus
+model: fable
 ---
 
 You are **Athéna** — the strategic security sentinel. Named after **Athena**, goddess of wisdom and strategic defence, and daughter of Metis. You own the **security domain end to end, in two modes**: (1) a pre-implementation **security-risk analysis** that scopes a security-focused task and leaves a remediation plan `talos` can implement, dispatched on demand when the assignment carries a cyber-security question; and (2) a post-implementation **security code review** over a pull request or diff that reports all security findings, dispatched after `talos` in parallel with `argos`. You are **read-only**: never edit the working tree, never commit, push, or merge, and never apply fixes — `talos` implements what you analyse, `argos` consolidates what you review, and the caller passes your findings to the agents that need them.

--- a/tests/InstallerTest.php
+++ b/tests/InstallerTest.php
@@ -4358,7 +4358,7 @@ test('agents directory ships the athena security-CR subagent with required front
     $content = (string) file_get_contents($agentPath);
     expect($content)->toContain('name: athena');
     expect($content)->toContain('tools: Read, Glob, Grep, Bash');
-    expect($content)->toContain('model: opus');
+    expect($content)->toContain('model: fable');
     expect($content)->toContain('@skills/security-review/SKILL.md');
     expect($content)->toContain('@skills/laravel-security/SKILL.md');
     expect($content)->toContain('@skills/security-bounty-hunter/SKILL.md');


### PR DESCRIPTION
## Shrnutí

Přepíná bezpečnostního agenta `athena` z modelu `opus` na **Claude Fable 5** (alias `fable`, konzistentní s krátkými aliasy `opus` / `sonnet` používanými u ostatních agentů).

## Změny

- **`agents/athena.md`** — frontmatter `model: opus` → `model: fable`.
- **`tests/InstallerTest.php`** — aktualizace assertu na `model: fable` v testu „agents directory ships the athena security-CR subagent with required frontmatter".

## Testování

`composer build` — 278 passed (1499 assertions), coverage 100 %.