### PR TITLE
feat(athena): make standalone CR publishing tracker-aware (issue #691)

### DIFF
--- a/agents/athena.md
+++ b/agents/athena.md
@@ -50,7 +50,13 @@ When dispatched to analyse a security-focused task before any code is written, y
 
 4. **Consolidate findings.** Deduplicate across the four skill outputs and severity-label each finding (severity labels stay verbatim: `Critical`, `Moderate`, `Minor`). A `Critical` finding blocks convergence.
 
-5. **Hand off the security review.** Athéna does **not** post its own PR comment when dispatched alongside `argos` — its findings travel back in the `Security CR done` handoff and are recorded in the shared brief, and `argos` consolidates them into the single CR comment it publishes (see *Parallel dispatch model*). Only when Athéna runs standalone (no `argos` in the loop) **and** a GitHub PR URL is available does it publish directly, through the canonical CR channel `skills/code-review-github/scripts/upsert-comment.sh <PR-NUMBER|URL> -` (body on stdin; the helper appends the actor marker and POSTs a fresh comment) — never a raw `gh pr comment`. Format either way: severity-sorted list with code references and remediation hints, led by a summary line `Security CR: N Critical / N Moderate / N Minor`. When there is no PR to publish to, the findings travel back in the handoff inline.
+5. **Hand off the security review.** Athéna does **not** post its own PR comment when dispatched alongside `argos` — its findings travel back in the `Security CR done` handoff and are recorded in the shared brief, and `argos` consolidates them into the single CR comment it publishes (see *Parallel dispatch model*). Only when Athéna runs standalone (no `argos` in the loop) **and** a PR / tracker item is available does it publish directly, through the **tracker-matching** canonical CR channel — mirroring the source-to-skill routing that `argos` uses (see *How to run* in `agents/argos.md`):
+   - **GitHub** source → `skills/code-review-github/scripts/upsert-comment.sh <PR-NUMBER|URL> -` (body on stdin)
+   - **JIRA** source → `skills/code-review-jira/scripts/upsert-comment.sh <JIRA-KEY> -` (body on stdin)
+   - **Bugsnag** source → publish through the Bugsnag CR channel equivalent (per `@skills/code-review-bugsnag/SKILL.md`)
+   - **No resolvable source** → findings travel back in the handoff inline; nothing is published.
+
+   Never use a raw `gh pr comment` or a hardcoded GitHub channel for a non-GitHub source. Format either way: severity-sorted list with code references and remediation hints, led by a summary line `Security CR: N Critical / N Moderate / N Minor`.
 
 ## Security rules
 

--- a/tests/Installer/AgentsTest.php
+++ b/tests/Installer/AgentsTest.php
@@ -190,6 +190,20 @@ test('athena references the laravel security audit workflow for existing-app aud
     expect($content)->toContain('@skills/laravel-security/references/audit-workflow.md');
 });
 
+test('athena standalone publishing routes to the tracker-matching CR channel, not always GitHub (issue #691)', function (): void {
+    $packageDir = dirname(__DIR__, 2);
+    $content = (string) file_get_contents($packageDir . '/agents/athena.md');
+
+    // Standalone mode must route to the tracker-specific publish channel, not always GitHub.
+    expect($content)->toContain('skills/code-review-github/scripts/upsert-comment.sh');
+    expect($content)->toContain('skills/code-review-jira/scripts/upsert-comment.sh');
+    expect($content)->toContain('@skills/code-review-bugsnag/SKILL.md');
+    // Must not hardcode GitHub as the only standalone publish channel.
+    expect($content)->not->toContain('a GitHub PR URL is available does it publish directly');
+    // The tracker-matching routing must be explicit.
+    expect($content)->toContain('tracker-matching');
+});
+
 test('laravel-security audit-workflow ships with all 7 areas, severity mapping, and regression-test requirement', function (): void {
     $packageDir = dirname(__DIR__, 2);
     $content = (string) file_get_contents($packageDir . '/skills/laravel-security/references/audit-workflow.md');


### PR DESCRIPTION
## Summary

- When `athena` runs standalone (no `argos` in the loop), its security review is now published through the **tracker-matching** CR channel instead of always using the GitHub channel.
- **GitHub** source → `skills/code-review-github/scripts/upsert-comment.sh`
- **JIRA** source → `skills/code-review-jira/scripts/upsert-comment.sh`
- **Bugsnag** source → published via `@skills/code-review-bugsnag/SKILL.md`
- **No source** → findings travel back in the handoff inline only.
- `argos` already had this routing; the change makes `athena` consistent with it.
- Adds a regression test in `tests/Installer/AgentsTest.php` that pins the tracker-matching routing contract and asserts the old GitHub-hardcoded phrase is gone.

Closes #691

## Test plan

- [ ] `composer build` passes — 292 tests, 100% coverage, phpstan clean, pint clean.
- [ ] New test `athena standalone publishing routes to the tracker-matching CR channel, not always GitHub (issue #691)` passes in `AgentsTest.php`.
- [ ] Verify that `agents/athena.md` step 5 now lists all three tracker-specific channels (GitHub, JIRA, Bugsnag) and no longer says "a GitHub PR URL is available does it publish directly".
- [ ] Verify `agents/argos.md` is unchanged (it already had the correct routing).