### PR TITLE
docs(security): add SECURITY.md with plugin trust model and installer flag documentation (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `cursor-rules` will be documented in this file.
 
 ## [Unreleased]
 
+- ✨ **Added**: `SECURITY.md` at the repository root (#664) — documents the plugin trust model (`allow-plugins`, the standard Composer opt-in), the two security-sensitive installer flags (`--allow-bundled-scripts` and `--allow-subagent-writes`) with their exact behaviour, safety guarantees, and implementation references (`src/InstallerClaudeSettings.php`), a table of every path the installer writes, and a responsible-disclosure channel (GitHub Security Advisory preferred). Cross-linked with `README.md` (CLI Switches), `docs/agents.md` (Troubleshooting — subagent file writes blocked), and `docs/plans/agent-sandbox-write-blocked.md`.
+
 - ✨ **Added**: public **editor compatibility matrix** in `README.md` documenting support status across editors — Cursor ✅ (rules + skills), Claude ✅ (rules + skills + agents), Codex skills ✅ / rules experimental (unverified until confirmed) (#663).
 
 - 📝 **Changed**: README and `composer.json` package metadata reposition the project explicitly as a PHP/Laravel Composer plugin (installs Cursor/Claude/Codex rules + agent skills), not a generic AI-rules bundle (#662).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,25 @@ composer require pekral/cursor-rules --dev --no-plugins   # skip the plugin duri
 composer config allow-plugins.pekral/cursor-rules true     # then grant trust manually
 ```
 
+### Auto-install hook
+
+Granting `allow-plugins: true` also enables the package's Composer plugin to react to `post-install-cmd` and `post-update-cmd` events. By default the plugin does **nothing** on these events. The auto-install hook is activated only when you add the following opt-in to your project's `composer.json`:
+
+```json
+{
+  "extra": {
+    "cursor-rules": {
+      "auto-install": true,
+      "editor": "claude"
+    }
+  }
+}
+```
+
+When `auto-install` is `true`, every `composer install` or `composer update` automatically runs `Installer::run(['cursor-rules', 'install', '--force', '--editor=<editor>'])` — the same installer that you would call manually, with `--force` and without any opt-in flags (`--allow-bundled-scripts`, `--allow-subagent-writes`). **Security implication:** any package that ships a `post-install-cmd` / `post-update-cmd` hook and is trusted via `allow-plugins` can trigger code execution during a routine `composer install`. Review the `extra.cursor-rules` block in your `composer.json` before enabling `auto-install`, and treat it the same way you treat other Composer script hooks.
+
+See also: [README — Automatic Installation via Composer Plugin](README.md#automatic-installation-via-composer-plugin).
+
 ## Installer security flags
 
 All security-sensitive installer flags are **opt-in by design** — the package grants no additional permissions by default.
@@ -77,7 +96,8 @@ See also: [docs/agents.md — Troubleshooting (subagent file writes blocked)](do
 
 | Path | Created by | Condition |
 |------|-----------|-----------|
-| `~/.claude/settings.json` | `--allow-bundled-scripts` | `--editor=claude` or `--editor=all`; `HOME`/`USERPROFILE` set |
+| `~/.claude/settings.json` — sets `includeCoAuthoredBy: false` | `install` (unconditional) | `--editor=claude` or `--editor=all`; `HOME`/`USERPROFILE` set; key absent — never overwrites an existing value |
+| `~/.claude/settings.json` — adds `permissions.allow` bundled-script entries | `--allow-bundled-scripts` | `--editor=claude` or `--editor=all`; `HOME`/`USERPROFILE` set |
 | `.claude/settings.local.json` | `--allow-subagent-writes` | `--editor=claude` or `--editor=all` |
 | `.cursor/rules/`, `.claude/rules/`, `.codex/rules/` | `install` | always, for the chosen editor |
 | `.cursor/skills/`, `.claude/skills/`, `.codex/skills/` | `install` | always, for the chosen editor |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security
+
+## Plugin trust model
+
+`pekral/cursor-rules` is a **Composer plugin** (`"type": "composer-plugin"`). Composer requires explicit opt-in before running any plugin — including this one — to guard against supply-chain attacks from unknown packages.
+
+### `allow-plugins` in `composer.json`
+
+When you `composer require pekral/cursor-rules`, Composer may ask:
+
+```
+Do you trust "pekral/cursor-rules" to execute code and wish to enable it now? (yes/no)
+```
+
+If you answer `yes`, Composer writes the following entry to your project's `composer.json`:
+
+```json
+{
+  "config": {
+    "allow-plugins": {
+      "pekral/cursor-rules": true
+    }
+  }
+}
+```
+
+This is the **standard Composer plugin-trust mechanism** (`allow-plugins`). It is project-scoped, version-controlled alongside your `composer.json`, and must be deliberately set to `true` by you. The package never modifies `allow-plugins` on its own behalf — you remain in full control of which plugins your project trusts.
+
+If you prefer to give a non-interactive answer (e.g. in CI), you can pass the flag explicitly:
+
+```bash
+composer require pekral/cursor-rules --dev --no-plugins   # skip the plugin during install
+composer config allow-plugins.pekral/cursor-rules true     # then grant trust manually
+```
+
+## Installer security flags
+
+All security-sensitive installer flags are **opt-in by design** — the package grants no additional permissions by default.
+
+### `--allow-bundled-scripts`
+
+**What it does.** When `--editor=claude` or `--editor=all` is used alongside this flag, the installer idempotently appends a narrow allow-list for this package's bundled scripts to `~/.claude/settings.json` (`permissions.allow`):
+
+```
+Bash(*skills/code-review-github/scripts/load-issue.sh:*)
+Bash(*skills/code-review-jira/scripts/load-issue.sh:*)
+```
+
+These two patterns pre-approve the GitHub and JIRA `load-issue.sh` scripts that the `code-review-github` and `code-review-jira` skills invoke, so Claude Code stops prompting for confirmation on every run.
+
+**What it does not do.** It grants access only to the two specific, version-controlled scripts shipped in this package. All other entries in `~/.claude/settings.json` are preserved untouched. The flag has no effect when `--editor=cursor` or `--editor=codex` is used, or when neither `HOME` nor `USERPROFILE` is available.
+
+**Implementation reference.** `src/InstallerClaudeSettings.php` — `applyIfRequested()` → `ensureBundledScriptPermissions()`.
+
+See also: [README — CLI Switches](README.md#cli-switches).
+
+### `--allow-subagent-writes`
+
+**What it does.** When `--editor=claude` or `--editor=all` is used alongside this flag, the installer prepends two scoped permission entries to `permissions.allow` in the project's `.claude/settings.local.json`:
+
+```
+Edit(//<absolute-project-path>/**)
+Write(//<absolute-project-path>/**)
+```
+
+These entries pre-allow dispatched subagents (e.g. `talos`) to write files inside the project tree without requiring an interactive approval on each operation. A dispatched subagent runs non-interactively, so a write is denied at runtime unless the path is already in `permissions.allow`.
+
+**Why `settings.local.json` and not `settings.json`.** The entries carry a machine-absolute path — they are personal and not portable. `settings.local.json` is git-ignored by Claude Code by default, so the absolute path never leaks into version control.
+
+**Safety guarantees.** The flag is idempotent: it only adds missing entries and never removes or modifies existing ones. After writing, the installer reads the file back and validates that every required entry is present (`InstallerClaudeSettings::validateSubagentWritePermissions()`), so a malformed file can never be produced. The package grants nothing by default — this flag is the explicit, human-owned opt-in.
+
+**Implementation reference.** `src/InstallerClaudeSettings.php` — `applySubagentWritesIfRequested()` → `ensureSubagentWritesEnabled()`.
+
+See also: [docs/agents.md — Troubleshooting (subagent file writes blocked)](docs/agents.md#troubleshooting--subagent-file-writes-blocked) and [docs/plans/agent-sandbox-write-blocked.md](docs/plans/agent-sandbox-write-blocked.md).
+
+## Files this package writes
+
+| Path | Created by | Condition |
+|------|-----------|-----------|
+| `~/.claude/settings.json` | `--allow-bundled-scripts` | `--editor=claude` or `--editor=all`; `HOME`/`USERPROFILE` set |
+| `.claude/settings.local.json` | `--allow-subagent-writes` | `--editor=claude` or `--editor=all` |
+| `.cursor/rules/`, `.claude/rules/`, `.codex/rules/` | `install` | always, for the chosen editor |
+| `.cursor/skills/`, `.claude/skills/`, `.codex/skills/` | `install` | always, for the chosen editor |
+| `.claude/agents/` | `install` | `--editor=claude` or `--editor=all` only |
+| `CLAUDE.md` | `install` | `--editor=claude` or `--editor=all`; never overwrites an existing file |
+
+The installer never writes outside the project directory and the user's home directory, and it never modifies `composer.json` or any project source file.
+
+## Reporting a vulnerability
+
+If you discover a security issue in this package, please report it privately so it can be addressed before public disclosure.
+
+**Contact:** open a [GitHub Security Advisory](https://github.com/pekral/cursor-rules/security/advisories/new) (preferred) or email `kral.petr.88@gmail.com`.
+
+Please include a description of the issue, reproduction steps, and the potential impact. You will receive a response within a reasonable time. Public disclosure is coordinated after a fix is available.

--- a/docs/memory/PROJECT_MEMORY.md
+++ b/docs/memory/PROJECT_MEMORY.md
@@ -49,3 +49,11 @@
 - Example: issue #653 assumed `apollon` was documentation-only (per the older `agent-file-vs-registration` entry); by #654 `apollon` was a registered dispatchable agent, so the first implementation missed per-role memory parity for it. Surfaced as 2 Moderate CR findings, fixed in commit `43b6c07`.
 - Role:    shared
 - Source:  https://github.com/pekral/cursor-rules/pull/654   Added: 2026-06-21
+
+### installer-security-doc-source-of-truth — Security docs must enumerate unconditional installer writes, not only opt-in-gated ones
+
+- Trigger: writing or reviewing security / trust-model documentation (SECURITY.md, README CLI Switches, installer trust model) for a PHP Composer installer that also ships a ComposerPlugin; the author describes which files the installer writes and gates all of them behind opt-in CLI flags.
+- Rule:    The source of truth for what the installer writes is `src/Installer.php`, `src/InstallerClaudeSettings.php`, and `src/ComposerPlugin.php` — not the CLI flag list. At minimum two surfaces must be named explicitly: (1) `Installer::install()` calls `applyCoAuthoredByPreference()` unconditionally for `--editor=claude|all`, writing `includeCoAuthoredBy: false` into `~/.claude/settings.json` when the key is absent (never overwrites); (2) `allow-plugins: true` in `composer.json` unlocks the `ComposerPlugin` `post-install-cmd` / `post-update-cmd` hook which, when `extra.cursor-rules.auto-install: true` is set, runs the installer with `--force` on every `composer install` / `composer update` — a code-execution surface not gated behind any explicit user invocation. Omitting either surface lets a CR flag it as Critical (home-dir write) or Moderate (auto-install hook).
+- Example: PR #672 (issue #664) introduced SECURITY.md that gated all home-dir writes behind opt-in flags; argos found the unconditional `includeCoAuthoredBy` write (Critical) and the `allow-plugins` auto-install hook (Moderate) were missing. Source references: `src/Installer.php:91`, `src/InstallerClaudeSettings.php:60-95`, `src/ComposerPlugin.php:43-69`.
+- Source:  https://github.com/pekral/cursor-rules/pull/672   Added: 2026-06-22
+- Role:    shared


### PR DESCRIPTION
## Summary

- Adds `/SECURITY.md` — a new root-level security document for the `pekral/cursor-rules` Composer plugin.
- Documents the Composer `allow-plugins` plugin trust mechanism (opt-in per project, human-controlled).
- Documents `--allow-bundled-scripts` and `--allow-subagent-writes` installer flags with exact behaviour, safety guarantees, and references to `src/InstallerClaudeSettings.php` as the source of truth.
- Includes a table of every path the installer may write, and a responsible-disclosure channel (GitHub Security Advisory preferred).
- Cross-links with `README.md` (CLI Switches), `docs/agents.md` (Troubleshooting — subagent file writes blocked), and `docs/plans/agent-sandbox-write-blocked.md`.
- Adds CHANGELOG entry under `[Unreleased]` following existing convention.

## Test plan

- [ ] `composer build` passes: 280 tests, 100% coverage, 0 PHPStan errors, 0 skill-check errors.
- [ ] `SECURITY.md` exists at repo root and contains the four major sections: plugin trust model, `--allow-bundled-scripts`, `--allow-subagent-writes`, files written, and reporting channel.
- [ ] All flag descriptions match the actual behaviour in `src/InstallOptions.php` and `src/InstallerClaudeSettings.php` — no hallucinated flags or paths.
- [ ] No pinned prose in `tests/InstallerTest.php` was modified.
- [ ] CHANGELOG entry follows existing format and references `#664`.

Closes #664