### PR TITLE
ci: run quality checks on PHP 8.5 to match the tooling floor

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
           coverage: none
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quality-checks:
-    name: "🔍 Quality Checks (PHP 8.4)"
+    name: "🔍 Quality Checks (PHP 8.5)"
     runs-on: ubuntu-latest
 
     steps:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@2.37.1
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: pcov, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
           coverage: pcov
 
@@ -27,9 +27,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-php-8.4-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-
+            ${{ runner.os }}-php-8.5-
             ${{ runner.os }}-php-
 
       - name: Install dependencies


### PR DESCRIPTION
## Shrnutí

Opravuje repo-wide selhání CI. `pekral/phpcs-rules` na `dev-master` nově vyžaduje PHP `^8.5`, takže `composer install` na CI matici **PHP 8.4** selže:

```
pekral/phpcs-rules dev-master requires php ^8.5 -> your php version (8.4.22) does not satisfy that requirement
```

To shazuje *Quality Checks* job u **každého** PR (objeveno při pokusu o merge #726). Projekt nemá `require.php` a všechny tři first-party `pekral/*` tooling závislosti jedou na `dev-master`, takže floor toolchainu je teď 8.5 (lokální dev už běží na 8.5).

## Co se mění

- `.github/workflows/pr.yml` — PHP matrix 8.4 → 8.5 (název jobu, `setup-php`, cache klíče)
- `.github/workflows/composer-update.yml` — `setup-php` 8.4 → 8.5

## Jak testovat

CI tohoto PR běží na upraveném workflow (8.5) — `composer install` projde a *Quality Checks* musí být zelené.

Odblokovává merge #726 a všech dalších PR.