### PR TITLE
feat(#668): Clever Athena — Laravel Security Audit workflow (7 areas)

### DIFF
--- a/agents/athena.md
+++ b/agents/athena.md
@@ -29,7 +29,7 @@ Both modes run the same four security skills and the same security rules; they d
 When dispatched to analyse a security-focused task before any code is written, you scope the security risk and leave a plan `talos` can pick up cold — you do **not** review an existing diff here.
 
 1. **Detect the subject** using `@skills/resolve-issue/references/source-detection.md` and the deterministic loaders (read-only) — or take the described task / current context when no tracker is given.
-2. **Analyse the security risk through the four security skills as analysis lenses** — `@skills/security-review/SKILL.md`, `@skills/laravel-security/SKILL.md` (skip gracefully when not a Laravel app), `@skills/security-bounty-hunter/SKILL.md`, `@skills/security-threat-analysis/SKILL.md` — and apply the security rules (`@rules/security/backend.md`, `@rules/security/frontend.md`, `@rules/security/mobile.md`) as the cross-cutting lens. Identify the attack surface, the concrete threat(s), and the affected code, severity-labelled (`Critical` / `Moderate` / `Minor`). Do not re-implement any skill — defer to it as the source of truth.
+2. **Analyse the security risk through the four security skills as analysis lenses** — `@skills/security-review/SKILL.md`, `@skills/laravel-security/SKILL.md` (skip gracefully when not a Laravel app; when auditing an existing Laravel app, run the full 7-area Laravel Security Audit workflow via `@skills/laravel-security/references/audit-workflow.md`), `@skills/security-bounty-hunter/SKILL.md`, `@skills/security-threat-analysis/SKILL.md` — and apply the security rules (`@rules/security/backend.md`, `@rules/security/frontend.md`, `@rules/security/mobile.md`) as the cross-cutting lens. Identify the attack surface, the concrete threat(s), and the affected code, severity-labelled (`Critical` / `Moderate` / `Minor`). Do not re-implement any skill — defer to it as the source of truth.
 3. **Frame the smallest safe remediation** by running `@skills/analyze-problem/SKILL.md` over the security findings — Goal, Architecture, Implementation steps, Sources, Success criteria — so `talos` can implement without re-deriving the threat model. Do not duplicate the skill; defer to it.
 4. **Publish the plan artifact as a GitHub issue** (via `gh`), carrying the security-risk analysis and the remediation plan, so `talos` (and a later run) can pick it up cold. Do not write files into the repository or mutate the working tree — the plan lives on the tracker, keeping you read-only with respect to code.
 5. **Hand back `Security analysis done`** with the plan link and the Critical / Moderate / Minor counts. `talos` implements next; the caller passes your analysis to the agents that need it. You do not implement.
@@ -40,7 +40,7 @@ When dispatched to analyse a security-focused task before any code is written, y
 
 2. **Run all security skills in sequence over the resolved diff:**
    - `@skills/security-review/SKILL.md` — the core security review pass.
-   - `@skills/laravel-security/SKILL.md` — Laravel-specific security patterns (skip gracefully when the project is not a Laravel app).
+   - `@skills/laravel-security/SKILL.md` — Laravel-specific security patterns (skip gracefully when the project is not a Laravel app; when auditing an existing app, extend with the 7-area workflow via `@skills/laravel-security/references/audit-workflow.md`).
    - `@skills/security-bounty-hunter/SKILL.md` — bug-bounty style, attacker-mindset sweep.
    - `@skills/security-threat-analysis/SKILL.md` — threat-modelling and attack-surface analysis.
 

--- a/skills/laravel-security/SKILL.md
+++ b/skills/laravel-security/SKILL.md
@@ -407,6 +407,10 @@ SecurityLogger::log('role_change', ['target_user' => $targetId, 'new_role' => 'a
 | Security event logging | Audit auth failures, role changes, suspicious activity |
 | `.env` not committed | Verify `.gitignore` includes `.env` |
 
+## Laravel Security Audit
+
+When auditing an existing Laravel application (instead of building new features), use `@skills/laravel-security/references/audit-workflow.md`. It covers the 7 audit areas — Authorization/IDOR/BOLA, Authentication, Validation, XSS, File upload, Secrets/configuration, Dependencies — with severity mapping (Critical/High/Medium/Low/Info → CR scale Critical/Moderate/Minor), Grep patterns, and a required regression-test sketch per confirmed finding. The building blocks in this file (Production Configuration, Authentication, Authorization, Eloquent Security, CSRF, XSS Prevention, Input Validation, File Upload Security, Secrets and Dependencies) are the reference fixes the audit workflow links back to.
+
 ## Done when
 - The relevant secure default is applied and matches the project's existing style
 - No secret is hardcoded; required config/secrets are validated at boot

--- a/skills/laravel-security/references/audit-workflow.md
+++ b/skills/laravel-security/references/audit-workflow.md
@@ -4,7 +4,7 @@ Defenzivní bezpečnostní auditor v autorizovaném prostředí. Cílem je nají
 
 ## Severity škála
 
-Auditní reportování používá 5 stupňů; konvergenční brána repo (CR) mapuje na 3 stupně:
+Auditní reportování používá 5 stupňů; konvergenční brána repo (CR) mapuje na 3 stupně (High+Medium splývají do Moderate, Low+Info splývají do Minor):
 
 | Auditní severity | CR severity | Blokuje konvergenci? |
 |------------------|-------------|----------------------|
@@ -39,7 +39,7 @@ Piny athena.md (`Critical`/`Moderate`/`Minor`) zůstávají beze změny — audi
 **Vzory Grep:**
 
 ```bash
-grep -rn "Post::find\|Model::find" app/Http/Controllers/
+grep -rn "::find\(\|::findOrFail\(\|::firstOrFail\(" app/Http/Controllers/
 grep -rn "->authorize\|Gate::authorize\|@can" app/ --include="*.php" --include="*.blade.php"
 ```
 
@@ -85,11 +85,12 @@ grep -rn "throttle:" routes/ app/
 ```php
 it('regenerates session on login', function (): void {
     $user = User::factory()->create();
-    $old = session()->getId();
+    $this->get('/login');
+    $guestToken = $this->app['session']->token();
 
-    post('/login', ['email' => $user->email, 'password' => 'password']);
+    $this->post('/login', ['email' => $user->email, 'password' => 'password']);
 
-    expect(session()->getId())->not->toBe($old);
+    expect($this->app['session']->token())->not->toBe($guestToken);
 });
 ```
 
@@ -219,16 +220,20 @@ grep -rn "Log::" app/ --include="*.php" | grep -i "password\|secret\|token"
 **Příklad regresního testu:**
 
 ```php
-it('does not log sensitive fields', function (): void {
+// Cíl: ten konkrétní Log:: řádek, který grep výše odhalí, např.:
+// Log::info('Auth attempt', ['token' => $request->bearerToken(), 'api_key' => $request->input('api_key')]);
+it('does not include secret/token/api_key value in the flagged log call context', function (): void {
     $logs = [];
     Log::listen(static function ($log) use (&$logs): void {
-        $logs[] = json_encode($log->context);
+        $logs[] = $log->context;
     });
 
-    post('/login', ['email' => 'a@b.com', 'password' => 'secret123']);
+    $secret = 'supersecret-' . uniqid();
+    // Nahraď volání endpointu tím, kde grep odhalil Log:: s citlivým klíčem.
+    $this->post('/api/example', ['api_key' => $secret]);
 
-    foreach ($logs as $entry) {
-        expect($entry)->not->toContain('secret123');
+    foreach ($logs as $context) {
+        expect(json_encode($context))->not->toContain($secret);
     }
 });
 ```

--- a/skills/laravel-security/references/audit-workflow.md
+++ b/skills/laravel-security/references/audit-workflow.md
@@ -1,0 +1,282 @@
+# Laravel Security Audit Workflow
+
+Defenzivní bezpečnostní auditor v autorizovaném prostředí. Cílem je najít a nahlásit slabiny a navrhnout opravu + regresní test — **ne exploitovat**.
+
+## Severity škála
+
+Auditní reportování používá 5 stupňů; konvergenční brána repo (CR) mapuje na 3 stupně:
+
+| Auditní severity | CR severity | Blokuje konvergenci? |
+|------------------|-------------|----------------------|
+| Critical         | Critical    | ANO                  |
+| High             | Moderate    | ANO                  |
+| Medium           | Moderate    | ANO                  |
+| Low              | Minor       | NE                   |
+| Info             | Minor       | NE                   |
+
+Piny athena.md (`Critical`/`Moderate`/`Minor`) zůstávají beze změny — audit severity je reportovací vrstva nad nimi.
+
+## Každý potvrzený nález nese
+
+1. **Oblast** (1–7 níže) + **severity** (Critical/High/Medium/Low/Info).
+2. **Konkrétní soubor + řádek** (nebo vzorec vyhledávání).
+3. **Navrhovaná oprava** — odkazem na příslušnou sekci `@skills/laravel-security/SKILL.md`.
+4. **Návrh regresního testu** (Pest/PHPUnit) — auditor načrtne test, který by nález odhalil; aplikační opravu implementuje `talos`.
+
+## 7 oblastí auditu
+
+### 1. Authorization — IDOR/BOLA
+
+**Co hledat:**
+
+- Chybějící `$this->authorize()` / `Gate::authorize()` / `@can` v controllerech a Livewire komponentách — policy nebo gate pro každý resource endpoint.
+- Přímé dotazy bez scope na aktuálního uživatele: `Post::find($id)` místo `auth()->user()->posts()->findOrFail($id)`.
+- Chybějící Route Model Binding s policy: controller přijme `{post}` a nikdy neověří vlastnictví.
+- Tenant isolation: multi-tenant app bez globálního scope nebo filtrování `tenant_id`.
+- Role bypass: admin route group bez middleware `role:admin`; Filament panel bez `canAccessPanel()`.
+- Livewire actions: mounted component není autorizační hranice — každá action musí znovu volat authorize.
+
+**Vzory Grep:**
+
+```bash
+grep -rn "Post::find\|Model::find" app/Http/Controllers/
+grep -rn "->authorize\|Gate::authorize\|@can" app/ --include="*.php" --include="*.blade.php"
+```
+
+**Referenční oprava:** sekce *Authorization* v `@skills/laravel-security/SKILL.md`.
+
+**Příklad regresního testu:**
+
+```php
+it('prevents accessing another user post', function (): void {
+    $owner = User::factory()->create();
+    $attacker = User::factory()->create();
+    $post = Post::factory()->for($owner)->create();
+
+    $response = actingAs($attacker)->get("/posts/{$post->id}");
+
+    $response->assertForbidden(); // nebo assertNotFound() dle zvolené strategie
+});
+```
+
+---
+
+### 2. Authentication
+
+**Co hledat:**
+
+- Chybějící rate limiting na `/login`, `/forgot-password`, `/register` — viz sekce *API Security* (RateLimiter).
+- Session fixation: `$request->session()->regenerate()` chybí po úspěšném přihlášení.
+- Logout: session není invalidována (`invalidate()` + `regenerateToken()`) nebo token není revokován.
+- Přístup deaktivovaných uživatelů: `Authenticatable::banned/is_active` není kontrolováno po přihlášení (event `Authenticated` nebo middleware `EnsureUserIsActive`).
+- Reset hesla: tokenová platnost; žetony nejsou jednorázové nebo mají příliš dlouhou expiraci.
+
+**Vzory Grep:**
+
+```bash
+grep -rn "session()->regenerate\b" app/
+grep -rn "throttle:" routes/ app/
+```
+
+**Referenční oprava:** sekce *Authentication* a *API Security* v `@skills/laravel-security/SKILL.md`.
+
+**Příklad regresního testu:**
+
+```php
+it('regenerates session on login', function (): void {
+    $user = User::factory()->create();
+    $old = session()->getId();
+
+    post('/login', ['email' => $user->email, 'password' => 'password']);
+
+    expect(session()->getId())->not->toBe($old);
+});
+```
+
+---
+
+### 3. Validation a requesty
+
+**Co hledat:**
+
+- Chybějící FormRequest — inline `$request->validate()` ve více místech nebo žádná validace.
+- `authorize()` vrací `true` napevno nebo chybí logika — FormRequest musí skutečně autorizovat.
+- Mass assignment: `$request->all()` nebo `$request->except(...)` předáno do `create()`/`fill()`; model nemá `$fillable`.
+- Nevalidované parametry: query string / route parameter použit v dotazu bez sanitizace.
+- DB::raw nebo whereRaw s interpolací: `DB::select("... '{$input}'")`; `orderByRaw($request->sort)`.
+
+**Vzory Grep:**
+
+```bash
+grep -rn "request()->all()\|->all()" app/Http/Controllers/
+grep -rn "DB::raw\|whereRaw\|orderByRaw\|selectRaw" app/ --include="*.php"
+grep -rn "return true;" app/Http/Requests/ --include="*.php"
+```
+
+**Referenční oprava:** sekce *Eloquent Security* a *Input Validation* v `@skills/laravel-security/SKILL.md`.
+
+**Příklad regresního testu:**
+
+```php
+it('rejects unvalidated sort parameter', function (): void {
+    $response = get('/posts?sort=malicious_sql_fragment--');
+    $response->assertUnprocessable(); // nebo assertBadRequest()
+});
+```
+
+---
+
+### 4. XSS
+
+**Co hledat:**
+
+- `{!! $variable !!}` v Blade šablonách — zkontroluj, zda proměnná pochází z uživatelského vstupu.
+- `innerHTML` nebo `x-html` v Alpine.js bez sanitizace.
+- Markdown renderování bez HTML purification (nepurifikovaný výstup v `{!! Str::markdown($input) !!}`).
+- Livewire / Inertia: props z databáze zobrazené bez escapování ve Vue/React.
+- `@json($data)` s citlivými nebo uživatelskými daty — ověř, co se serializuje.
+
+**Vzory Grep:**
+
+```bash
+grep -rn "{!!" resources/views/ --include="*.blade.php"
+grep -rn "x-html\|innerHTML" resources/
+grep -rn "Str::markdown\|commonmark" app/ resources/
+```
+
+**Referenční oprava:** sekce *XSS Prevention* v `@skills/laravel-security/SKILL.md`.
+
+**Příklad regresního testu:**
+
+```php
+it('escapes user-supplied content in view', function (): void {
+    $post = Post::factory()->create(['title' => '<script>alert(1)</script>']);
+
+    $response = get("/posts/{$post->id}");
+
+    $response->assertSee('&lt;script&gt;', false);
+    $response->assertDontSee('<script>alert(1)</script>', false);
+});
+```
+
+---
+
+### 5. File upload
+
+**Co hledat:**
+
+- Chybějící `mimes:` nebo `extensions:` validace — lze nahrát `.php`, `.html`, `.svg`, `.phar`.
+- Chybějící `max:` — DoS přes velké soubory.
+- Uložení na `public` disk bez autorizačního serve endpointu — soubory dostupné přímo bez auth.
+- Path traversal: použití `$request->file('f')->getClientOriginalName()` v cestě bez sanitizace.
+- SVG upload bez sanitizace (SVG může obsahovat `<script>`).
+
+**Vzory Grep:**
+
+```bash
+grep -rn "->store\|->storeAs" app/ --include="*.php"
+grep -rn "getClientOriginalName\|getClientOriginalExtension" app/ --include="*.php"
+grep -rn "'public'" app/ --include="*.php"
+```
+
+**Referenční oprava:** sekce *File Upload Security* v `@skills/laravel-security/SKILL.md`.
+
+**Příklad regresního testu:**
+
+```php
+it('rejects php file upload', function (): void {
+    $file = UploadedFile::fake()->create('shell.php', 10, 'application/x-php');
+
+    $response = actingAs(User::factory()->create())
+        ->post('/uploads', ['file' => $file]);
+
+    $response->assertUnprocessable();
+});
+```
+
+---
+
+### 6. Secrets a konfigurace
+
+**Co hledat:**
+
+- `.env` commitováno do repozitáře (`.gitignore` chybí nebo je chybné).
+- API klíče, hesla, tokeny napevno v kódu nebo v testech (např. `'secret' => 'hardcoded_key'`).
+- `APP_DEBUG=true` v `.env.example` nebo v production configu.
+- Credentials v logu: `Log::info('Login', ['password' => $password])`.
+- Cookie nastavení: `Secure`, `HttpOnly`, `SameSite` — viz sekce *Production Configuration*.
+
+**Vzory Grep:**
+
+```bash
+grep -rn "APP_DEBUG=true" . --include=".env*"
+grep -rn "password\|secret\|api_key" --include="*.php" app/ config/ | grep -v "env(\|config("
+grep -rn "Log::" app/ --include="*.php" | grep -i "password\|secret\|token"
+```
+
+**Referenční oprava:** sekce *Production Configuration* a *Secrets and Dependencies* v `@skills/laravel-security/SKILL.md`. Pro cookie viz `@rules/security/backend.md`.
+
+**Příklad regresního testu:**
+
+```php
+it('does not log sensitive fields', function (): void {
+    $logs = [];
+    Log::listen(static function ($log) use (&$logs): void {
+        $logs[] = json_encode($log->context);
+    });
+
+    post('/login', ['email' => 'a@b.com', 'password' => 'secret123']);
+
+    foreach ($logs as $entry) {
+        expect($entry)->not->toContain('secret123');
+    }
+});
+```
+
+---
+
+### 7. Dependencies
+
+**Co hledat:**
+
+- Nespuštěný `composer audit` — CI pipeline bez audit stepu.
+- Zastaralé balíčky s CVE v `composer.lock`.
+- Frontend: `npm audit` / `yarn audit` pokud projekt obsahuje `package.json`.
+- Balíčky nainstalované z dev-dependencies v produkci (nedostatečný `--no-dev`).
+
+**Příkazy:**
+
+```bash
+composer audit
+# pokud frontend:
+npm audit --audit-level=high
+```
+
+**Referenční oprava:** sekce *Secrets and Dependencies* v `@skills/laravel-security/SKILL.md`. Pro dependency-selection viz `@rules/php/dependency-selection.mdc`.
+
+**Příklad regresního testu (CI pin):**
+
+```yaml
+# .github/workflows/ci.yml
+- name: Security audit
+  run: composer audit
+```
+
+Regresní test pro PHP: ověřit, že CI krok `composer audit` existuje v pipeline YML (obsahový test v testsuite).
+
+---
+
+## Výstupní formát nálezu
+
+```
+[Oblast] [Severity] Popis nálezu
+Soubor: app/Http/Controllers/PostController.php:42
+Oprava: viz sekce Authorization v @skills/laravel-security/SKILL.md
+Regresní test: <načrtnutý test výše>
+```
+
+Severity-sorted výstup (Critical → High → Medium → Low → Info). Každý confirmed nález musí mít návrh regresního testu.
+
+## Dedup/gating
+
+Pokud oblast už pokrývá existující bullet v `@skills/laravel-security/SKILL.md` nebo v `@rules/security/backend.md` / `@rules/security/frontend.md`, audit sekce odkazuje na něj a nepřidává duplicitní detekční logiku. Nová detekce v tomto souboru pokrývá pouze vzory specifické pro auditní workflow (Grep příkazy, příklady testů), nikoli secure-by-default bloky (ty žijí v SKILL.md).

--- a/tests/Installer/AgentsTest.php
+++ b/tests/Installer/AgentsTest.php
@@ -182,6 +182,38 @@ test('athena also runs a pre-implementation security-analysis mode that feeds ta
     expect($content)->toContain('Security CR done');
 });
 
+test('athena references the laravel security audit workflow for existing-app audits', function (): void {
+    $packageDir = dirname(__DIR__, 2);
+    $content = (string) file_get_contents($packageDir . '/agents/athena.md');
+
+    // The 7-area audit workflow lives in a references file; athena links to it, not re-implements it.
+    expect($content)->toContain('@skills/laravel-security/references/audit-workflow.md');
+});
+
+test('laravel-security audit-workflow ships with all 7 areas, severity mapping, and regression-test requirement', function (): void {
+    $packageDir = dirname(__DIR__, 2);
+    $content = (string) file_get_contents($packageDir . '/skills/laravel-security/references/audit-workflow.md');
+
+    // Severity mapping: 5-level audit scale maps to 3-level CR scale.
+    expect($content)->toContain('Critical');
+    expect($content)->toContain('Moderate');
+    expect($content)->toContain('Minor');
+
+    // All 7 audit areas must be present.
+    expect($content)->toContain('Authorization');
+    expect($content)->toContain('Authentication');
+    expect($content)->toContain('Validation');
+    expect($content)->toContain('XSS');
+    expect($content)->toContain('File upload');
+    expect($content)->toContain('Secrets');
+    expect($content)->toContain('Dependencies');
+
+    // Every confirmed finding must carry a regression-test sketch.
+    expect($content)->toContain('regresní test');
+    // Defensive framing: audit, not attack.
+    expect($content)->toContain('autorizovaném prostředí');
+});
+
 test('every dispatched agent reads and appends to the shared task brief', function (): void {
     $packageDir = dirname(__DIR__, 2);
 


### PR DESCRIPTION
## Summary

- Adds `skills/laravel-security/references/audit-workflow.md` — the full 7-area Laravel Security Audit workflow: Authorization/IDOR/BOLA, Authentication, Validation a requesty, XSS, File upload, Secrets a konfigurace, Dependencies.
- Each area includes Grep patterns for auditors and a Pest/PHPUnit regression-test sketch per confirmed finding.
- Explicit 5→3 severity mapping: Critical→Critical; High/Medium→Moderate; Low/Info→Minor (keeps repo CR convergence gate intact).
- Defensive framing throughout — bezpečnostní auditor v autorizovaném prostředí, no exploit/attack language.
- Wires the workflow into `agents/athena.md` (both security-analysis and security-review modes) and adds a hook section in `skills/laravel-security/SKILL.md` pointing to the references file (SKILL.md stays at 423 lines, well under 500-line hard limit).
- Adds 2 new pins in `tests/Installer/AgentsTest.php` — verifies athena references the audit workflow and that all 7 areas + severity mapping + regression-test requirement ship.

## Test plan

- [ ] `composer build` passes: 284 tests, 100% coverage, 0 PHPStan errors, 0 composer audit advisories
- [ ] `laravel-security/SKILL.md` scores 100/100 in skill-check
- [ ] All pre-existing athena pins still pass (name, tools, model, 4 skills, dual modes, handoff statuses)
- [ ] New pin: athena references `@skills/laravel-security/references/audit-workflow.md`
- [ ] New pin: audit-workflow.md ships all 7 areas, severity mapping, regression-test requirement, defensive framing

Closes #668