### PR TITLE
fix(gitignore): ignore /.agents/ and /AGENTS.md as stale foreign artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ Thumbs.db
 /.cursor/
 /.codex/
 /.claude/
+/.agents/
+/AGENTS.md
 composer.lock
 
 

--- a/tests/Installer/InstallCopyTest.php
+++ b/tests/Installer/InstallCopyTest.php
@@ -21,6 +21,8 @@ test('gitignore ignores local cursor and claude directories', function (): void 
 
     expect($gitignore)->toContain('/.cursor/');
     expect($gitignore)->toContain('/.claude/');
+    expect($gitignore)->toContain('/.agents/');
+    expect($gitignore)->toContain('/AGENTS.md');
 });
 
 test('install ignores rules directory in project root and uses package source', function (): void {


### PR DESCRIPTION
## Summary

Fixes #742.

`.gitignore` did not cover `/.agents/` and `/AGENTS.md`, so a stray, previously `git add`-ed copy of an external agent/`AGENTS.md` convention (121 files) kept the working tree staged and dirty. This PR makes an explicit tracked-vs-ignored decision and cleans up the stale artifacts.

### Decision: ignore both, do not track

- **`/.agents/`** — ignore. It duplicates the already-tracked `skills/` (the repo would ship its own package data a second time, out of sync, outside the reach of `tests/Installer/*ContentTest.php`). The installer's *only* agents install target is `$root . '/.claude/agents'` (`src/InstallerPath.php:137-144`) — the same class of directory as the already-ignored `/.claude/`, `/.cursor/`, `/.codex/`.
- **`/AGENTS.md`** — ignore, do not commit. The precedent is `CLAUDE.md`, which is tracked only because it is the *package source* (`resolveClaudeMdSource()` -> `resolveClaudeMdTarget()`, `src/Installer.php:89`). `AGENTS.md` has no source and no consumer in this repo, and it contradicts `CLAUDE.md` (it references a non-existent `.Codex/` path — it's a manual, drifted copy).

### The issue's premise was refuted, not confirmed

Empirically verified on a clean `HEAD` snapshot (`git archive HEAD` into a scratch dir): neither `php bin/cursor-rules install --force --editor=all` nor the full `composer run-script build` produces `/.agents/` or `AGENTS.md`. The install step only ever writes `.claude/`, `.codex/`, `.cursor/` (all already ignored); the build step only adds `build/` and `.phpunit.cache/` (already ignored). The 121 files were a one-off, stale, foreign artifact — not a reproducible generator side effect — so this PR removes them from disk (`rm -rf .agents AGENTS.md`) in addition to unstaging them from the index, rather than leaving a stale document a runtime respecting the `AGENTS.md` convention could still load.

## Changes

- `.gitignore` — added `/.agents/` and `/AGENTS.md` next to the existing `/.claude/` entry.
- `git restore --staged -- .agents AGENTS.md` — unstaged the 121 previously-added files (not part of the commit).
- `rm -rf .agents AGENTS.md` — removed the stale artifacts from disk.
- `tests/Installer/InstallCopyTest.php` — extended the existing `gitignore ignores local cursor and claude directories` test with assertions for `/.agents/` and `/AGENTS.md`.

## Out of scope

- The separate finding that `composer build`'s install step runs without a required `--editor=` flag (`composer.json:90-91`) and is therefore currently a silent no-op — tracked separately, not mixed into this PR.

## Test plan

- [x] `git diff --cached --name-only` is empty (was 121 files)
- [x] `git check-ignore -v .agents AGENTS.md` exits 0 (was exit 1)
- [x] `git status --short` empty -> `composer build` -> `git status --short` still empty
- [x] `composer build`: 339 tests passed, 100% coverage