### PR TITLE
feat(load-issue): embed sub-issues / subtasks with full content

### DIFF
--- a/docs/memory/PROJECT_MEMORY.md
+++ b/docs/memory/PROJECT_MEMORY.md
@@ -134,3 +134,11 @@
 - Rule:    Route through metis first when the *mechanism* is ambiguous (which signal, where the contract lives) even if the *code* is a clone — the ambiguity is in the design, not the implementation. Once metis fixes the design, the implementation is low-risk and argos+athena converge in iteration 1. Worth recording so a similar "claim / status / follow-up" request is scoped as metis-then-clone rather than treated as net-new high-risk work.
 - Source:  https://github.com/pekral/cursor-rules/pull/706   Added: 2026-06-23
 - Role:    daidalos
+
+### github-sub-issues-only-via-graphql — GitHub native sub-issues are reachable only through GraphQL, not `gh ... --json`
+
+- Trigger: extending `skills/code-review-github/scripts/load-issue.sh` (or any GitHub loader) to read native sub-issues / parent-child issue relations.
+- Rule:    `gh issue view --json subIssues` fails with `Unknown JSON field: "subIssues"` — the `gh` CLI projection does not expose the relation. Fetch it via `gh api graphql` against `repository.issue.subIssues` (the `subIssues(first:N){ nodes{ ... } }` connection; REST `/issues/{n}/sub_issues` also works). Bind owner/repo/number as GraphQL variables with `-F`/`-f` (no string interpolation into the query). Sub-issues exist on issues only (the GraphQL `issue(number)` is null for a PR number), so gate on `kind == "issue"` and default to `[]` on any failure. JIRA already exposes `subtasks` shallowly via `acli ... view --fields '*all'`, but full subtask body/comments/attachments need one extra `acli ... view` + `comment list` per subtask. GitHub issues have no attachment field — uploads are inline URLs in body/comments.
+- Example: issue #721 / PR #723 — added `subIssues[]` (full body + comments + labels via GraphQL) to the GitHub loader and deepened JIRA `subtasks[]` with description/comments/attachments. Both reviews (argos quality + athena security) converged 0/0/0 in iteration 1; `composer build` green (315 tests, 100% coverage).
+- Source:  https://github.com/pekral/cursor-rules/pull/723   Added: 2026-06-29
+- Role:    shared

--- a/skills/code-review-github/scripts/load-issue.sh
+++ b/skills/code-review-github/scripts/load-issue.sh
@@ -26,6 +26,11 @@
 #
 #     # issue-only (null / [] when kind == "pr")
 #     "closingPullRequests": [ { "number", "title", "url", "state" } ],
+#     "subIssues": [ {
+#         "number", "title", "url", "state", "author", "body",
+#         "labels", "createdAt", "updatedAt", "closedAt",
+#         "comments": [ { "author", "body", "createdAt", "updatedAt", "url" } ]
+#     } ],
 #
 #     # pr-only (null / [] when kind == "issue")
 #     "baseRefName", "headRefName", "baseRefOid", "headRefOid",
@@ -55,11 +60,20 @@
 #   - `closingPullRequests` (for issues) is sourced from
 #     `closedByPullRequestsReferences` and surfaces the PRs that will close the
 #     issue when merged. `closingIssues` (for PRs) lists issues the PR closes.
+#   - `subIssues` (for issues) is sourced from the GraphQL `subIssues` connection
+#     (the `gh` CLI `--json` projection does not expose it). Each entry carries
+#     the sub-issue's full body and comments so the assignment context is
+#     complete from a single call. GitHub issues have no separate attachment
+#     field — uploaded files live as inline URLs inside the body / comments, so
+#     embedding both already covers "attachments". Sub-issues are loaded one
+#     level deep (sub-issues of sub-issues are not traversed) and capped at the
+#     first 50 sub-issues with the first 100 comments each.
 #
 # Known limitations (intentionally out of scope, fall back to GitHub MCP):
 #   - Review thread / line-anchored review comments (`gh api .../pulls/<N>/comments`)
 #   - Per-commit check runs and detailed CI logs
 #   - Attachment binary contents (only URLs and metadata are returned)
+#   - Sub-issues beyond one level / the first 50, and beyond 100 comments each
 #
 # Exit codes:
 #   1  usage error (missing or unparseable argument)
@@ -197,11 +211,46 @@ if ! printf '%s' "$PAYLOAD" | jq -e . >/dev/null 2>&1; then
   exit 3
 fi
 
+# Sub-issues are a GitHub-native relation exposed only through GraphQL (the `gh`
+# CLI `--json` projection has no `subIssues` field). Only issues carry them; for
+# PRs and on any GraphQL failure we fall back to an empty array so the script
+# never breaks on a repo without the feature enabled.
+SUBISSUES_JSON='[]'
+if [[ "$KIND" == "issue" ]]; then
+  SUBISSUES_QUERY='query($owner:String!,$repo:String!,$n:Int!){repository(owner:$owner,name:$repo){issue(number:$n){subIssues(first:50){nodes{number title url state body createdAt updatedAt closedAt author{login} labels(first:50){nodes{name}} comments(first:100){nodes{author{login} body createdAt updatedAt url}}}}}}}'
+  if RAW_SUBISSUES="$(gh api graphql -f query="$SUBISSUES_QUERY" -F owner="$OWNER" -F repo="$REPO" -F n="$NUMBER" 2>/dev/null)" && [[ -n "$RAW_SUBISSUES" ]]; then
+    SUBISSUES_JSON="$(printf '%s' "$RAW_SUBISSUES" | jq -c '
+      [ (.data.repository.issue.subIssues.nodes // [])[] | {
+          number: (.number // null),
+          title: (.title // null),
+          url: (.url // null),
+          state: (.state // null),
+          author: (.author.login // null),
+          body: (.body // ""),
+          labels: [ (.labels.nodes // [])[] | (.name // null) ],
+          createdAt: (.createdAt // null),
+          updatedAt: (.updatedAt // null),
+          closedAt: (.closedAt // null),
+          comments: [ (.comments.nodes // [])[] | {
+            author: (.author.login // null),
+            body: (.body // ""),
+            createdAt: (.createdAt // null),
+            updatedAt: (.updatedAt // null),
+            url: (.url // null)
+          } ]
+        } ]' 2>/dev/null || printf '[]')"
+  fi
+fi
+if ! printf '%s' "$SUBISSUES_JSON" | jq -e . >/dev/null 2>&1; then
+  SUBISSUES_JSON='[]'
+fi
+
 jq -n \
   --arg kind "$KIND" \
   --arg owner "$OWNER" \
   --arg repo "$REPO" \
-  --argjson payload "$PAYLOAD" '
+  --argjson payload "$PAYLOAD" \
+  --argjson subIssues "$SUBISSUES_JSON" '
 def total_reactions:
   ([ (.reactionGroups // [])[] | (.users.totalCount // .reactors.totalCount // 0) ] | add) // 0;
 
@@ -270,6 +319,7 @@ $payload as $p
     closingPullRequests: (if $kind == "issue"
       then ($p.closedByPullRequestsReferences | map_refs)
       else [] end),
+    subIssues: (if $kind == "issue" then $subIssues else [] end),
 
     baseRefName: (if $kind == "pr" then ($p.baseRefName // null) else null end),
     headRefName: (if $kind == "pr" then ($p.headRefName // null) else null end),

--- a/skills/code-review-jira/scripts/load-issue.sh
+++ b/skills/code-review-jira/scripts/load-issue.sh
@@ -25,7 +25,10 @@
 #     "descriptionText": "<flattened plain text>",
 #     "descriptionMediaRefs": [ { "adfId", "altText" } ],
 #     "issueLinks":  [ { "id", "type", "direction", "verb", "linkedKey", "linkedSummary", "linkedStatus", "linkedType" } ],
-#     "subtasks":    [ { "key", "summary", "status", "type" } ],
+#     "subtasks":    [ { "key", "summary", "status", "type",
+#                        "descriptionText", "descriptionAdf",
+#                        "comments":    [ { "author", "body", "created", "visibility" } ],
+#                        "attachments": [ { "id", "name", "size", "mimeType", "contentUrl", "author", "created" } ] } ],
 #     "comments":    [ { "author", "body", "created", "visibility" } ],
 #     "attachments": [ { "id", "name", "size", "mimeType", "contentUrl", "author", "created" } ],
 #     "customFields":  { "customfield_XXXXX": <parsed value>, … },
@@ -48,6 +51,13 @@
 #     customFields[$JIRA_DEV_SUMMARY_FIELD] (default `customfield_10000`,
 #     overridable via the JIRA_DEV_SUMMARY_FIELD env var). The shape stays
 #     identical across JIRA sites because it's computed, not field-id-bound.
+#   - `subtasks[]` carries the full sub-issue context (description, comments,
+#     attachments), not just the shallow reference the parent issue embeds. Each
+#     subtask is fetched individually (one `acli ... workitem view` plus one
+#     `acli ... comment list` per subtask), so a parent with many subtasks costs
+#     proportionally more API calls. A subtask whose individual fetch fails
+#     degrades to its shallow reference (key/summary/status/type) with empty
+#     description / comments / attachments rather than breaking the whole load.
 #   - The Atlassian CLI `--paginate` flag emits a JSON stream (one document per
 #     page) instead of a single document. We slurp with `jq -s` to merge pages.
 #   - `pullRequests` are resolved via `gh search prs <KEY>` and may include PRs
@@ -154,6 +164,30 @@ fi
 
 COMMENTS_JSON="$(acli jira workitem comment list --key "$KEY" --json --paginate 2>/dev/null | jq -s '{ comments: ([ .[].comments // [] ] | add // []) }' 2>/dev/null || printf '{"comments": []}')"
 
+# Fetch the full context of every subtask (description, comments, attachments).
+# The parent issue only embeds a shallow subtask reference, so each subtask is
+# loaded individually and accumulated into an object keyed by subtask key. A
+# failed individual fetch is skipped, leaving that subtask with its shallow
+# reference only.
+SUBTASK_DETAILS='{}'
+SUBTASK_KEYS="$(printf '%s' "$VIEW_JSON" | jq -r '(.fields.subtasks // [])[] | .key // empty' 2>/dev/null || true)"
+if [[ -n "$SUBTASK_KEYS" ]]; then
+  while IFS= read -r SUBTASK_KEY; do
+    [[ -z "$SUBTASK_KEY" ]] && continue
+    SUBTASK_VIEW="$(acli jira workitem view "$SUBTASK_KEY" --fields '*all' --json 2>/dev/null || true)"
+    if [[ -z "$SUBTASK_VIEW" ]] || ! printf '%s' "$SUBTASK_VIEW" | jq -e . >/dev/null 2>&1; then
+      continue
+    fi
+    SUBTASK_COMMENTS="$(acli jira workitem comment list --key "$SUBTASK_KEY" --json --paginate 2>/dev/null | jq -s '{ comments: ([ .[].comments // [] ] | add // []) }' 2>/dev/null || printf '{"comments": []}')"
+    SUBTASK_DETAILS="$(jq -c -n \
+      --arg key "$SUBTASK_KEY" \
+      --argjson acc "$SUBTASK_DETAILS" \
+      --argjson view "$SUBTASK_VIEW" \
+      --argjson commentsResp "$SUBTASK_COMMENTS" \
+      '$acc + { ($key): { view: $view, comments: ($commentsResp.comments // []) } }' 2>/dev/null || printf '%s' "$SUBTASK_DETAILS")"
+  done <<< "$SUBTASK_KEYS"
+fi
+
 PRS_JSON='[]'
 if command -v gh >/dev/null 2>&1; then
   PRS_JSON="$(gh search prs "$KEY" \
@@ -170,6 +204,7 @@ jq -n \
   --arg devField "$DEV_FIELD" \
   --argjson view "$VIEW_JSON" \
   --argjson commentsResp "$COMMENTS_JSON" \
+  --argjson subtaskDetails "$SUBTASK_DETAILS" \
   --argjson prs "$PRS_JSON" '
 def tryParseTrimEnd:
   . as $s
@@ -270,12 +305,33 @@ def adfMedia:
           linkedStatus: (.inwardIssue.fields.status.name // null),
           linkedType: (.inwardIssue.fields.issuetype.name // null) }
       end)),
-    subtasks: ($sub | map({
-      key: .key,
-      summary: (.fields.summary // null),
-      status: (.fields.status.name // null),
-      type: (.fields.issuetype.name // null)
-    })),
+    subtasks: ($sub | map(. as $st
+      | ($subtaskDetails[$st.key] // null) as $d
+      | ($d.view.fields // null) as $sf
+      | ($sf.description // null) as $sdesc
+      | {
+          key: $st.key,
+          summary: ($st.fields.summary // null),
+          status: ($st.fields.status.name // null),
+          type: ($st.fields.issuetype.name // null),
+          descriptionAdf: $sdesc,
+          descriptionText: (if $sdesc == null then "" else ($sdesc | adfText | gsub("\n\n+"; "\n\n") | sub("\n+$"; "")) end),
+          comments: (if $d == null then [] else (($d.comments // []) | map(. as $c | {
+            author: (if ($c.author | type) == "object" then ($c.author.displayName // null) else $c.author end),
+            body: (if ($c.body | type) == "object" then ($c.body | adfText) else $c.body end),
+            created: ($c.created // null),
+            visibility: (if ($c.visibility | type) == "object" then $c.visibility.value else ($c.visibility // null) end)
+          })) end),
+          attachments: (if $sf == null then [] else (($sf.attachment // []) | map({
+            id: (.id // null),
+            name: (.filename // null),
+            size: (.size // null),
+            mimeType: (.mimeType // null),
+            contentUrl: (.content // null),
+            author: (if (.author | type) == "object" then (.author.displayName // null) else .author end),
+            created: (.created // null)
+          })) end)
+        })),
     comments: ($commentsResp.comments // [] | map(. as $c | {
       author: (if ($c.author | type) == "object" then ($c.author.displayName // null) else $c.author end),
       body: (if ($c.body | type) == "object" then ($c.body | adfText) else $c.body end),

--- a/tests/Installer/SkillsContentTest.php
+++ b/tests/Installer/SkillsContentTest.php
@@ -302,6 +302,31 @@ test('github load-issue script is shipped, executable, and documents the same sh
     expect($content)->toContain('"closingPullRequests"');
     expect($content)->toContain('"statusCheckRollup"');
     expect($content)->toContain('(www\.)?github\.com');
+    // Sub-issues are embedded with their full body and comments, sourced from
+    // the GraphQL subIssues connection (the gh --json projection lacks it).
+    expect($content)->toContain('"subIssues"');
+    expect($content)->toContain('subIssues(first:');
+    expect($content)->toContain('gh api graphql');
+    expect($content)->toContain('subIssues: (if $kind == "issue" then $subIssues else [] end)');
+});
+
+test('jira load-issue embeds full subtask context (description, comments, attachments)', function (): void {
+    $packageDir = dirname(__DIR__, 2);
+    $script = $packageDir . '/skills/code-review-jira/scripts/load-issue.sh';
+
+    expect(file_exists($script))->toBeTrue();
+    expect(is_executable($script))->toBeTrue();
+
+    $content = (string) file_get_contents($script);
+    // Each subtask is fetched individually so its description, comments, and
+    // attachments are embedded — not just the parent's shallow reference.
+    expect($content)->toContain('acli jira workitem view "$SUBTASK_KEY"');
+    expect($content)->toContain('--argjson subtaskDetails "$SUBTASK_DETAILS"');
+    expect($content)->toContain('descriptionText:');
+    expect($content)->toContain('descriptionAdf:');
+    // A failed per-subtask fetch must degrade to the shallow reference, never
+    // break the whole load.
+    expect($content)->toContain('leaving that subtask with its shallow');
 });
 
 test('github-consuming skills route context loading through load-issue.sh', function (): void {


### PR DESCRIPTION
## Summary

Resolves #721 — `load-issue.sh` now loads **sub-issues** with their full context (body / description, comments, and attachments) so a single call returns the complete picture of a task and its children.

- **GitHub** (`skills/code-review-github/scripts/load-issue.sh`): adds a `subIssues[]` field, sourced from the GraphQL `subIssues` connection (the `gh --json` projection has no such field). Each entry carries the sub-issue's `number`, `title`, `url`, `state`, `author`, full `body`, `labels`, timestamps, and full `comments[]`. GitHub has no separate attachment field — uploaded files live as inline URLs in the body/comments, so embedding both already covers "attachments". Loaded one level deep, capped at the first 50 sub-issues with 100 comments each, and degrades to `[]` on any GraphQL failure.
- **JIRA** (`skills/code-review-jira/scripts/load-issue.sh`): deepens the existing `subtasks[]` — previously only `key`/`summary`/`status`/`type` — with `descriptionText`, `descriptionAdf`, `comments[]`, and `attachments[]`. Each subtask is fetched individually (one `workitem view` + one `comment list` per subtask). A failed per-subtask fetch degrades to the shallow reference rather than breaking the whole load.
- **Bugsnag**: out of scope — the error model has no sub-issue concept.

## Testing instructions

- `composer build` — full quality gate, green (315 tests, 100% coverage).
- GitHub loader verified live against issue #721 (no sub-issues → `subIssues: []`, no breakage) and against synthetic GraphQL samples for the populated path.
- JIRA loader's `jq` projection verified against synthetic `view`/`comment` samples for the populated, degraded (subtask fetch failed), and empty paths.
- New content-pinning assertions in `tests/Installer/SkillsContentTest.php` cover both loaders.

## TODO

- [ ] `gather-issue-context.sh` (GitHub) could additionally surface the embedded `subIssues[]` in its Markdown brief / BFS traversal (mirroring how the JIRA brief already recurses subtasks). Left out to keep this PR scoped to `load-issue.sh` per the agreed approach; worth a follow-up if the Markdown brief consumers need sub-issue content too.
