### PR TITLE
docs: add public editor compatibility matrix to README (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `cursor-rules` will be documented in this file.
 
 ## [Unreleased]
 
+- ✨ **Added**: public **editor compatibility matrix** in `README.md` documenting support status across editors — Cursor ✅ (rules + skills), Claude ✅ (rules + skills + agents), Codex skills ✅ / rules experimental (unverified until confirmed) (#663).
+
 - 📝 **Changed**: README and `composer.json` package metadata reposition the project explicitly as a PHP/Laravel Composer plugin (installs Cursor/Claude/Codex rules + agent skills), not a generic AI-rules bundle (#662).
 
 ## [0.9.0] - 2026-06-20

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The `--editor` flag is **required**. Use it to choose the target agent:
 - **codex**: `.codex/rules`, `.codex/skills`, and when `HOME`/`USERPROFILE` is set also `~/.codex/skills`
 - **all**: all of the above (Cursor, Claude, Codex in project + home)
 
+### Editor compatibility
+
+| Feature | Cursor | Claude | Codex |
+|---------|--------|--------|-------|
+| Rules | ✅ | ✅ | experimental / unverified |
+| Skills | ✅ | ✅ | ✅ |
+| Agents | — | ✅ | — |
+
+Agents are installed only for `--editor=claude` and `--editor=all`; they are skipped for `cursor` and `codex` because only Claude Code has a native subagent format. Codex rules support is listed as experimental / unverified — the installer copies the files into `.codex/rules`, but native rule loading by Codex has not been confirmed; report your findings in [#663](https://github.com/pekral/cursor-rules/issues/663).
+
 When the package is required via Composer, sources are read from `vendor/pekral/cursor-rules/rules` and `vendor/pekral/cursor-rules/skills`.
 
 **Important:** By default, the installer only copies missing files and keeps existing content untouched. Use the `--force` flag to overwrite existing files: `vendor/bin/cursor-rules install --force`. This is particularly useful when you want to update rules to their latest versions or when you've made local changes that should be replaced. The file `.cursor/rules/project.mdc` and `CLAUDE.md` are never overwritten once they exist in the target project, so you can safely customize them.


### PR DESCRIPTION
## Summary

- Přidává veřejnou **Editor compatibility matrix** do `README.md` hned za sekci Available targets (ř. ~38), která dokumentuje stav podpory napříč editory: Cursor ✅ (rules + skills), Claude ✅ (rules + skills + agents), Codex skills ✅ / rules experimental / unverified.
- Přidává záznam do `CHANGELOG.md` sekce `[Unreleased]` ve formátu projektu s `(#663)`.
- Codex rules jsou označeny jako experimental / unverified — installer soubory kopíruje do `.codex/rules`, ale nativní načítání pravidel Codexem nebylo potvrzeno.
- Agenti jsou dokumentováni jako Claude-only (skipped pro cursor/codex).

Closes #663.

## Test plan

- [x] `composer build` proběhl bez chyb (0 errors, pre-existující warnings v jiných souborech nejsou nové)
- [x] InstallerTest: všechny testy zelené (žádný FAIL)
- [x] Žádné piny z InstallerTest nebyly porušeny (editována pouze sekce mezi bullet body editor targetů, nikoli jejich text)
- [x] CHANGELOG formát odpovídá konvenci projektu