### PR TITLE
feat(git): add conditional worktree cleanup to post-merge step

### DIFF
--- a/rules/git/general.mdc
+++ b/rules/git/general.mdc
@@ -16,7 +16,7 @@ globs: ["*"]
 ## Worktrees / Workspaces
 - **Do not create git worktrees or separate workspaces automatically.** By default an agent works in the current branch and working tree (a feature / fix branch off the default branch is enough); never run `git worktree add`, clone into a side directory, or spin up an isolated workspace on your own initiative.
 - Create an isolated worktree **only on explicit request** — when the caller / user asks for it, or when a workflow the user explicitly opted into (e.g. parallel multi-unit orchestration) genuinely requires per-unit isolation to avoid corrupting a shared tree. Absent that explicit request, stay in the current tree.
-- When an isolated worktree *was* requested, remove it once the work unit is done (`git worktree remove`) so no orphaned trees are left behind.
+- When an isolated worktree *was* requested, remove it after the PR for the work unit has been merged (deployed) — the post-merge step of `@skills/merge-github-pr/SKILL.md` owns this. Before removing, verify the worktree is not the currently active working tree and has no uncommitted changes; never pass `--force`. Run `git worktree remove <path>` followed by `git worktree prune` to clean up metadata. This keeps git clean and leaves no orphaned trees behind.
 
 ## Pull Policy
 - Resolve the default branch by name first — it is `main` on some repos and `master` on others. Never hardcode `origin/main`; on a `master`-default repo that reference does not exist and the command fails. Derive it once: `DEFAULT_BRANCH="$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's@^origin/@@')"`.
@@ -78,6 +78,7 @@ A pull request is a **Draft** for as long as it is **not yet ready to merge and 
     - Merge into `main`
     - Close the PR
     - Delete the branch
+    - Remove the worktree if one was created for this work unit (see *Worktrees / Workspaces* above for the opt-in / safety rules; `@skills/merge-github-pr/SKILL.md` §4 owns the step)
     - Switch locally to `main`
     - Pull latest changes
 

--- a/skills/merge-github-pr/SKILL.md
+++ b/skills/merge-github-pr/SKILL.md
@@ -64,6 +64,11 @@ When the merge was **not** explicitly requested, this exception does not apply �
 ### 4. Post-merge
 
 - Delete branch (if configured)
+- **Remove worktree (opt-in only)** — if an isolated git worktree was explicitly created for this work unit (per `@rules/git/general.mdc` *Worktrees / Workspaces*), remove it now that the merge is complete:
+  1. Verify the worktree is not the currently active working tree and has no uncommitted changes. If it is active or dirty, report the issue and skip removal — never pass `--force`.
+  2. `git worktree remove <path>` — removes the worktree directory and its metadata.
+  3. `git worktree prune` — cleans up any remaining stale worktree metadata.
+  If no worktree was explicitly created for this work unit (the default: agent worked in the shared tree), skip this step entirely.
 - Confirm merge success
 
 ---

--- a/tests/Installer/SkillsContentTest.php
+++ b/tests/Installer/SkillsContentTest.php
@@ -101,6 +101,22 @@ test('draft-PR-until-review-converges policy is wired through the rule and the P
     expect($merge)->toContain('isDraft == false');
 });
 
+test('merge-github-pr post-merge step includes conditional worktree cleanup with opt-in and used-tree guards (issue #699)', function (): void {
+    $packageDir = dirname(__DIR__, 2);
+    $merge = (string) file_get_contents($packageDir . '/skills/merge-github-pr/SKILL.md');
+
+    // The cleanup step must be conditional on the worktree having been explicitly created.
+    expect($merge)->toContain('opt-in');
+    // The step must reference the git rule's Worktrees / Workspaces section.
+    expect($merge)->toContain('Worktrees / Workspaces');
+    // The step must prohibit forcing removal of an active or dirty tree.
+    expect($merge)->toContain('--force');
+    // The step must include the remove command.
+    expect($merge)->toContain('git worktree remove');
+    // The step must prune leftover metadata.
+    expect($merge)->toContain('git worktree prune');
+});
+
 test('resolve-random skills are not shipped in source skills directory', function (): void {
     $packageDir = dirname(__DIR__, 2);
     expect(is_dir($packageDir . '/skills/resolve-random-github-issue'))->toBeFalse();


### PR DESCRIPTION
## Popis

Implementuje požadavek z issue #699: po nasazení (merge) PR agent odstraní git worktree, aby zůstal čistý git.

## Změny

### `skills/merge-github-pr/SKILL.md` — §4 Post-merge

Přidán podmíněný krok úklidu worktree hned za "Delete branch":
- **Opt-in guard:** krok se provede pouze tehdy, byl-li worktree explicitně vytvořen pro daný work unit (dle `@rules/git/general.mdc` *Worktrees / Workspaces*). Pokud agent pracoval ve sdíleném tree (výchozí stav), krok se přeskočí.
- **Bezpečnostní pojistka:** před odstraněním se ověří, že worktree není aktuální pracovní tree a nemá rozpracované změny. Pokud ano, odstraní se přeskočí a nahlásí chyba — `--force` se nikdy nepoužije.
- `git worktree remove <path>` + `git worktree prune` pro úklid metadat.

### `rules/git/general.mdc`

- **§Worktrees / Workspaces:** upřesněn okamžik odstranění — výslovně svázán s nasazením (merge) PR, odkaz na `merge-github-pr` §4. Doplněna pojistka opt-in + zákaz smazat aktivní/dirty tree.
- **§PR Lifecycle:** doplněn krok "Remove the worktree if one was created for this work unit" do post-merge checklistu, hned za "Delete the branch".

### `tests/Installer/SkillsContentTest.php`

Nový pinning test `merge-github-pr post-merge step includes conditional worktree cleanup with opt-in and used-tree guards (issue #699)` — hlídá přítomnost opt-in guardu, odkazu na *Worktrees / Workspaces*, zákazu `--force`, `git worktree remove` a `git worktree prune`.

## Zdroje

- Issue #699 (zadání): https://github.com/pekral/cursor-rules/issues/699
- Plán #701 (metis): https://github.com/pekral/cursor-rules/issues/701

## Testování

Lokální gate: `composer build` — **296 passed (1627 assertions)**, všechny zelené, bez nových varování.

Nový test prochází: `merge-github-pr post-merge step includes conditional worktree cleanup with opt-in and used-tree guards (issue #699)`.

Closes #699
